### PR TITLE
refactor: return early instead of sys.exit when nothing to archive

### DIFF
--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 import logging
 import time
 
@@ -85,7 +84,7 @@ def exporter(config: ConfigNode):
             "No %s data available from given Bookstack instance. Nothing to archive",
             export_level,
         )
-        sys.exit(0)
+        return
 
     log.info("Beginning archive")
     # get all content for each node
@@ -94,7 +93,7 @@ def exporter(config: ConfigNode):
     # skip gzip/upload/cleanup so we don't crash gzipping a non-existent tar.
     if not archive.has_exported_content:
         log.warning("No %s content was archived. Nothing to upload", export_level)
-        sys.exit(0)
+        return
 
     # create tar if needed and gzip tar
     archive.create_archive()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -4,8 +4,6 @@ export-level node selection in run.exporter."""
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from bookstack_file_exporter import run
 
 
@@ -87,14 +85,13 @@ class TestExporterDispatchPages:
         mock_export_helper.get_chapter_nodes.assert_not_called()
         mock_archiver.get_bookstack_exports.assert_called_once_with(page_nodes)
 
-    def test_pages_level_empty_nodes_exits(self, monkeypatch):
+    def test_pages_level_empty_nodes_returns_early(self, monkeypatch):
         config = _make_exporter_config("pages")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
             chapter_nodes={}, page_nodes={}
         )
-        with pytest.raises(SystemExit):
-            run.exporter(config)
+        run.exporter(config)
         mock_archiver.get_bookstack_exports.assert_not_called()
 
 
@@ -115,14 +112,13 @@ class TestExporterDispatchBooks:
         mock_export_helper.get_chapter_nodes.assert_not_called()
         mock_archiver.get_bookstack_exports.assert_called_once_with(book_nodes)
 
-    def test_books_level_empty_nodes_exits(self, monkeypatch):
+    def test_books_level_empty_nodes_returns_early(self, monkeypatch):
         config = _make_exporter_config("books")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={},
             chapter_nodes={}, page_nodes={}
         )
-        with pytest.raises(SystemExit):
-            run.exporter(config)
+        run.exporter(config)
         mock_archiver.get_bookstack_exports.assert_not_called()
 
 
@@ -144,14 +140,13 @@ class TestExporterDispatchChapters:
         mock_export_helper.get_all_pages.assert_not_called()
         mock_archiver.get_bookstack_exports.assert_called_once_with(chapter_nodes)
 
-    def test_chapters_level_empty_nodes_exits(self, monkeypatch):
+    def test_chapters_level_empty_nodes_returns_early(self, monkeypatch):
         config = _make_exporter_config("chapters")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
             chapter_nodes={}, page_nodes={}
         )
-        with pytest.raises(SystemExit):
-            run.exporter(config)
+        run.exporter(config)
         mock_archiver.get_bookstack_exports.assert_not_called()
 
 
@@ -202,8 +197,7 @@ class TestExporterSharedTail:
         # nothing landed in the tar → no content to upload
         mock_archiver.has_exported_content = False
 
-        with pytest.raises(SystemExit):
-            run.exporter(config)
+        run.exporter(config)
 
         mock_archiver.create_archive.assert_not_called()
         mock_archiver.archive_remote.assert_not_called()
@@ -259,3 +253,28 @@ class TestExporterNodeFilterWiring:
         mock_node_filter_cls.assert_not_called()
         _, kwargs = mock_node_exporter_cls.call_args
         assert kwargs.get("node_filter") is None
+
+
+# ---------------------------------------------------------------------------
+# Notification behavior: empty-nodes early return fires SUCCESS notify
+# ---------------------------------------------------------------------------
+
+class TestRunNotificationOnEarlyReturn:
+    def test_empty_nodes_early_return_fires_success_notification(self, monkeypatch):
+        """When notifications are configured and exporter() hits an empty-nodes
+        early return, run() must still call do_notify() with no error argument."""
+        config = _make_exporter_config("pages")
+        config.user_inputs.notifications = {"apprise_urls": ["mock://notify"]}
+
+        _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={}
+        )
+
+        mock_notif_instance = MagicMock()
+        mock_notif_cls = MagicMock(return_value=mock_notif_instance)
+        monkeypatch.setattr("bookstack_file_exporter.run.NotifyHandler", mock_notif_cls)
+
+        run.run(config)
+
+        mock_notif_instance.do_notify.assert_called_once_with()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -1,6 +1,7 @@
 """Tests for run.entrypoint dispatch (single run vs interval loop) and
 export-level node selection in run.exporter."""
 # pylint: disable=missing-class-docstring,missing-function-docstring,unused-argument
+import logging
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -85,13 +86,16 @@ class TestExporterDispatchPages:
         mock_export_helper.get_chapter_nodes.assert_not_called()
         mock_archiver.get_bookstack_exports.assert_called_once_with(page_nodes)
 
-    def test_pages_level_empty_nodes_returns_early(self, monkeypatch):
+    def test_pages_level_empty_nodes_returns_early(self, monkeypatch, caplog):
         config = _make_exporter_config("pages")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
             chapter_nodes={}, page_nodes={}
         )
-        run.exporter(config)
+        with caplog.at_level(logging.WARNING, logger="bookstack_file_exporter.run"):
+            run.exporter(config)
+        # took the empty-nodes branch specifically (not some other early path)
+        assert any("Nothing to archive" in r.message for r in caplog.records)
         mock_archiver.get_bookstack_exports.assert_not_called()
 
 
@@ -112,13 +116,16 @@ class TestExporterDispatchBooks:
         mock_export_helper.get_chapter_nodes.assert_not_called()
         mock_archiver.get_bookstack_exports.assert_called_once_with(book_nodes)
 
-    def test_books_level_empty_nodes_returns_early(self, monkeypatch):
+    def test_books_level_empty_nodes_returns_early(self, monkeypatch, caplog):
         config = _make_exporter_config("books")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={},
             chapter_nodes={}, page_nodes={}
         )
-        run.exporter(config)
+        with caplog.at_level(logging.WARNING, logger="bookstack_file_exporter.run"):
+            run.exporter(config)
+        # took the empty-nodes branch specifically (not some other early path)
+        assert any("Nothing to archive" in r.message for r in caplog.records)
         mock_archiver.get_bookstack_exports.assert_not_called()
 
 
@@ -140,13 +147,16 @@ class TestExporterDispatchChapters:
         mock_export_helper.get_all_pages.assert_not_called()
         mock_archiver.get_bookstack_exports.assert_called_once_with(chapter_nodes)
 
-    def test_chapters_level_empty_nodes_returns_early(self, monkeypatch):
+    def test_chapters_level_empty_nodes_returns_early(self, monkeypatch, caplog):
         config = _make_exporter_config("chapters")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
             chapter_nodes={}, page_nodes={}
         )
-        run.exporter(config)
+        with caplog.at_level(logging.WARNING, logger="bookstack_file_exporter.run"):
+            run.exporter(config)
+        # took the empty-nodes branch specifically (not some other early path)
+        assert any("Nothing to archive" in r.message for r in caplog.records)
         mock_archiver.get_bookstack_exports.assert_not_called()
 
 
@@ -277,4 +287,26 @@ class TestRunNotificationOnEarlyReturn:
 
         run.run(config)
 
+        mock_notif_instance.do_notify.assert_called_once_with()
+
+    def test_empty_archive_early_return_fires_success_notification(self, monkeypatch):
+        """Second early-return site: nodes existed but nothing landed in the tar
+        (has_exported_content False). run() must still call do_notify() with no
+        error argument, and the downstream archive steps must be skipped."""
+        config = _make_exporter_config("pages")
+        config.user_inputs.notifications = {"apprise_urls": ["mock://notify"]}
+
+        mock_archiver, _ = _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={10: MagicMock()}
+        )
+        mock_archiver.has_exported_content = False
+
+        mock_notif_instance = MagicMock()
+        mock_notif_cls = MagicMock(return_value=mock_notif_instance)
+        monkeypatch.setattr("bookstack_file_exporter.run.NotifyHandler", mock_notif_cls)
+
+        run.run(config)
+
+        mock_archiver.create_archive.assert_not_called()
         mock_notif_instance.do_notify.assert_called_once_with()


### PR DESCRIPTION
## Changes
- `exporter()` returns early instead of `sys.exit(0)` at both "nothing to archive" sites; process exit is owned by the top level. Net exit code unchanged (0).
- Removed the now-unused `import sys`.

## Motivation
`sys.exit()` inside business logic makes `exporter()` untestable (requires catching `SystemExit`) and couples the function to the CLI lifecycle.

## Behavior change (intentional)
`SystemExit` derives from `BaseException`, not `Exception`, so the old `sys.exit(0)` short-circuited past `run()`'s notification block — empty runs sent **no** notification. With an early `return`, control flows back into `run()`, which proceeds to the success notification path. So an empty run now fires a **success** notification (generic body — "completed successfully" + timestamp, no filename, so nothing references a missing archive). Accepted as a fix.

Secondary: in interval-loop mode the old `sys.exit(0)` would have terminated the loop on an empty run; with `return` the loop now continues to the next interval. Strict improvement, consistent with the change's intent.

## Test plan
- `uv run pytest -q` → 364 passed.
- `uv run pylint bookstack_file_exporter/run.py` → 10.00/10 (only pre-existing broad-except `W0718` in `run()`, unchanged).
- 4 prior `pytest.raises(SystemExit)` assertions rewritten to assert a clean return plus downstream-skip (`get_bookstack_exports` / `create_archive` / `archive_remote` / `clean_up` not called); the 3 empty-nodes tests renamed `*_returns_early` and hardened with a "Nothing to archive" warning-log assertion (proves the intended branch ran).
- New tests cover both early-return sites firing a success notification through `run()` with no error argument.

## In-depth
Part of the modularity/testability refactor series. Disjoint files from prior items — parallel-safe. Follow-up `feat:` (F1) stacks after this to add the archive destination(s) to the success notification body.
