### PR TITLE
harden http_get_all against duplicate query params

### DIFF
--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -2,6 +2,7 @@ import logging
 import os
 from typing import Dict, List, Union
 import urllib3
+from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 # pylint: disable=import-error
 import requests
 # pylint: disable=import-error
@@ -67,13 +68,15 @@ class HttpHelper:
 
     def http_get_all(self, url: str, count: int = 500) -> List[Dict]:
         """fetch all items from a paginated bookstack list endpoint"""
-        separator = "&" if "?" in url else "?"
+        parsed = urlparse(url)
+        base_query = [(k, v) for k, v in parse_qsl(parsed.query)
+                      if k not in ('count', 'offset')]
         all_data: List[Dict] = []
         offset = 0
         while True:
-            body = self.http_get_request(
-                f"{url}{separator}count={count}&offset={offset}"
-            ).json()
+            query = urlencode(base_query + [('count', count), ('offset', offset)])
+            paginated_url = urlunparse(parsed._replace(query=query))
+            body = self.http_get_request(paginated_url).json()
             batch = body.get('data', [])
             if not batch:
                 break


### PR DESCRIPTION
## Summary

- `http_get_all` appended `count` and `offset` via string concatenation, producing duplicate query keys (and undefined server behavior) if a caller passed a URL that already contained either param
- Switched to `urllib.parse` so any caller-provided `count`/`offset` is stripped before pagination params are added; other query params (`sort`, `filter[...]`, etc.) pass through unchanged

## Changes

- `bookstack_file_exporter/common/util.py`: rewrote `http_get_all` to parse, rebuild, and re-serialize the URL via `urlparse` / `parse_qsl` / `urlencode` / `urlunparse`

## Notes

No current caller passes a URL with `count` or `offset` — this is purely defensive for future reuse. Follow-up to #76 and #77.

## Test plan

- [ ] Existing exports run end-to-end unchanged (URLs without query params behave identically)
- [ ] Smoke check that proper encoding is preserved when extra params are present