### PR TITLE
fix(deps): raise dependency floors to tested baseline

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "Pyyaml>=6.0.2",
+    "Pyyaml>=6.0.3",
     "Pydantic>=2.13.4",
     "beautifulsoup4>=4.14.3",
-    "requests>=2.32.3",
-    "minio>=7.2.15",
-    "apprise>=1.9.4",
-    "markdown-it-py>=3.0.0",
+    "requests>=2.34.2",
+    "minio>=7.2.20",
+    "apprise>=1.10.0",
+    "markdown-it-py>=4.2.0",
 ]
 
 [project.urls]
@@ -33,10 +33,10 @@ bookstack-file-exporter = "bookstack_file_exporter.__main__:main"
 
 [dependency-groups]
 dev = [
-    "pytest>=8.0",
-    "pytest-cov>=5.0",
-    "responses>=0.25",
-    "pylint",
+    "pytest>=9.0.3",
+    "pytest-cov>=7.1.0",
+    "responses>=0.26.1",
+    "pylint>=4.0.5",
 ]
 
 [tool.setuptools.packages.find]

--- a/uv.lock
+++ b/uv.lock
@@ -123,21 +123,21 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "apprise", specifier = ">=1.9.4" },
+    { name = "apprise", specifier = ">=1.10.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
-    { name = "markdown-it-py", specifier = ">=3.0.0" },
-    { name = "minio", specifier = ">=7.2.15" },
+    { name = "markdown-it-py", specifier = ">=4.2.0" },
+    { name = "minio", specifier = ">=7.2.20" },
     { name = "pydantic", specifier = ">=2.13.4" },
-    { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "pyyaml", specifier = ">=6.0.3" },
+    { name = "requests", specifier = ">=2.34.2" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pylint" },
-    { name = "pytest", specifier = ">=8.0" },
-    { name = "pytest-cov", specifier = ">=5.0" },
-    { name = "responses", specifier = ">=0.25" },
+    { name = "pylint", specifier = ">=4.0.5" },
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "pytest-cov", specifier = ">=7.1.0" },
+    { name = "responses", specifier = ">=0.26.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes
- Raise `>=` floors in `pyproject.toml` to match versions already in `uv.lock`:
  - Runtime: `apprise>=1.10.0`, `markdown-it-py>=4.2.0` (3→4 major), `requests>=2.34.2`, `minio>=7.2.20`, `Pyyaml>=6.0.3`
  - Dev: `pytest>=9.0.3`, `pytest-cov>=7.1.0`, `responses>=0.26.1`, `pylint>=4.0.5`
- Sync `uv.lock` specifier strings to new floors.
- **No resolved versions changed** — resolver was already at these; floors now declare the tested baseline. `requires-python` stays `>=3.11`.

## Motivation
Floors had drifted behind the locked/tested set (some by a full major, e.g. markdown-it-py 3→4). This makes the declared minimums match what CI actually verifies, so the package no longer advertises support for untested older versions.

## Test plan
- Matrix `uv sync --frozen --python <v>` + `pytest` on 3.11 / 3.12 / 3.13 / 3.14 → **193 passed** each
- `pylint` on 3.14 → **10.00/10**, no new messages
- `task run:local` (native, live BookStack) → exit 0, archive created
- `task docker:build:local` + `task docker:test` → build + run exit 0

## In-depth
- **markdown-it-py 3→4 floor:** raised deliberately — we test on 4.2.0; advertising `>=3` would claim untested compat.
- **Renovate overlap:** `config:recommended` would eventually bump these; this PR just front-runs it and cleans the stale floors now. Keeps `>=` (library contract), no exact pins.