### PR TITLE
chore: sync uv.lock version via release-please extra-files

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,14 @@
       "release-type": "python",
       "package-name": "bookstack-file-exporter",
       "changelog-path": "CHANGELOG.md",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "extra-files": [
+        {
+          "type": "toml",
+          "path": "uv.lock",
+          "jsonpath": "$.package[?(@.name.value=='bookstack-file-exporter')].version"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
Replace CI relock approach with release-please's native extra-files toml updater so the release PR bumps uv.lock's root package version atomically in a single commit. Filter-by-name jsonpath avoids positional fragility when deps reorder.