### PR TITLE
Fix KeyError: 'slug'

### DIFF
--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -88,7 +88,7 @@ class NodeExporter():
         for _, parent in parent_nodes.items():
             if parent.children:
                 for child in parent.children:
-                    if child.get('type') == "chapters":
+                    if child.get('type') == "chapter":
                         continue
                     child_id = child['id']
                     child_url = f"{base_url}/{child_id}"

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -88,6 +88,8 @@ class NodeExporter():
         for _, parent in parent_nodes.items():
             if parent.children:
                 for child in parent.children:
+                    if child.get('type') == "chapters":
+                        continue
                     child_id = child['id']
                     child_url = f"{base_url}/{child_id}"
                     child_data = self._get_json_response(child_url)


### PR DESCRIPTION
This happens when a book has chapters and not just pages. Fixes #30 

This modification works for my specific Bookstack instance but I would greatly appreciate more testing on different setups.