### PR TITLE
fix: add workflow concurrency controls

### DIFF
--- a/.github/workflows/on_pr_merged.yml
+++ b/.github/workflows/on_pr_merged.yml
@@ -7,6 +7,11 @@ on:
     branches:
       - main
 
+# cancel a stale in-flight build so :main reflects the newest commit on rapid merges
+concurrency:
+  group: main-image
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/on_release.yml
+++ b/.github/workflows/on_release.yml
@@ -9,6 +9,11 @@ on:
 permissions:
   contents: write
 
+# never cancel a release mid-flight (partial artifacts); tags are unique so this only guards dup runs
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Changes
Add `concurrency` blocks to two workflows:
- `on_pr_merged.yml` → group `main-image`, `cancel-in-progress: true`. Rapid merges to main cancel stale in-flight `:main` image builds so newest commit wins.
- `on_release.yml` → group `release-${{ github.ref_name }}`, `cancel-in-progress: false`. Release runs never cancel mid-flight (avoids partial artifacts); tags are unique so this only guards duplicate runs.

No job logic changed.

## Motivation
CI had no concurrency guards. Overlapping main builds could publish a stale `:main` image; concurrent release runs risked partial artifacts. Pattern ported from sibling repo `tdarr-exporter` CI.

## Test plan
- YAML keys placed at workflow top level (valid `concurrency` location).
- Verify on next merge to main: older queued build shows cancelled.
- Verify on next tag push: release run is not cancellable by a duplicate.