### PR TITLE
fix: paginate bookstack list api endpoints

### DIFF
--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -1,6 +1,6 @@
 import logging
 import os
-from typing import Dict, Union
+from typing import Dict, List, Union
 import urllib3
 # pylint: disable=import-error
 import requests
@@ -64,6 +64,24 @@ class HttpHelper:
                     response.status_code, url)
             raise e
         return response
+
+    def http_get_all(self, url: str, count: int = 500) -> List[Dict]:
+        """fetch all items from a paginated bookstack list endpoint"""
+        separator = "&" if "?" in url else "?"
+        all_data: List[Dict] = []
+        offset = 0
+        while True:
+            body = self.http_get_request(
+                f"{url}{separator}count={count}&offset={offset}"
+            ).json()
+            batch = body.get('data', [])
+            if not batch:
+                break
+            all_data.extend(batch)
+            if len(all_data) >= body.get('total', 0):
+                break
+            offset += count
+        return all_data
 
     @staticmethod
     def should_verify(url: str) -> str:

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -41,10 +41,7 @@ class NodeExporter():
         return response.json()
 
     def _get_all_ids(self, url: str) -> List[int]:
-        ids_api_meta = self._get_json_response(url)
-        if ids_api_meta:
-            return [item['id'] for item in ids_api_meta['data']]
-        return []
+        return [item['id'] for item in self.http_client.http_get_all(url)]
 
     def _get_parents(self, base_url: str, parent_ids: List[int],
                       path_prefix: str = "") -> Dict[int, Node]:


### PR DESCRIPTION
## Summary

- `_get_all_ids` made a single unpaginated call to BookStack list endpoints (`/api/shelves`, `/api/books`, `/api/chapters`), silently dropping all results beyond the first page (default 100 items, max 500)
- With 270 chapters, only the first 100 were fetched — remaining 170 chapters and all their pages were never exported
- Root cause of #74: books with mixed chapters and pages appeared to only export direct pages because their chapters fell beyond page 1 of the chapter listing

## Changes

- `bookstack_file_exporter/common/util.py`: added `HttpHelper.http_get_all(url, count=500)` — paginates list endpoints using `count`/`offset` params until `len(data) >= total` (confirmed from BookStack API docs: default 100, max 500 per page)
- `bookstack_file_exporter/exporter/exporter.py`: `_get_all_ids` now delegates to `http_client.http_get_all`, replacing the single-call implementation

## Test plan

- [ ] Verify export with a BookStack instance containing >100 chapters — all chapter pages should now be exported
- [ ] Confirm total exported page count matches BookStack page count
- [ ] Verify books with mixed chapters and direct pages export all content

Closes #74