### PR TITLE
fix: code review remediation (bug fixes, DRY, tests)

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -1,4 +1,3 @@
-from typing import List, Dict
 from datetime import datetime
 import logging
 import os
@@ -52,7 +51,7 @@ class Archiver:
                         "attempting to skip this step")
             return
 
-    def get_bookstack_exports(self, page_nodes: Dict[int, Node]):
+    def get_bookstack_exports(self, page_nodes: dict[int, Node]):
         """export all page content"""
         log.info("Exporting all bookstack page contents")
         # get images first if requested
@@ -99,10 +98,10 @@ class Archiver:
         if to_delete:
             self._delete_files(to_delete)
 
-    def _get_stale_archives(self) -> List[str]:
+    def _get_stale_archives(self) -> list[str]:
         # if user is uploading to object storage
         # delete the local .tgz archive since we have it there already
-        archive_list: List[str] = util.scan_archives(self.base_dir,
+        archive_list: list[str] = util.scan_archives(self.base_dir,
                                                      self._page_archiver.file_extension_map['tgz'])
         if not archive_list:
             log.debug("No archive files found to clean up")
@@ -120,7 +119,7 @@ class Archiver:
             to_delete = self._filter_archives(archive_list)
         return to_delete
 
-    def _filter_archives(self, file_list: List[str]) -> List[str]:
+    def _filter_archives(self, file_list: list[str]) -> list[str]:
         """get older archives based on keep number"""
         file_dict = {file: os.stat(file).st_ctime for file in file_list}
         ordered = sorted(file_dict.items(), key=lambda item: item[1])
@@ -134,7 +133,7 @@ class Archiver:
         log.debug("%d local archives will be cleaned up", len(files_to_clean))
         return files_to_clean
 
-    def _delete_files(self, file_list: List[str]):
+    def _delete_files(self, file_list: list[str]):
         for file in file_list:
             util.remove_file(file)
 

--- a/bookstack_file_exporter/archiver/asset_archiver.py
+++ b/bookstack_file_exporter/archiver/asset_archiver.py
@@ -289,6 +289,8 @@ class AssetArchiver:
                 asset_data = asset_response.content
             case "attachments":
                 asset_data = self._decode_attachment_data(asset_response.json()['content'])
+            case _:
+                raise ValueError(f"unsupported asset type: {asset_type}")
         return asset_data
 
     def update_asset_links(self, asset_type: str, page_name: str, page_data: bytes,

--- a/bookstack_file_exporter/archiver/asset_archiver.py
+++ b/bookstack_file_exporter/archiver/asset_archiver.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import base64
-from typing import Union, Literal
+from typing import Literal
 
 from markdown_it import MarkdownIt
 # pylint: disable=import-error
@@ -43,7 +43,7 @@ class AssetNode:
         return f"{self._relative_path_prefix}/{page_name}/{self.name}"
 
     def all_urls(
-            self, asset_data: dict[str, Union[int, str, bool, dict]],
+            self, asset_data: dict[str, int | str | bool | dict],
             kind: Literal["markdown", "html"]) -> list[str]:
         """All URLs for this asset that may appear in an exported page.
 
@@ -118,7 +118,7 @@ class AssetNode:
         return [u for u in dict.fromkeys([*extracted, self.page_url]) if u]
 
     @staticmethod
-    def _get_md_url_strs(asset_data: dict[str, Union[int, str]]) -> list[str]:
+    def _get_md_url_strs(asset_data: dict[str, int | str]) -> list[str]:
         """Extract image src and link href values from content.markdown.
         Uses markdown-it-py for spec-compliant parsing — handles URLs with
         parentheses and alt-text containing parens without regex brittleness."""
@@ -150,7 +150,7 @@ class AssetNode:
         return urls
 
     @staticmethod
-    def _get_html_url_strs(asset_data: dict[str, Union[int, str]]) -> list[str]:
+    def _get_html_url_strs(asset_data: dict[str, int | str]) -> list[str]:
         """Extract URLs from content.html using bs4. Skips data: URIs."""
         html_str = ""
         if 'content' in asset_data and 'html' in asset_data['content']:
@@ -181,7 +181,7 @@ class ImageNode(AssetNode):
     Returns:
         ImageNode instance for use in archiving images for a page
     """
-    def __init__(self, meta_data: dict[str, Union[int, str]]):
+    def __init__(self, meta_data: dict[str, int | str]):
         super().__init__(meta_data)
         self.download_url: str = meta_data['url']
         self.page_url: str = meta_data['url']
@@ -200,7 +200,7 @@ class AttachmentNode(AssetNode):
     Returns:
         AttachmentNode instance for use in archiving attachments for a page
     """
-    def __init__(self, meta_data: dict[str, Union[int, str, bool]],
+    def __init__(self, meta_data: dict[str, int | str | bool],
                  base_url: str):
         super().__init__(meta_data)
         self.download_url: str = f"{base_url}/{self.id_}"
@@ -273,7 +273,7 @@ class AssetArchiver:
         return self._asset_map[asset_type](asset_json)
 
     def get_asset_data(self, asset_type: str,
-            meta_data: Union[AttachmentNode, ImageNode]) -> dict[str, str | bool | int | dict]:
+            meta_data: AttachmentNode | ImageNode) -> dict[str, str | bool | int | dict]:
         """Get asset data based on type"""
         data_url = f"{self.api_urls[asset_type]}/{meta_data.id_}"
         asset_data_response: Response = self.http_client.http_get_request(
@@ -403,8 +403,8 @@ class AssetArchiver:
         return page_data
 
     @staticmethod
-    def _group_by_page(nodes: list["ImageNode | AttachmentNode"]
-                       ) -> dict[int, list["ImageNode | AttachmentNode"]]:
+    def _group_by_page(nodes: list[ImageNode | AttachmentNode]
+                       ) -> dict[int, list[ImageNode | AttachmentNode]]:
         grouped: dict[int, list] = {}
         for node in nodes:
             grouped.setdefault(node.page_id, []).append(node)

--- a/bookstack_file_exporter/archiver/asset_archiver.py
+++ b/bookstack_file_exporter/archiver/asset_archiver.py
@@ -403,32 +403,21 @@ class AssetArchiver:
         return page_data
 
     @staticmethod
-    def _create_image_map(json_data: dict[str,
-            list[dict[str, str | int | bool | dict]]]) -> dict[int, list[ImageNode]]:
-        image_page_map = {}
-        for img_meta in json_data:
-            img_node = ImageNode(img_meta)
-            if img_node.page_id in image_page_map:
-                image_page_map[img_node.page_id].append(img_node)
-            else:
-                image_page_map[img_node.page_id] = [img_node]
-        return image_page_map
+    def _group_by_page(nodes: list["ImageNode | AttachmentNode"]
+                       ) -> dict[int, list["ImageNode | AttachmentNode"]]:
+        grouped: dict[int, list] = {}
+        for node in nodes:
+            grouped.setdefault(node.page_id, []).append(node)
+        return grouped
 
-    def _create_attachment_map(
-            self,
-            json_data: dict[str, list[dict[str, str | int | bool | dict]]]
-            ) -> dict[int, list[AttachmentNode]]:
-        asset_nodes = {}
-        for asset_meta in json_data:
-            asset_node = None
-            if asset_meta['external']:
-                continue # skip external link, only get attachments
-            asset_node = AttachmentNode(asset_meta, self.api_urls['attachments'])
-            if asset_node.page_id in asset_nodes:
-                asset_nodes[asset_node.page_id].append(asset_node)
-            else:
-                asset_nodes[asset_node.page_id] = [asset_node]
-        return asset_nodes
+    @classmethod
+    def _create_image_map(cls, json_data) -> dict[int, list[ImageNode]]:
+        return cls._group_by_page([ImageNode(meta) for meta in json_data])
+
+    def _create_attachment_map(self, json_data) -> dict[int, list[AttachmentNode]]:
+        nodes = [AttachmentNode(meta, self.api_urls['attachments'])
+                 for meta in json_data if not meta['external']]
+        return self._group_by_page(nodes)
 
     @staticmethod
     def _decode_attachment_data(b64encoded_data: str) -> bytes:

--- a/bookstack_file_exporter/archiver/minio_archiver.py
+++ b/bookstack_file_exporter/archiver/minio_archiver.py
@@ -43,11 +43,7 @@ class MinioArchiver:
             raise ValueError(f"Given bucket does not exist: {self.bucket}")
 
     def _generate_path(self, path_name: Union[str, None]) -> str:
-        if path_name:
-            if path_name[-1] == '/':
-                return path_name[:-1]
-            return path_name
-        return ""
+        return path_name.rstrip('/') if path_name else ""
 
     def upload_backup(self, local_file_path: str):
         """upload archive file to minio bucket"""

--- a/bookstack_file_exporter/archiver/minio_archiver.py
+++ b/bookstack_file_exporter/archiver/minio_archiver.py
@@ -1,4 +1,3 @@
-from typing import Union, List
 import logging
 
 # pylint: disable=import-error
@@ -42,7 +41,7 @@ class MinioArchiver:
         if not self._client.bucket_exists(self.bucket):
             raise ValueError(f"Given bucket does not exist: {self.bucket}")
 
-    def _generate_path(self, path_name: Union[str, None]) -> str:
+    def _generate_path(self, path_name: str | None) -> str:
         return path_name.rstrip('/') if path_name else ""
 
     def upload_backup(self, local_file_path: str):
@@ -68,19 +67,19 @@ class MinioArchiver:
         if to_delete:
             self._delete_objects(to_delete)
 
-    def _scan_objects(self, file_extension: str) -> List[MinioObject]:
+    def _scan_objects(self, file_extension: str) -> list[MinioObject]:
         filter_str = "bookstack_export_"
         # prefix should end in '/' for minio
         # ref: https://min.io/docs/minio/linux/developers/python/API.html#list_objects
         path_prefix = self.path + "/"
         # get all objects in archive path/directory
-        full_list: List[MinioObject] = self._client.list_objects(self.bucket, prefix=path_prefix)
+        full_list: list[MinioObject] = self._client.list_objects(self.bucket, prefix=path_prefix)
         # validate and filter out non managed objects
         return [object for object in full_list
                 if object.object_name.endswith(file_extension)
                     and filter_str in object.object_name]
 
-    def _get_stale_objects(self, file_extension: str) -> List[MinioObject]:
+    def _get_stale_objects(self, file_extension: str) -> list[MinioObject]:
         minio_objects = self._scan_objects(file_extension)
         if not minio_objects:
             log.debug("No minio objects found to clean up")
@@ -97,7 +96,7 @@ class MinioArchiver:
             to_delete = self._filter_objects(minio_objects)
         return to_delete
 
-    def _filter_objects(self, minio_objects: List[MinioObject]) -> List[MinioObject]:
+    def _filter_objects(self, minio_objects: list[MinioObject]) -> list[MinioObject]:
         # sort by minio datetime 'last_modified' time
         # ascending order
         sorted_objects = sorted(minio_objects, key=lambda d: d.last_modified)
@@ -113,6 +112,6 @@ class MinioArchiver:
         log.debug("%d minio objects will be cleaned up", len(objects_to_clean))
         return objects_to_clean
 
-    def _delete_objects(self, minio_objects: List[MinioObject]):
+    def _delete_objects(self, minio_objects: list[MinioObject]):
         for item in minio_objects:
             self._client.remove_object(self.bucket, item.object_name)

--- a/bookstack_file_exporter/archiver/page_archiver.py
+++ b/bookstack_file_exporter/archiver/page_archiver.py
@@ -215,7 +215,4 @@ class PageArchiver:
         """return whether or not to export attachments"""
         return self.asset_config.export_attachments
 
-    @property
-    def verify_ssl(self) -> bool:
-        """return whether or not to verify ssl for http requests"""
-        return self.asset_config.verify_ssl
+

--- a/bookstack_file_exporter/archiver/page_archiver.py
+++ b/bookstack_file_exporter/archiver/page_archiver.py
@@ -1,4 +1,3 @@
-from typing import Union, List, Dict
 import logging
 # pylint: disable=import-error
 from requests.exceptions import HTTPError, RetryError
@@ -73,7 +72,7 @@ class PageArchiver:
             return False
         return True
 
-    def archive_pages(self, page_nodes: Dict[int, Node]):
+    def archive_pages(self, page_nodes: dict[int, Node]):
         """export page contents and their images/attachments"""
         # get assets first if requested
         # this is because we may want to manipulate page data with modify_links flag
@@ -109,7 +108,7 @@ class PageArchiver:
                 self._archive_page_meta(page.file_path, page.meta)
 
     def _rewrite_page_data(self, export_format: str, page_name: str,
-                           page_data: bytes, page_assets: Dict[str, list]) -> bytes:
+                           page_data: bytes, page_assets: dict[str, list]) -> bytes:
         """Dispatch link rewriting for the given export format. No-op for non-rewritable formats."""
         if export_format == 'markdown':
             rewriter = self._modify_links
@@ -132,18 +131,18 @@ class PageArchiver:
         return archiver_util.get_byte_response(url=url,
                                                http_client=self.http_client)
 
-    def _archive_page_meta(self, page_path: str, meta_data: Dict[str, Union[str, int]]):
+    def _archive_page_meta(self, page_path: str, meta_data: dict[str, str | int]):
         meta_file_name = f"{self.archive_base_path}/{page_path}{_FILE_EXTENSION_MAP['meta']}"
         bytes_meta = archiver_util.get_json_bytes(meta_data)
         self.write_data(file_path=meta_file_name, data=bytes_meta)
 
-    def _get_image_meta(self) -> Dict[int, List[ImageNode]]:
+    def _get_image_meta(self) -> dict[int, list[ImageNode]]:
         """Get all image metadata into a {page_number: [image_url]} format"""
         if not self.asset_config.export_images:
             return {}
         return self.asset_archiver.get_asset_nodes('images')
 
-    def _get_attachment_meta(self) -> Dict[int, List[AttachmentNode]]:
+    def _get_attachment_meta(self) -> dict[int, list[AttachmentNode]]:
         """Get all attachment metadata into a {page_number: [attachment_url]} format"""
         if not self.asset_config.export_attachments:
             return {}
@@ -151,7 +150,7 @@ class PageArchiver:
 
     def _modify_links(self, asset_type: str,
                       page_name: str, page_data: bytes,
-                      asset_nodes: List[ImageNode | AttachmentNode]) -> bytes:
+                      asset_nodes: list[ImageNode | AttachmentNode]) -> bytes:
         """Markdown link rewriting. Short-circuits when modify_links is False."""
         if not self.modify_links:
             return page_data
@@ -160,7 +159,7 @@ class PageArchiver:
 
     def _modify_html(self, asset_type: str,
                      page_name: str, page_data: bytes,
-                     asset_nodes: List[ImageNode | AttachmentNode]) -> bytes:
+                     asset_nodes: list[ImageNode | AttachmentNode]) -> bytes:
         """HTML link rewriting. Short-circuits when modify_links is False (no bs4 parse)."""
         if not self.modify_links:
             return page_data
@@ -168,7 +167,7 @@ class PageArchiver:
                                                            asset_nodes)
 
     def archive_page_assets(self, asset_type: str, parent_path: str, page_name: str,
-                            asset_nodes: List[ImageNode | AttachmentNode]) -> set[int]:
+                            asset_nodes: list[ImageNode | AttachmentNode]) -> set[int]:
         """pull images locally into a directory based on page"""
         if not asset_nodes:
             return set()
@@ -201,7 +200,7 @@ class PageArchiver:
         archiver_util.create_gzip(self.tar_file, self.archive_file)
 
     @property
-    def file_extension_map(self) -> Dict[str, str]:
+    def file_extension_map(self) -> dict[str, str]:
         """file extension metadata"""
         return _FILE_EXTENSION_MAP
 

--- a/bookstack_file_exporter/archiver/page_archiver.py
+++ b/bookstack_file_exporter/archiver/page_archiver.py
@@ -213,5 +213,3 @@ class PageArchiver:
     def export_attachments(self) -> bool:
         """return whether or not to export attachments"""
         return self.asset_config.export_attachments
-
-

--- a/bookstack_file_exporter/archiver/util.py
+++ b/bookstack_file_exporter/archiver/util.py
@@ -1,4 +1,3 @@
-from typing import Dict, Union
 import json
 import os
 import logging
@@ -28,7 +27,7 @@ def write_tar(base_tar_dir: str, file_path: str, data: bytes):
         log.debug("Adding file: %s with size: %d bytes to tar file", tar_info.name, tar_info.size)
         tar.addfile(tar_info, fileobj=data_obj)
 
-def get_json_bytes(data: Dict[str, Union[str, int]]) -> bytes:
+def get_json_bytes(data: dict[str, str | int]) -> bytes:
     """dump dict to json file"""
     return json.dumps(data, indent=4).encode('utf-8')
 

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -93,26 +93,23 @@ class HttpHelper:
             return "https://"
         return "http://"
 
-def check_var(env_key: str, default_val: Union[list[str],str], can_error: bool = False) -> str:
+def check_var(env_key: str, default_val: Union[list[str], str],
+              required: bool = True) -> Union[list[str], str]:
     """
-    :param: env_key = the environment variable to check
-    :param: default_val = the default value if any to set if env variable not set
-    :param: can_error = whether or not missing both env_key and default_val should
-            trigger an exception
-    
-    :return: env_key if present or default_val if not
-    :throws: ValueError if both parameters are empty.
+    :param env_key: environment variable to check (takes precedence)
+    :param default_val: fallback value if the env var is unset
+    :param required: if True, raise when both env var and default are empty
+
+    :return: env var value if set, else default_val
+    :raises ValueError: if required and both env var and default_val are empty
     """
     env_value = os.environ.get(env_key, "")
-    # env value takes precedence
     if env_value:
-        log.debug("""env key: %s specified.
-                    Will override configuration file value if set.""", env_key)
+        log.debug("env key: %s specified; overrides configuration file value if set.", env_key)
         return env_value
-    # check for optional inputs, if env and input is missing
-    if not can_error:
-        if not env_value and not default_val:
-            raise ValueError(f"""{env_key} is not specified in env and is
-                                missing from configuration - at least one should be set""")
-    # fall back to configuration file value if present
+    if required and not default_val:
+        raise ValueError(
+            f"{env_key} is not specified in env and is missing from configuration "
+            "- at least one should be set"
+        )
     return default_val

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -34,24 +34,30 @@ class HttpHelper:
         self.http_timeout = config.timeout
         self.verify_ssl = config.verify_ssl
         self._headers = headers
+        self._session = self._build_session()
+
+    def _build_session(self) -> requests.Session:
+        """build a requests Session with retry adapters mounted for http and https"""
+        session = requests.Session()
+        # {backoff factor} * (2 ** ({number of previous retries}))
+        # {raise_on_status} if status falls in status_forcelist range
+        #  and retries have been exhausted.
+        # {status_force_list} 413, 429, 503 defaults are overwritten with additional ones
+        retries = Retry(total=self.retry_count,
+                        backoff_factor=self.backoff_factor,
+                        raise_on_status=True,
+                        status_forcelist=self.retry_codes)
+        adapter = HTTPAdapter(max_retries=retries)
+        session.mount("https://", adapter)
+        session.mount("http://", adapter)
+        return session
 
     # more details on options: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
     def http_get_request(self, url: str) -> requests.Response:
         """make http requests and return response object"""
-        url_prefix = self.should_verify(url)
         try:
-            with requests.Session() as session:
-                # {backoff factor} * (2 ** ({number of previous retries}))
-                # {raise_on_status} if status falls in status_forcelist range
-                #  and retries have been exhausted.
-                # {status_force_list} 413, 429, 503 defaults are overwritten with additional ones
-                retries = Retry(total=self.retry_count,
-                                backoff_factor=self.backoff_factor,
-                                raise_on_status=True,
-                                status_forcelist=self.retry_codes)
-                session.mount(url_prefix, HTTPAdapter(max_retries=retries))
-                response = session.get(url, headers=self._headers, verify=self.verify_ssl,
-                                       timeout=self.http_timeout)
+            response = self._session.get(url, headers=self._headers,
+                                         verify=self.verify_ssl, timeout=self.http_timeout)
         except Exception as req_err:
             log.error("Failed to make request for %s", url)
             raise req_err
@@ -62,7 +68,7 @@ class HttpHelper:
             # this means it either exceeded 50X retries in `http_get_request` handler
             # or it returned a 40X which is not expected
             log.error("Bookstack request failed with status code: %d on url: %s",
-                    response.status_code, url)
+                      response.status_code, url)
             raise e
         return response
 
@@ -85,13 +91,6 @@ class HttpHelper:
                 break
             offset += count
         return all_data
-
-    @staticmethod
-    def should_verify(url: str) -> str:
-        """check if http or https"""
-        if url.startswith("https"):
-            return "https://"
-        return "http://"
 
 def check_var(env_key: str, default_val: Union[list[str], str],
               required: bool = True) -> Union[list[str], str]:

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -1,6 +1,5 @@
 import logging
 import os
-from typing import Dict, List, Union
 from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 import urllib3
 # pylint: disable=import-error
@@ -26,7 +25,7 @@ class HttpHelper:
     Returns:
         :HttpHelper: instance with methods to help with http requests.
     """
-    def __init__(self, headers: Dict[str, str],
+    def __init__(self, headers: dict[str, str],
                  config: HttpConfig):
         self.backoff_factor = config.backoff_factor
         self.retry_codes = config.retry_codes
@@ -72,12 +71,12 @@ class HttpHelper:
             raise e
         return response
 
-    def http_get_all(self, url: str, count: int = 500) -> List[Dict]:
+    def http_get_all(self, url: str, count: int = 500) -> list[dict]:
         """fetch all items from a paginated bookstack list endpoint"""
         parsed = urlparse(url)
         base_query = [(k, v) for k, v in parse_qsl(parsed.query)
                       if k not in ('count', 'offset')]
-        all_data: List[Dict] = []
+        all_data: list[dict] = []
         offset = 0
         while True:
             query = urlencode(base_query + [('count', count), ('offset', offset)])
@@ -92,8 +91,8 @@ class HttpHelper:
             offset += count
         return all_data
 
-def check_var(env_key: str, default_val: Union[list[str], str],
-              required: bool = True) -> Union[list[str], str]:
+def check_var(env_key: str, default_val: list[str] | str,
+              required: bool = True) -> list[str] | str:
     """
     :param env_key: environment variable to check (takes precedence)
     :param default_val: fallback value if the env var is unset

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -201,25 +201,3 @@ class ConfigNode:
     def object_storage_config(self) -> Dict[str, StorageProviderConfig]:
         """return remote storage configuration"""
         return self._object_storage_config
-
-    # @staticmethod
-    # def _check_var(env_key: str, default_val: str) -> str:
-    #     """
-    #     :param: env_key = the environment variable to check
-    #     :param: default_val = the default value if any to set if env variable not set
-
-    #     :return: env_key if present or default_val if not
-    #     :throws: ValueError if both parameters are empty.
-    #     """
-    #     env_value = os.environ.get(env_key, "")
-    #     # env value takes precedence
-    #     if env_value:
-    #         log.debug("""env key: %s specified.
-    #                    Will override configuration file value if set.""", env_key)
-    #         return env_value
-    #     # check for optional inputs, if env and input is missing
-    #     if not env_value and not default_val:
-    #         raise ValueError(f"""{env_key} is not specified in env and is
-    #                           missing from configuration - at least one should be set""")
-    #     # fall back to configuration file value if present
-    #     return default_val

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -150,37 +150,25 @@ class ConfigNode:
     def _generate_urls(self) -> Dict[str, str]:
         urls = {}
         # remove trailing slash
-        host = self.user_inputs.host
-        if host[-1] == '/':
-            host = host[:-1]
+        host = self.user_inputs.host.rstrip('/')
         # check to see if http protocol is defined
-        if "http" not in self.user_inputs.host:
+        if "http" not in host:
             # use https by default
             url_prefix = "https://"
         else:
             url_prefix = ""
         for key, value in _API_PATHS.items():
-            urls[key] = f"{url_prefix}{self.user_inputs.host}/{value}"
+            urls[key] = f"{url_prefix}{host}/{value}"
         log.debug("api urls: %s", urls)
         return urls
 
     def _set_base_dir(self, cmd_output_dir: str) -> str:
-        output_dir = self.user_inputs.output_path
-        # override if command line specified
+        output_dir = cmd_output_dir or self.user_inputs.output_path
         if cmd_output_dir:
             log.debug("Output directory overwritten by command line option")
-            output_dir = cmd_output_dir
-        # check if user provided an output path
-        if output_dir:
-            # detect trailing slash
-            # normalize to no trailing slash for later consistency
-            if output_dir[-1] == '/':
-                base_dir = f"{output_dir}{_BASE_DIR_NAME}"
-            else:
-                base_dir = f"{output_dir}/{_BASE_DIR_NAME}"
-        else:
-            base_dir = _BASE_DIR_NAME
-        return base_dir
+        if not output_dir:
+            return _BASE_DIR_NAME
+        return f"{output_dir.rstrip('/')}/{_BASE_DIR_NAME}"
 
     @property
     def headers(self) -> Dict[str, str]:

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -1,6 +1,5 @@
 import os
 import argparse
-from typing import Dict, Tuple
 import logging
 # pylint: disable=import-error
 import yaml
@@ -63,7 +62,7 @@ class ConfigNode:
     def _generate_config(self, config_file: str) -> models.UserInput:
         if not os.path.isfile(config_file):
             raise FileNotFoundError(config_file)
-        with open(config_file, "r", encoding="utf-8") as yaml_stream:
+        with open(config_file, encoding="utf-8") as yaml_stream:
             try:
                 yaml_input = yaml.safe_load(yaml_stream)
             except Exception as load_err:
@@ -102,7 +101,7 @@ class ConfigNode:
                 "the legacy 'assets.modify_markdown' value is ignored."
             )
 
-    def _generate_credentials(self) -> Tuple[str, str]:
+    def _generate_credentials(self) -> tuple[str, str]:
         # if user provided credentials in config file, load them
         token_id = self.user_inputs.credentials.token_id
         token_secret = self.user_inputs.credentials.token_secret
@@ -112,7 +111,7 @@ class ConfigNode:
         token_secret = check_var(_BOOKSTACK_TOKEN_SECRET_FIELD, token_secret)
         return token_id, token_secret
 
-    def _generate_remote_config(self) -> Dict[str, StorageProviderConfig]:
+    def _generate_remote_config(self) -> dict[str, StorageProviderConfig]:
         object_config = {}
         # check for optional minio credentials if configuration is set in yaml configuration file
         if self.user_inputs.minio:
@@ -129,7 +128,7 @@ class ConfigNode:
                 raise ValueError(error_str)
         return object_config
 
-    def _generate_headers(self) -> Dict[str, str]:
+    def _generate_headers(self) -> dict[str, str]:
         headers = {}
         # add additional_headers provided by user
         if self.user_inputs.http_config.additional_headers:
@@ -147,7 +146,7 @@ class ConfigNode:
             headers['Authorization'] = f"Token {self._token_id}:{self._token_secret}"
         return headers
 
-    def _generate_urls(self) -> Dict[str, str]:
+    def _generate_urls(self) -> dict[str, str]:
         urls = {}
         # remove trailing slash
         host = self.user_inputs.host.rstrip('/')
@@ -171,12 +170,12 @@ class ConfigNode:
         return f"{output_dir.rstrip('/')}/{_BASE_DIR_NAME}"
 
     @property
-    def headers(self) -> Dict[str, str]:
+    def headers(self) -> dict[str, str]:
         """get generated headers"""
         return self._headers
 
     @property
-    def urls(self) -> Dict[str, str]:
+    def urls(self) -> dict[str, str]:
         """get generated urls"""
         return self._urls
 
@@ -186,6 +185,6 @@ class ConfigNode:
         return self._base_dir_name
 
     @property
-    def object_storage_config(self) -> Dict[str, StorageProviderConfig]:
+    def object_storage_config(self) -> dict[str, StorageProviderConfig]:
         """return remote storage configuration"""
         return self._object_storage_config

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -1,23 +1,23 @@
-from typing import Dict, Literal, List, Optional
+from typing import Literal
 # pylint: disable=import-error
 from pydantic import BaseModel, Field, AliasChoices, ConfigDict
 
 # pylint: disable=too-few-public-methods
 class ObjectStorageConfig(BaseModel):
     """YAML schema for minio configuration"""
-    host: Optional[str] = ""
-    access_key: Optional[str] = ""
-    secret_key: Optional[str] = ""
+    host: str | None = ""
+    access_key: str | None = ""
+    secret_key: str | None = ""
     bucket: str
-    path: Optional[str] = ""
+    path: str | None = ""
     region: str
-    keep_last: Optional[int] = 0
+    keep_last: int | None = 0
 
 # pylint: disable=too-few-public-methods
 class BookstackAccess(BaseModel):
     """YAML schema for bookstack access credentials"""
-    token_id: Optional[str] = ""
-    token_secret: Optional[str] = ""
+    token_id: str | None = ""
+    token_secret: str | None = ""
 
 # pylint: disable=too-few-public-methods
 class Assets(BaseModel):
@@ -26,48 +26,48 @@ class Assets(BaseModel):
     # so legacy config key `modify_markdown` can still be accepted.
     model_config = ConfigDict(populate_by_name=True)
 
-    export_images: Optional[bool] = False
-    export_attachments: Optional[bool] = False
-    modify_links: Optional[bool] = Field(
+    export_images: bool | None = False
+    export_attachments: bool | None = False
+    modify_links: bool | None = Field(
         default=False,
         validation_alias=AliasChoices("modify_links", "modify_markdown"),
     )
-    export_meta: Optional[bool] = False
+    export_meta: bool | None = False
 
 class HttpConfig(BaseModel):
     """YAML schema for user provided http settings"""
-    verify_ssl: Optional[bool] = False
-    timeout: Optional[int] = 30
-    backoff_factor: Optional[float] = 2.5
-    retry_codes: Optional[List[int]] = [413, 429, 500, 502, 503, 504]
-    retry_count: Optional[int] = 5
-    additional_headers: Optional[Dict[str, str]] = {}
+    verify_ssl: bool | None = False
+    timeout: int | None = 30
+    backoff_factor: float | None = 2.5
+    retry_codes: list[int] | None = [413, 429, 500, 502, 503, 504]
+    retry_count: int | None = 5
+    additional_headers: dict[str, str] | None = {}
 
 class AppRiseNotifyConfig(BaseModel):
     """YAML schema for user provided app rise settings"""
-    service_urls: Optional[List[str]] = []
-    config_path: Optional[str] = ""
-    plugin_paths: Optional[List[str]] = []
-    storage_path: Optional[str] = ""
-    custom_title: Optional[str] = ""
-    custom_attachment_path: Optional[str] = ""
-    on_success: Optional[bool] = False
-    on_failure: Optional[bool] = True
+    service_urls: list[str] | None = []
+    config_path: str | None = ""
+    plugin_paths: list[str] | None = []
+    storage_path: str | None = ""
+    custom_title: str | None = ""
+    custom_attachment_path: str | None = ""
+    on_success: bool | None = False
+    on_failure: bool | None = True
 
 class Notifications(BaseModel):
     """YAML schema for user provided notification settings"""
-    apprise: Optional[AppRiseNotifyConfig] = None
+    apprise: AppRiseNotifyConfig | None = None
 
 # pylint: disable=too-few-public-methods
 class UserInput(BaseModel):
     """YAML schema for user provided configuration file"""
     host: str
-    credentials: Optional[BookstackAccess] = BookstackAccess()
-    formats: List[Literal["markdown", "html", "pdf", "plaintext", "zip"]]
-    output_path: Optional[str] = ""
-    assets: Optional[Assets] = Assets()
-    minio: Optional[ObjectStorageConfig] = None
-    keep_last: Optional[int] = 0
-    run_interval: Optional[int] = 0
-    http_config: Optional[HttpConfig] = HttpConfig()
-    notifications: Optional[Notifications] = None
+    credentials: BookstackAccess | None = BookstackAccess()
+    formats: list[Literal["markdown", "html", "pdf", "plaintext", "zip"]]
+    output_path: str | None = ""
+    assets: Assets | None = Assets()
+    minio: ObjectStorageConfig | None = None
+    keep_last: int | None = 0
+    run_interval: int | None = 0
+    http_config: HttpConfig | None = HttpConfig()
+    notifications: Notifications | None = None

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -25,7 +25,7 @@ class AppRiseNotifyConfig:
     """
     def __init__(self, config: models.AppRiseNotifyConfig):
         self.service_urls: Union[str, list] = check_var(_APPRISE_FIELDS["urls"],
-                                  config.service_urls, can_error=True)
+                                  config.service_urls, required=False)
         self.config_path = config.config_path
         self.plugin_paths = config.plugin_paths
         self.storage_path = config.storage_path

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -10,9 +10,6 @@ log = logging.getLogger(__name__)
 
 _APPRISE_FIELDS = {
     "urls": "APPRISE_URLS",
-    # "config_path": "APPRISE_CONFIG_PATH",
-    # "plugin_paths": "APPRISE_PLUGIN_PATHS",
-    # "storage_path": "APPRISE_STORAGE_PATH"
 }
 
 # pylint: disable=too-few-public-methods, too-many-instance-attributes

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-from typing import Union
 
 from bookstack_file_exporter.config_helper import models
 from bookstack_file_exporter.common.util import check_var
@@ -24,7 +23,7 @@ class AppRiseNotifyConfig:
         AppRiseNotifyConfig instance for holding configuration
     """
     def __init__(self, config: models.AppRiseNotifyConfig):
-        self.service_urls: Union[str, list] = check_var(_APPRISE_FIELDS["urls"],
+        self.service_urls: str | list = check_var(_APPRISE_FIELDS["urls"],
                                   config.service_urls, required=False)
         self.config_path = config.config_path
         self.plugin_paths = config.plugin_paths

--- a/bookstack_file_exporter/config_helper/remote.py
+++ b/bookstack_file_exporter/config_helper/remote.py
@@ -39,7 +39,7 @@ class StorageProviderConfig:
 
     def is_valid(self, storage_type: str) -> bool:
         """check if object storage config is valid"""
-        return self._valid_checker[storage_type]
+        return self._valid_checker[storage_type]()
 
     def _is_minio_valid(self) -> bool:
         """check if minio config is valid"""

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -128,8 +128,7 @@ class NodeExporter():
         # these should not already be present in map
         # since we started with shelves first and then moved our way down.
         if books_no_shelf:
-            for key, value in books_no_shelf.items():
-                book_nodes[key] = value
+            book_nodes.update(books_no_shelf)
 
         return book_nodes
 
@@ -155,6 +154,5 @@ class NodeExporter():
             ## since we filter empty, check if there is any content
             ## add all chapter pages to existing page nodes
             if page_chapter_nodes:
-                for key, value in page_chapter_nodes.items():
-                    page_nodes[key] = value
+                page_nodes.update(page_chapter_nodes)
         return page_nodes

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -1,4 +1,3 @@
-from typing import Dict, List, Union
 import logging
 
 # pylint: disable=import-error
@@ -19,32 +18,32 @@ class NodeExporter():
     Returns:
         NodeExporter instance to handle building shelve/book/chapter/page relations.
     """
-    def __init__(self, api_urls: Dict[str, str], http_client: HttpHelper):
+    def __init__(self, api_urls: dict[str, str], http_client: HttpHelper):
         self.api_urls = api_urls
         self.http_client = http_client
 
-    def get_all_shelves(self) -> Dict[int, Node]:
+    def get_all_shelves(self) -> dict[int, Node]:
         """
         Function to get all shelf Node instances 
         :returns: Dict[int, Node] for all shelf nodes
         """
         base_url = self.api_urls["shelves"]
-        all_parents: List[int] = self._get_all_ids(base_url)
+        all_parents: list[int] = self._get_all_ids(base_url)
         if not all_parents:
             log.warning("No shelves found in given Bookstack instance")
             return {}
         return self._get_parents(base_url, all_parents)
 
-    def _get_json_response(self, url: str) -> List[Dict[str, Union[str,int]]]:
+    def _get_json_response(self, url: str) -> list[dict[str, str |int]]:
         """get http response data in json format"""
         response: Response = self.http_client.http_get_request(url=url)
         return response.json()
 
-    def _get_all_ids(self, url: str) -> List[int]:
+    def _get_all_ids(self, url: str) -> list[int]:
         return [item['id'] for item in self.http_client.http_get_all(url)]
 
-    def _get_parents(self, base_url: str, parent_ids: List[int],
-                      path_prefix: str = "") -> Dict[int, Node]:
+    def _get_parents(self, base_url: str, parent_ids: list[int],
+                      path_prefix: str = "") -> dict[int, Node]:
         parent_nodes = {}
         for parent_id in parent_ids:
             parent_url = f"{base_url}/{parent_id}"
@@ -52,7 +51,7 @@ class NodeExporter():
             parent_nodes[parent_id] = Node(parent_data, path_prefix=path_prefix)
         return parent_nodes
 
-    def get_chapter_nodes(self, book_nodes: Dict[int, Node]) -> Dict[int, Node]:
+    def get_chapter_nodes(self, book_nodes: dict[int, Node]) -> dict[int, Node]:
         """build chapter nodes by walking each book's contents"""
         base_url = self.api_urls["chapters"]
         chapter_nodes = {}
@@ -65,14 +64,14 @@ class NodeExporter():
                 chapter_nodes[chapter_id] = Node(chapter_data, book_node)
         return chapter_nodes
 
-    def get_child_nodes(self, resource_type: str, parent_nodes: Dict[int, Node],
-                        filter_empty: bool = True, node_type: str = "") -> Dict[int, Node]:
+    def get_child_nodes(self, resource_type: str, parent_nodes: dict[int, Node],
+                        filter_empty: bool = True, node_type: str = "") -> dict[int, Node]:
         """get child nodes from a book/chapter/shelf"""
         base_url = self.api_urls[resource_type]
         return self._get_children(base_url, parent_nodes, filter_empty, node_type)
 
-    def _get_children(self, base_url: str, parent_nodes: Dict[int, Node],
-                       filter_empty: bool, node_type: str = "") -> Dict[int, Node]:
+    def _get_children(self, base_url: str, parent_nodes: dict[int, Node],
+                       filter_empty: bool, node_type: str = "") -> dict[int, Node]:
         child_nodes = {}
         for _, parent in parent_nodes.items():
             if parent.children:
@@ -98,11 +97,11 @@ class NodeExporter():
                         child_nodes[child_id] = child_node
         return child_nodes
 
-    def get_unassigned_books(self, existing_books: Dict[int, Node],
-                              path_prefix: str) -> Dict[int, Node]:
+    def get_unassigned_books(self, existing_books: dict[int, Node],
+                              path_prefix: str) -> dict[int, Node]:
         """get books not under a shelf"""
         book_url = self.api_urls["books"]
-        all_books: List[int] = self._get_all_ids(book_url)
+        all_books: list[int] = self._get_all_ids(book_url)
         unassigned = []
         # get all existing ones and compare against current known books
         for book in all_books:
@@ -114,7 +113,7 @@ class NodeExporter():
         return self._get_parents(book_url, unassigned, path_prefix)
 
     # convenience function
-    def get_all_books(self, shelve_nodes: Dict[int, Node], unassigned_dir: str) -> Dict[int, Node]:
+    def get_all_books(self, shelve_nodes: dict[int, Node], unassigned_dir: str) -> dict[int, Node]:
         """get all books"""
         book_nodes = {}
         # get books in shelves
@@ -133,7 +132,7 @@ class NodeExporter():
         return book_nodes
 
     # convenience function
-    def get_all_pages(self, book_nodes: Dict[int, Node]) -> Dict[int, Node]:
+    def get_all_pages(self, book_nodes: dict[int, Node]) -> dict[int, Node]:
         """get all pages and their content"""
         ## pages
         page_nodes = {}
@@ -141,16 +140,16 @@ class NodeExporter():
             # add `page` flag, we only want pages
             # filter out chapters for now
             # chapters can have their own children/pages
-            page_nodes: Dict[int, Node] = self.get_child_nodes("pages",
+            page_nodes: dict[int, Node] = self.get_child_nodes("pages",
                                                 book_nodes, node_type="page")
         ## chapters (if exists)
         # chapter nodes are treated a little differently
         # chapters are children under books
-        chapter_nodes: Dict[int, Node] = self.get_chapter_nodes(book_nodes)
+        chapter_nodes: dict[int, Node] = self.get_chapter_nodes(book_nodes)
         # add chapter node pages
         # replace existing page node if found with proper chapter parent
         if chapter_nodes:
-            page_chapter_nodes: Dict[int, Node] = self.get_child_nodes("pages", chapter_nodes)
+            page_chapter_nodes: dict[int, Node] = self.get_child_nodes("pages", chapter_nodes)
             ## since we filter empty, check if there is any content
             ## add all chapter pages to existing page nodes
             if page_chapter_nodes:

--- a/bookstack_file_exporter/exporter/node.py
+++ b/bookstack_file_exporter/exporter/node.py
@@ -36,7 +36,6 @@ class Node():
         self._parent = parent
         self._path_prefix = path_prefix
         # for convenience/usage for exporter
-        # self.name: str = self.meta['slug']
         self.name = self.get_name(self.meta['slug'], self.meta['name'])
         # id() is a built-in function and should not be used as a variable name
         self.id_: int = self.meta['id']
@@ -56,9 +55,6 @@ class Node():
 
     def _get_file_path(self) -> str:
         if self._parent:
-            # page node
-            # if not self._children:
-            #     return f"{self._parent.file_path}/{self.name}/{self.name}"
             return f"{self._parent.file_path}/{self.name}"
         return ""
 

--- a/bookstack_file_exporter/exporter/node.py
+++ b/bookstack_file_exporter/exporter/node.py
@@ -1,4 +1,4 @@
-from typing import Dict, Union, List
+from typing import Union
 import unicodedata
 from re import sub as re_sub
 
@@ -30,7 +30,7 @@ class Node():
         relationships for resources like pages, books, chapters, and shelves.
 
     """
-    def __init__(self, meta: Dict[str, Union[str, int]],
+    def __init__(self, meta: dict[str, str | int],
                  parent: Union['Node', None] = None, path_prefix: str = ""):
         self.meta = meta
         self._parent = parent
@@ -58,7 +58,7 @@ class Node():
             return f"{self._parent.file_path}/{self.name}"
         return ""
 
-    def _get_children(self) -> List[Dict[str, Union[str, int]]]:
+    def _get_children(self) -> list[dict[str, str | int]]:
         children = []
         # find first match
         for match in _CHILD_KEYS:

--- a/bookstack_file_exporter/notify/handler.py
+++ b/bookstack_file_exporter/notify/handler.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 from bookstack_file_exporter.config_helper import models, notifications
 from bookstack_file_exporter.notify import notifiers
@@ -32,7 +31,7 @@ class NotifyHandler:
 
         return targets
 
-    def do_notify(self, excep: Union[None, Exception] = None) -> None:
+    def do_notify(self, excep: None | Exception = None) -> None:
         """handle notification sending for all configured targets"""
         if len(self.targets) == 0:
             log.debug("No notification targets found")

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from typing import Union
 from apprise import Apprise, AppriseAsset, AppriseConfig
 
 from bookstack_file_exporter.config_helper import notifications
@@ -42,14 +41,14 @@ class AppRiseNotify:
         client.asset=asset
         return client
 
-    def _get_title(self, excep: Union[None, Exception]) -> str:
+    def _get_title(self, excep: None | Exception) -> str:
         if self.config.custom_title:
             return self.config.custom_title
         if excep:
             return _DEFAULT_TITLE_PREFIX + "Failed"
         return _DEFAULT_TITLE_PREFIX + "Success"
 
-    def _get_message_text(self, error_msg: Union[None, Exception]) -> str:
+    def _get_message_text(self, error_msg: None | Exception) -> str:
         timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
         if error_msg:
             error_str = str(error_msg)

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -2,7 +2,6 @@ import argparse
 import sys
 import logging
 import time
-from typing import Dict
 
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
 from bookstack_file_exporter.exporter.node import Node
@@ -56,12 +55,12 @@ def exporter(config: ConfigNode):
     log.info("Building shelve/book/chapter/page relationships")
     export_helper = NodeExporter(config.urls, http_client)
     ## shelves
-    shelve_nodes: Dict[int, Node] = export_helper.get_all_shelves()
+    shelve_nodes: dict[int, Node] = export_helper.get_all_shelves()
     ## books
-    book_nodes: Dict[int, Node] = export_helper.get_all_books(shelve_nodes,
+    book_nodes: dict[int, Node] = export_helper.get_all_books(shelve_nodes,
                                                               config.unassigned_book_dir)
     ## pages
-    page_nodes: Dict[int, Node] = export_helper.get_all_pages(book_nodes)
+    page_nodes: dict[int, Node] = export_helper.get_all_pages(book_nodes)
     if not page_nodes:
         log.warning("No page data available from given Bookstack instance. Nothing to archive")
         sys.exit(0)

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -15,15 +15,14 @@ log = logging.getLogger(__name__)
 
 def entrypoint(args: argparse.Namespace):
     """entrypoint for export process"""
-    # get configuration from helper
     config = ConfigNode(args)
-    if config.user_inputs.run_interval:
-        while True:
-            run(config)
-            log.info("Waiting %s seconds for next run", config.user_inputs.run_interval)
-            # sleep process state
-            time.sleep(config.user_inputs.run_interval)
-    run(config)
+    if not config.user_inputs.run_interval:
+        run(config)
+        return
+    while True:
+        run(config)
+        log.info("Waiting %s seconds for next run", config.user_inputs.run_interval)
+        time.sleep(config.user_inputs.run_interval)
 
 def run(config: ConfigNode):
     """run export process with error handling and notification support"""

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bookstack_file_exporter.archiver.archiver import Archiver
+from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
 
 
 # ---------------------------------------------------------------------------
@@ -353,3 +354,21 @@ def test_clean_up_with_stale_archives_calls_delete(
     archiver_instance._delete_files = MagicMock()
     archiver_instance.clean_up()
     archiver_instance._delete_files.assert_called_once_with(stale)
+
+
+# ---------------------------------------------------------------------------
+# MinioArchiver._generate_path — trailing-slash normalisation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("input_path,expected", [
+    ("backups/",   "backups"),
+    ("backups//",  "backups"),   # double-slash: old code leaves one slash, new code strips all
+    ("backups",    "backups"),
+    ("a/b/c/",     "a/b/c"),
+    (None,         ""),
+    ("",           ""),
+])
+def test_generate_path_strips_all_trailing_slashes(input_path, expected):
+    """_generate_path must strip ALL trailing slashes, not just one."""
+    result = MinioArchiver._generate_path(None, input_path)
+    assert result == expected

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -2,6 +2,7 @@
 """Unit tests for Archiver archive and clean-up behavior."""
 import logging
 import os
+import re
 from datetime import datetime
 from typing import List
 from unittest.mock import MagicMock
@@ -55,6 +56,11 @@ def test_generate_root_folder_format(monkeypatch, base_name):
     result = Archiver._generate_root_folder(base_name)
     expected = f"{base_name}_2024-03-15_10-30-45"
     assert result == expected
+
+
+def test_archive_dir_has_timestamp_suffix(archiver_instance):
+    """Archiver.archive_dir must end with _YYYY-MM-DD_HH-MM-SS."""
+    assert re.search(r"_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$", archiver_instance.archive_dir)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_asset_archiver_core.py
+++ b/tests/unit/test_asset_archiver_core.py
@@ -3,6 +3,8 @@
 """Unit tests for AssetArchiver markdown link-rewrite behavior (Phase 0 + Phase 1)."""
 import logging
 
+import pytest
+
 from bookstack_file_exporter.archiver.asset_archiver import (
     AttachmentNode,
     ImageNode,
@@ -251,3 +253,8 @@ class TestPhase1MdFixes:
 
         assert any("no substitution" in r.message.lower()
                    for r in caplog.records if r.levelno == logging.DEBUG)
+
+
+def test_get_asset_bytes_unknown_type_raises_valueerror(asset_archiver):
+    with pytest.raises(ValueError, match="unsupported asset type"):
+        asset_archiver.get_asset_bytes("widgets", "https://wiki.example.com/x")

--- a/tests/unit/test_asset_archiver_core.py
+++ b/tests/unit/test_asset_archiver_core.py
@@ -258,3 +258,23 @@ class TestPhase1MdFixes:
 def test_get_asset_bytes_unknown_type_raises_valueerror(asset_archiver):
     with pytest.raises(ValueError, match="unsupported asset type"):
         asset_archiver.get_asset_bytes("widgets", "https://wiki.example.com/x")
+
+
+def test_create_attachment_map_skips_external(asset_archiver):
+    json_data = [
+        {"id": 1, "uploaded_to": 7, "name": "a.pdf", "external": False},
+        {"id": 2, "uploaded_to": 7, "name": "ext", "external": True},
+        {"id": 3, "uploaded_to": 9, "name": "b.pdf", "external": False},
+    ]
+    result = asset_archiver._create_attachment_map(json_data)
+    assert set(result.keys()) == {7, 9}
+    assert [n.id_ for n in result[7]] == [1]
+
+
+def test_create_image_map_groups_by_page(asset_archiver):
+    json_data = [
+        {"id": 1, "uploaded_to": 7, "url": "https://x/a.png"},
+        {"id": 2, "uploaded_to": 7, "url": "https://x/b.png"},
+    ]
+    result = asset_archiver._create_image_map(json_data)
+    assert [n.id_ for n in result[7]] == [1, 2]

--- a/tests/unit/test_common_util.py
+++ b/tests/unit/test_common_util.py
@@ -24,14 +24,14 @@ def test_check_var_env_set_no_default(monkeypatch):
 
 
 def test_check_var_unset_no_default_can_error_true(monkeypatch):
-    """Env var unset, no default, can_error=True → returns empty string, no exception."""
+    """Env var unset, no default, required=False → returns empty string, no exception."""
     monkeypatch.delenv("MY_TEST_CAN_ERROR_TRUE", raising=False)
-    result = check_var("MY_TEST_CAN_ERROR_TRUE", "", can_error=True)
+    result = check_var("MY_TEST_CAN_ERROR_TRUE", "", required=False)
     assert result == ""
 
 
 def test_check_var_unset_no_default_raises(monkeypatch):
-    """Env var unset, no default, can_error=False → ValueError raised."""
+    """Env var unset, no default, required=True (default) → ValueError raised."""
     monkeypatch.delenv("MY_TEST_RAISES", raising=False)
     with pytest.raises(ValueError):
         check_var("MY_TEST_RAISES", "")
@@ -40,5 +40,26 @@ def test_check_var_unset_no_default_raises(monkeypatch):
 def test_check_var_unset_list_default_returns_list(monkeypatch):
     """Env var unset, list default → list returned as-is."""
     monkeypatch.delenv("MY_TEST_LIST_DEFAULT", raising=False)
-    result = check_var("MY_TEST_LIST_DEFAULT", ["a", "b"], can_error=False)
+    result = check_var("MY_TEST_LIST_DEFAULT", ["a", "b"], required=True)
     assert result == ["a", "b"]
+
+
+def test_check_var_env_takes_precedence(monkeypatch):
+    monkeypatch.setenv("MY_KEY", "from-env")
+    assert check_var("MY_KEY", "from-config") == "from-env"
+
+
+def test_check_var_falls_back_to_default(monkeypatch):
+    monkeypatch.delenv("MY_KEY", raising=False)
+    assert check_var("MY_KEY", "from-config") == "from-config"
+
+
+def test_check_var_required_missing_raises(monkeypatch):
+    monkeypatch.delenv("MY_KEY", raising=False)
+    with pytest.raises(ValueError):
+        check_var("MY_KEY", "", required=True)
+
+
+def test_check_var_optional_missing_returns_default(monkeypatch):
+    monkeypatch.delenv("MY_KEY", raising=False)
+    assert check_var("MY_KEY", [], required=False) == []

--- a/tests/unit/test_http_helper.py
+++ b/tests/unit/test_http_helper.py
@@ -171,19 +171,6 @@ def test_http_get_request_404_raises_http_error(http_config):
 
 
 # ---------------------------------------------------------------------------
-# should_verify (static method)
-# ---------------------------------------------------------------------------
-
-@pytest.mark.parametrize("url,expected", [
-    ("https://x.com", "https://"),
-    ("http://x.com", "http://"),
-    ("https://example.org/api/path", "https://"),
-])
-def test_should_verify(url, expected):
-    assert HttpHelper.should_verify(url) == expected
-
-
-# ---------------------------------------------------------------------------
 # http_get_request — error responses
 # ---------------------------------------------------------------------------
 
@@ -253,3 +240,30 @@ def test_http_get_request_does_not_retry_non_retryable_code():
         client.http_get_request(f"{BASE}/books")
     # only one HTTP call should have been made (no retries for 404)
     assert len(responses.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# session reuse
+# ---------------------------------------------------------------------------
+
+@responses.activate
+def test_http_get_request_returns_response(http_config):
+    responses.add(responses.GET, "https://wiki.test.example/api/books",
+                  json={"data": []}, status=200)
+    helper = HttpHelper({"Authorization": "Token x:y"}, http_config)
+    resp = helper.http_get_request("https://wiki.test.example/api/books")
+    assert resp.status_code == 200
+    assert resp.json() == {"data": []}
+
+
+@responses.activate
+def test_http_get_request_reuses_session(http_config):
+    responses.add(responses.GET, "https://wiki.test.example/api/books",
+                  json={"data": []}, status=200)
+    responses.add(responses.GET, "https://wiki.test.example/api/books",
+                  json={"data": []}, status=200)
+    helper = HttpHelper({}, http_config)
+    first = helper._session
+    helper.http_get_request("https://wiki.test.example/api/books")
+    helper.http_get_request("https://wiki.test.example/api/books")
+    assert helper._session is first  # session persists across calls

--- a/tests/unit/test_node_exporter.py
+++ b/tests/unit/test_node_exporter.py
@@ -250,6 +250,14 @@ def test_get_all_books_adds_unassigned_books(
     assert result[99].file_path.startswith("unassigned/")
 
 
+def test_get_all_books_merges_unassigned(api_urls, mock_http_client, monkeypatch):
+    exporter_obj = NodeExporter(api_urls, mock_http_client)
+    monkeypatch.setattr(exporter_obj, "get_child_nodes", lambda *a, **k: {1: "shelf-book"})
+    monkeypatch.setattr(exporter_obj, "get_unassigned_books", lambda *a, **k: {2: "loose-book"})
+    result = exporter_obj.get_all_books({10: "shelf"}, "unassigned/")
+    assert result == {1: "shelf-book", 2: "loose-book"}
+
+
 # ---------------------------------------------------------------------------
 # get_child_nodes / _get_children
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -221,3 +221,12 @@ class TestArchivePages:
 
         # 1 page × 2 formats = 2 write_tar calls
         assert mock_write_tar.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# 7. Regression: broken verify_ssl property must not exist on PageArchiver
+# ---------------------------------------------------------------------------
+
+def test_page_archiver_has_no_verify_ssl_property():
+    """verify_ssl was broken (read nonexistent Assets field); confirm it is gone."""
+    assert not hasattr(PageArchiver, "verify_ssl")

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -1,0 +1,21 @@
+"""Tests for StorageProviderConfig validation dispatch."""
+import pytest
+
+from bookstack_file_exporter.config_helper.models import ObjectStorageConfig
+from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
+
+
+def _config(**overrides):
+    base = {"bucket": "b", "region": "us-east-1", "host": "minio.local"}
+    base.update(overrides)
+    return ObjectStorageConfig(**base)
+
+
+def test_is_valid_true_when_host_present():
+    cfg = StorageProviderConfig("ak", "sk", _config(host="minio.local"))
+    assert cfg.is_valid("minio") is True
+
+
+def test_is_valid_false_when_host_missing():
+    cfg = StorageProviderConfig("ak", "sk", _config(host=""))
+    assert cfg.is_valid("minio") is False

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,0 +1,30 @@
+"""Tests for run.entrypoint dispatch (single run vs interval loop)."""
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bookstack_file_exporter import run
+
+
+def _config(run_interval):
+    return SimpleNamespace(user_inputs=SimpleNamespace(run_interval=run_interval))
+
+
+def test_entrypoint_runs_once_when_no_interval():
+    cfg = _config(run_interval=0)
+    with patch.object(run, "ConfigNode", return_value=cfg), \
+         patch.object(run, "run") as mock_run:
+        run.entrypoint(args=object())
+    assert mock_run.call_count == 1
+
+
+def test_entrypoint_loops_when_interval_set():
+    cfg = _config(run_interval=5)
+    # break out of the infinite loop after the first sleep
+    with patch.object(run, "ConfigNode", return_value=cfg), \
+         patch.object(run, "run") as mock_run, \
+         patch.object(run.time, "sleep", side_effect=InterruptedError):
+        try:
+            run.entrypoint(args=object())
+        except InterruptedError:
+            pass
+    assert mock_run.call_count == 1


### PR DESCRIPTION
## Changes

Targeted fixes from a Python code review (DRY, anti-patterns, testability, best practices). Each commit is self-contained and `fix:`-prefixed.

**Correctness bugs**
- `StorageProviderConfig.is_valid` returned the validator method object instead of calling it — minio config validation never ran. Now invokes it.
- Removed `PageArchiver.verify_ssl` property: it read `Assets.verify_ssl`, a field that does not exist on the `Assets` model (it lives on `HttpConfig`), so any call raised `AttributeError`. Property was unused; SSL verification is already handled in `HttpHelper`.
- `AssetArchiver.get_asset_bytes` `match` had no default branch (`UnboundLocalError` on unknown type). Added `case _` that raises `ValueError`.
- `run.entrypoint` had an unreachable `run(config)` after an infinite `while True`. Refactored to run once when no interval, loop when set.
- `_generate_urls` computed a trailing-slash-stripped `host` but then built URLs from the unstripped value, so the strip never applied. Now uses the normalized host.

**API clarity**
- `check_var`'s `can_error` flag was inverted vs. its behavior; renamed to `required` (default `True`) and widened the return annotation to reflect it can return a list.

**DRY / cleanup**
- Trailing-slash normalization in three sites now uses stdlib `str.rstrip('/')` (also fixes a latent single-slash-only bug on inputs like `host//`).
- Extracted a shared `_group_by_page` helper for the duplicated image/attachment page-grouping logic.
- Replaced manual dict-merge loops with `dict.update` in `NodeExporter`.
- Removed commented-out dead code (`_check_var` block, dead `_APPRISE_FIELDS` entries, stale `node.py` lines).

**Performance**
- `HttpHelper` now builds one `requests.Session` with retry adapters mounted once in `__init__` and reuses it, instead of constructing a new session + adapter on every request.

**Tooling / style**
- Modernized type hints to PEP 585 / PEP 604 via `pyupgrade` and dropped now-unused `typing` imports.

## Motivation

Reduce latent bugs and maintenance friction surfaced by review. Several issues were silent (validation that never ran, a property that always threw, a strip that never applied) and would only bite under specific config paths.

## Test plan / verification

- `uv run pytest` → 212 passed (new regression tests added per fix).
- `uv run pylint bookstack_file_exporter` → 10.00/10 except one intentional, pre-existing `W0718` (the notification catch-all in `run.py`).
- End-to-end: ran a full export against a live BookStack instance and diffed the output tree against a prior reference export (pages unchanged between runs). Result: identical structure (311 files), and the only content differences were BookStack's per-request CSP `nonce` value embedded in each HTML page (server-generated, non-deterministic, independent of this code). All markdown, meta JSON, images, attachments, and other formats were byte-identical.

## In-depth

- **Behavior change to watch:** the trailing-slash fix means a `host` ending in `/` now yields clean API URLs (previously a double slash). Hosts without a trailing slash are unaffected. Exported file paths derive from page slugs, not host, so on-disk output is unchanged regardless.
- **Deferred:** assertion that minio validation now runs only matters for remote uploads with an invalid config; local exports are unaffected.