### PR TITLE
ci: sync renovate config with shared homeylab baseline

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,9 @@
 {
-  "extends": ["config:recommended"],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended", ":configMigration"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
+  "minimumReleaseAge": "3 days",
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
@@ -9,13 +11,10 @@
       "groupSlug": "github-actions"
     },
     {
+      "matchManagers": ["!github-actions"],
       "matchUpdateTypes": ["minor", "patch"],
-      "groupName": "chore(deps): minor & patch updates",
+      "groupName": "minor & patch updates",
       "groupSlug": "minor-patch"
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "minimumReleaseAge": "3 days"
     }
   ],
   "timezone": "UTC"


### PR DESCRIPTION
## Changes
Align this repo's `.github/renovate.json` with the config used in `tdarr-exporter`:
- Add `$schema` for editor validation/autocomplete.
- Add `:configMigration` preset so Renovate auto-opens a PR when config options become deprecated.
- Apply `minimumReleaseAge: 3 days` globally instead of only on `major` updates. This also covers major (the old major-only rule is now redundant and removed).
- Add `!github-actions` to the minor/patch rule. Previously a github-actions minor/patch update matched both the github-actions group rule and the minor/patch group rule; the exclusion removes that overlap.
- Simplify the minor/patch `groupName` to `minor & patch updates` — the `chore(deps):` prefix is added automatically by the semantic-commit default from `config:recommended`.

## Motivation
Keep renovate behavior consistent across homeylab repos and fix the github-actions grouping overlap.

## Test plan
- JSON is valid and validates against the renovate schema.
- After merge, confirm Renovate's next run opens the expected grouped PRs (one github-actions group, one minor/patch group) and respects the 3-day release age.