### PR TITLE
feat: report archive path and destinations in success notification

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -101,39 +101,48 @@ class Archiver:
         self._archiver.gzip_archive()
 
     # send to remote systems
-    def archive_remote(self):
-        """for each target, do their respective tasks"""
+    def archive_remote(self) -> list[str]:
+        """for each target, do their respective tasks; return list of remote dest strings"""
         if not self.config.object_storage_config:
-            return
+            return []
         # dict built per-call so instance-level monkey-patching of handlers
         # propagates during tests (class-level dict captures pre-patch values)
         handlers = {
             "minio": self._archive_minio,
             "s3": self._archive_s3,
         }
+        dests: list[str] = []
         for key, value in self.config.object_storage_config.items():
             handler = handlers.get(key)
             if handler is None:
                 raise ValueError(f"unsupported remote storage type: {key}")
-            handler(value)
+            dests.append(handler(value))
+        return dests
 
-    def _archive_minio(self, obj_config: StorageProviderConfig):
+    def _archive_minio(self, obj_config: StorageProviderConfig) -> str:
         minio_archiver = MinioArchiver(obj_config.access_key,
                                        obj_config.secret_key, obj_config.config)
-        minio_archiver.upload_backup(self._archiver.archive_file)
+        dest = minio_archiver.upload_backup(self._archiver.archive_file)
         minio_archiver.clean_up(self._archiver.file_extension_map['tgz'])
+        return dest
 
     def _archive_s3(self, obj_config: StorageProviderConfig):
         raise NotImplementedError("S3 remote storage is not yet implemented")
 
-    def clean_up(self):
-        """remove archive after sending to remote target"""
+    def clean_up(self) -> list[str]:
+        """remove archive after sending to remote target; return files deleted"""
         # this captures keep_last = 0
         if not self.config.user_inputs.keep_last:
-            return
+            return []
         to_delete = self._get_stale_archives()
         if to_delete:
             self._delete_files(to_delete)
+        return to_delete
+
+    @property
+    def archive_file(self) -> str:
+        """full path to the produced .tgz archive"""
+        return self._archiver.archive_file
 
     def _get_stale_archives(self) -> list[str]:
         # if user is uploading to object storage

--- a/bookstack_file_exporter/archiver/minio_archiver.py
+++ b/bookstack_file_exporter/archiver/minio_archiver.py
@@ -44,8 +44,8 @@ class MinioArchiver:
     def _generate_path(self, path_name: str | None) -> str:
         return path_name.rstrip('/') if path_name else ""
 
-    def upload_backup(self, local_file_path: str):
-        """upload archive file to minio bucket"""
+    def upload_backup(self, local_file_path: str) -> str:
+        """upload archive file to minio bucket; return 'bucket/object_path' dest string"""
         # this will be the name of the object to upload
         # only get the file name not path
         # we are going to use path provided by user for object storage
@@ -57,6 +57,7 @@ class MinioArchiver:
         result = self._client.fput_object(self.bucket, object_path, local_file_path)
         log.info("""Created object: %s with tag: %s and version-id: %s""",
                  result.object_name, result.etag, result.version_id)
+        return f"{self.bucket}/{object_path}"
 
     def clean_up(self, file_extension: str):
         """delete objects based on 'keep_last' number"""

--- a/bookstack_file_exporter/notify/handler.py
+++ b/bookstack_file_exporter/notify/handler.py
@@ -2,6 +2,7 @@ import logging
 
 from bookstack_file_exporter.config_helper import models, notifications
 from bookstack_file_exporter.notify import notifiers
+from bookstack_file_exporter.notify.models import NotifyResult
 
 
 log = logging.getLogger(__name__)
@@ -13,7 +14,7 @@ class NotifyHandler:
 
     Args:
         :config: <models.Notifications> = User input configuration for notification handlers
-    
+
     Returns:
         NotifyHandler instance to help handle notification integrations.
     """
@@ -31,20 +32,22 @@ class NotifyHandler:
 
         return targets
 
-    def do_notify(self, excep: None | Exception = None) -> None:
+    def do_notify(self, excep: None | Exception = None, result: NotifyResult | None = None) -> None:
         """handle notification sending for all configured targets"""
         if len(self.targets) == 0:
             log.debug("No notification targets found")
             return
         for target, config in self.targets.items():
             log.debug("Starting notification handling for: %s", target)
-            self._supported_notifiers[target](config, excep)
+            self._supported_notifiers[target](config, excep, result)
 
-    def _handle_apprise(self, config: models.AppRiseNotifyConfig, excep: Exception):
+    def _handle_apprise(self, config: models.AppRiseNotifyConfig,
+                        excep: None | Exception = None,
+                        result: NotifyResult | None = None):
         a_config = notifications.AppRiseNotifyConfig(config)
         a_config.validate()
         apprise = notifiers.AppRiseNotify(a_config)
         # only send notification if on_success or on_failure is set
         if (not excep and a_config.on_success) or (excep and a_config.on_failure):
             log.info("Sending notification for run status")
-            apprise.notify(excep)
+            apprise.notify(excep, result)

--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -1,0 +1,9 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class NotifyResult:
+    """What an export run produced, for the success notification."""
+    local: str | None = None          # full local .tgz path, None if no archive made
+    remote: list[str] = field(default_factory=list)   # remote destinations, one per target
+    removed: list[str] = field(default_factory=list)   # local files clean_up() actually deleted

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -1,7 +1,9 @@
+import os
 from datetime import datetime
 from apprise import Apprise, AppriseAsset, AppriseConfig
 
 from bookstack_file_exporter.config_helper import notifications
+from bookstack_file_exporter.notify.models import NotifyResult
 
 _DEFAULT_TITLE_PREFIX = "Bookstack File Exporter "
 
@@ -9,11 +11,11 @@ _DEFAULT_TITLE_PREFIX = "Bookstack File Exporter "
 class AppRiseNotify:
     """
     AppRiseNotify helps send notifications via apprise for failed export runs
-    
+
     Args:
-        :config: <notifications.AppRiseNotifyConfig> = Configuration with user inputs and 
+        :config: <notifications.AppRiseNotifyConfig> = Configuration with user inputs and
                                                        general options
-    
+
     Returns:
         AppRiseNotify instance to help handle apprise notification integration.
     """
@@ -48,28 +50,45 @@ class AppRiseNotify:
             return _DEFAULT_TITLE_PREFIX + "Failed"
         return _DEFAULT_TITLE_PREFIX + "Success"
 
-    def _get_message_text(self, error_msg: None | Exception) -> str:
+    def _get_message_text(self, error_msg: None | Exception,
+                          result: NotifyResult | None = None) -> str:
         timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
         if error_msg:
             error_str = str(error_msg)
             body = f"""
             Bookstack File Exporter encountered an unrecoverable error.
-            
+
             Occurred At: {timestamp}
-            
+
             Error message: {error_str}
             """
         else:
             body = f"""
             Bookstack File Exporter completed successfully.
-            
+
             Completed At: {timestamp}
             """
+            if result is not None and result.local is not None:
+                local_abs = os.path.abspath(result.local)
+                removed_abs = {os.path.abspath(p) for p in result.removed}
+                was_removed = local_abs in removed_abs
+
+                archive_line = f"Archive: {result.local}"
+                if was_removed:
+                    archive_line += " (removed locally after upload)"
+                body += f"\n            {archive_line}"
+
+                if result.remote:
+                    body += f"\n            Uploaded to: {', '.join(result.remote)}"
+
+                pruned_count = len(removed_abs - {local_abs})
+                if pruned_count > 0:
+                    body += f"\n            Pruned {pruned_count} old local archive(s)"
         return body
 
-    def notify(self, excep: Exception):
+    def notify(self, excep: Exception | None = None, result: NotifyResult | None = None):
         """send notification with exception message"""
-        custom_body = self._get_message_text(excep)
+        custom_body = self._get_message_text(excep, result)
         title_ = self._get_title(excep)
         if self.config.custom_attachment:
             self._client.notify(

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -9,6 +9,7 @@ from bookstack_file_exporter.exporter.filter import NodeFilter
 from bookstack_file_exporter.archiver.archiver import Archiver
 from bookstack_file_exporter.common.util import HttpHelper
 from bookstack_file_exporter.notify.handler import NotifyHandler
+from bookstack_file_exporter.notify.models import NotifyResult
 
 log = logging.getLogger(__name__)
 
@@ -26,10 +27,10 @@ def entrypoint(args: argparse.Namespace):
 def run(config: ConfigNode):
     """run export process with error handling and notification support"""
     try:
-        exporter(config)
+        result = exporter(config)
         if config.user_inputs.notifications:
             notif = NotifyHandler(config.user_inputs.notifications)
-            notif.do_notify()
+            notif.do_notify(result=result)
     except Exception as run_err: # general catch all for notifications
         if not config.user_inputs.notifications:
             raise run_err
@@ -84,7 +85,7 @@ def exporter(config: ConfigNode):
             "No %s data available from given Bookstack instance. Nothing to archive",
             export_level,
         )
-        return
+        return None
 
     log.info("Beginning archive")
     # get all content for each node
@@ -93,16 +94,18 @@ def exporter(config: ConfigNode):
     # skip gzip/upload/cleanup so we don't crash gzipping a non-existent tar.
     if not archive.has_exported_content:
         log.warning("No %s content was archived. Nothing to upload", export_level)
-        return
+        return None
 
     # create tar if needed and gzip tar
     archive.create_archive()
 
     # archive to remote targets
-    archive.archive_remote()
+    remote = archive.archive_remote()
     # if remote target is specified and clean is true
     # clean up the .tgz archive since it is already uploaded
-    archive.clean_up()
+    removed = archive.clean_up()
 
+    local = archive.archive_file
     log.info("Created file archive: %s.tgz", archive.archive_dir)
     log.info("Completed run")
+    return NotifyResult(local=local, remote=remote, removed=removed)

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -379,9 +379,10 @@ def test_clean_up_keep_last_zero_returns_early(
     archiver_instance._delete_files = MagicMock(
         side_effect=lambda f: delete_calls.extend(f)  # pylint: disable=unnecessary-lambda
     )
-    archiver_instance.clean_up()
+    result = archiver_instance.clean_up()
     assert not scan_calls
     assert not delete_calls
+    assert result == []
 
 
 def test_clean_up_with_stale_archives_calls_delete(
@@ -394,6 +395,77 @@ def test_clean_up_with_stale_archives_calls_delete(
     archiver_instance._delete_files = MagicMock()
     archiver_instance.clean_up()
     archiver_instance._delete_files.assert_called_once_with(stale)
+
+
+def test_clean_up_keep_last_negative_returns_full_list(
+    monkeypatch, archiver_instance, mock_config, patch_scan_archives
+):
+    """keep_last < 0: all archives are in the returned deleted list (current .tgz included)."""
+    mock_config.user_inputs.keep_last = -1
+    file_list = ["/data/current.tgz", "/data/old.tgz", "/data/older.tgz"]
+    patch_scan_archives(file_list)
+    archiver_instance._delete_files = MagicMock()
+    result = archiver_instance.clean_up()
+    assert result == file_list
+    archiver_instance._delete_files.assert_called_once_with(file_list)
+
+
+def test_clean_up_keep_last_positive_returns_only_old_archives(
+    monkeypatch, archiver_instance, mock_config, patch_scan_archives
+):
+    """keep_last > 0 with more archives than cap: only the excess (old) ones returned."""
+    mock_config.user_inputs.keep_last = 1
+    # Three archives; keep_last=1 → 2 oldest should be deleted, newest kept
+    file_list = ["old1.tgz", "old2.tgz", "current.tgz"]
+    patch_scan_archives(file_list)
+    fake_ctimes = {"old1.tgz": 100, "old2.tgz": 200, "current.tgz": 300}
+    monkeypatch.setattr(os, "stat", _make_stat_patcher(fake_ctimes))
+    archiver_instance._delete_files = MagicMock()
+    result = archiver_instance.clean_up()
+    assert result == ["old1.tgz", "old2.tgz"]
+    assert "current.tgz" not in result
+
+
+# ---------------------------------------------------------------------------
+# archive_remote — return value
+# ---------------------------------------------------------------------------
+
+def test_archive_remote_returns_empty_list_when_no_config(archiver_instance, mock_config):
+    """No object storage config → returns []."""
+    mock_config.object_storage_config = {}
+    result = archiver_instance.archive_remote()
+    assert result == []
+
+
+def test_archive_remote_returns_minio_dest_list(monkeypatch, archiver_instance, mock_config):
+    """Minio handler called → returned dest string collected in list."""
+    minio_config = MagicMock()
+    mock_config.object_storage_config = {"minio": minio_config}
+    expected_dest = "my-bucket/backups/export.tgz"
+    monkeypatch.setattr(archiver_instance, "_archive_minio", MagicMock(return_value=expected_dest))
+    result = archiver_instance.archive_remote()
+    assert result == [expected_dest]
+
+
+def test_archive_minio_returns_dest_string(monkeypatch, archiver_instance):
+    """_archive_minio returns the bucket/path dest from upload_backup."""
+    obj_config = MagicMock()
+    obj_config.access_key = "key"
+    obj_config.secret_key = "secret"
+    obj_config.config = MagicMock()
+
+    expected_dest = "test-bucket/backups/archive.tgz"
+    mock_minio = MagicMock()
+    mock_minio.upload_backup.return_value = expected_dest
+    monkeypatch.setattr(
+        "bookstack_file_exporter.archiver.archiver.MinioArchiver",
+        MagicMock(return_value=mock_minio),
+    )
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    dest = archiver_instance._archive_minio(obj_config)
+    assert dest == expected_dest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_minio_archiver.py
+++ b/tests/unit/test_minio_archiver.py
@@ -1,0 +1,53 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name
+# pylint: disable=protected-access
+"""Unit tests for MinioArchiver.upload_backup return value."""
+from unittest.mock import MagicMock
+
+from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
+
+
+def _make_minio_archiver(bucket: str, path: str | None = None):
+    """Build a MinioArchiver bypassing real Minio init."""
+    instance = MinioArchiver.__new__(MinioArchiver)
+    instance._client = MagicMock()
+    instance.bucket = bucket
+    instance.path = MinioArchiver._generate_path(instance, path)
+    instance.keep_last = 0
+    return instance
+
+
+class TestUploadBackupReturnValue:
+    def test_returns_bucket_slash_object_path_with_prefix(self):
+        archiver = _make_minio_archiver("my-bucket", "backups/2024")
+        mock_result = MagicMock()
+        mock_result.object_name = "backups/2024/export.tgz"
+        mock_result.etag = "abc123"
+        mock_result.version_id = None
+        archiver._client.fput_object.return_value = mock_result
+
+        dest = archiver.upload_backup("/local/path/export.tgz")
+
+        assert dest == "my-bucket/backups/2024/export.tgz"
+
+    def test_returns_bucket_slash_filename_without_prefix(self):
+        archiver = _make_minio_archiver("my-bucket", None)
+        mock_result = MagicMock()
+        mock_result.object_name = "export.tgz"
+        mock_result.etag = "def456"
+        mock_result.version_id = "v1"
+        archiver._client.fput_object.return_value = mock_result
+
+        dest = archiver.upload_backup("/some/path/export.tgz")
+
+        assert dest == "my-bucket/export.tgz"
+
+    def test_fput_object_called_with_correct_args(self):
+        archiver = _make_minio_archiver("bucket-x", "uploads")
+        mock_result = MagicMock()
+        archiver._client.fput_object.return_value = mock_result
+
+        archiver.upload_backup("/data/archive.tgz")
+
+        archiver._client.fput_object.assert_called_once_with(
+            "bucket-x", "uploads/archive.tgz", "/data/archive.tgz"
+        )

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -1,0 +1,129 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name
+# pylint: disable=protected-access
+"""Unit tests for AppRiseNotify._get_message_text success-branch formatting."""
+import os
+from unittest.mock import MagicMock
+
+from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify.notifiers import AppRiseNotify
+
+
+def _make_notifier():
+    """Build AppRiseNotify bypassing Apprise client init."""
+    instance = AppRiseNotify.__new__(AppRiseNotify)
+    config = MagicMock()
+    config.custom_title = None
+    config.storage_path = None
+    config.plugin_paths = None
+    config.config_path = None
+    config.service_urls = []
+    config.custom_attachment = None
+    instance.config = config
+    instance._client = MagicMock()
+    return instance
+
+
+class TestGetMessageTextSuccessBranch:
+    def test_none_result_produces_generic_success_body(self):
+        notifier = _make_notifier()
+        body = notifier._get_message_text(None, result=None)
+        assert "completed successfully" in body
+        assert "Archive:" not in body
+        assert "Uploaded to:" not in body
+        assert "Pruned" not in body
+
+    def test_result_local_none_produces_generic_success_body(self):
+        notifier = _make_notifier()
+        result = NotifyResult(local=None, remote=[], removed=[])
+        body = notifier._get_message_text(None, result=result)
+        assert "completed successfully" in body
+        assert "Archive:" not in body
+
+    def test_local_only_shows_archive_line_no_suffix_no_remote_no_pruned(self):
+        notifier = _make_notifier()
+        result = NotifyResult(local="/data/export.tgz", remote=[], removed=[])
+        body = notifier._get_message_text(None, result=result)
+        assert "Archive: /data/export.tgz" in body
+        assert "(removed locally after upload)" not in body
+        assert "Uploaded to:" not in body
+        assert "Pruned" not in body
+
+    def test_local_in_removed_shows_suffix(self):
+        notifier = _make_notifier()
+        local = "/data/export.tgz"
+        result = NotifyResult(local=local, remote=[], removed=[local])
+        body = notifier._get_message_text(None, result=result)
+        assert "Archive: /data/export.tgz (removed locally after upload)" in body
+
+    def test_remote_nonempty_shows_uploaded_to_line(self):
+        notifier = _make_notifier()
+        result = NotifyResult(
+            local="/data/export.tgz",
+            remote=["bucket1/backups/export.tgz", "bucket2/export.tgz"],
+            removed=[],
+        )
+        body = notifier._get_message_text(None, result=result)
+        assert "Uploaded to: bucket1/backups/export.tgz, bucket2/export.tgz" in body
+
+    def test_removed_has_old_files_shows_pruned_count(self):
+        notifier = _make_notifier()
+        local = "/data/new.tgz"
+        removed = ["/data/old1.tgz", "/data/old2.tgz", local]
+        result = NotifyResult(local=local, remote=[], removed=removed)
+        body = notifier._get_message_text(None, result=result)
+        # local is in removed (suffix present) + 2 old archives pruned
+        assert "(removed locally after upload)" in body
+        assert "Pruned 2 old local archive(s)" in body
+
+    def test_old_files_only_no_local_in_removed(self):
+        notifier = _make_notifier()
+        local = "/data/new.tgz"
+        removed = ["/data/old1.tgz", "/data/old2.tgz"]
+        result = NotifyResult(local=local, remote=[], removed=removed)
+        body = notifier._get_message_text(None, result=result)
+        assert "(removed locally after upload)" not in body
+        assert "Pruned 2 old local archive(s)" in body
+
+    def test_abspath_normalization_relative_vs_absolute(self):
+        """Relative and absolute path forms of the same file are treated as the same."""
+        notifier = _make_notifier()
+        # Use a known absolute path and a relative form that resolves to the same place
+        cwd = os.getcwd()
+        local_abs = os.path.join(cwd, "export.tgz")
+        local_rel = "export.tgz"
+        # Pass abs as local, relative form in removed — should still match
+        result = NotifyResult(local=local_abs, remote=[], removed=[local_rel])
+        body = notifier._get_message_text(None, result=result)
+        assert "(removed locally after upload)" in body
+
+    def test_abspath_normalization_relative_local_absolute_removed(self):
+        """Reverse form: relative local vs absolute removed entry still match (suffix)."""
+        notifier = _make_notifier()
+        local_rel = "export.tgz"
+        removed_abs = os.path.join(os.getcwd(), "export.tgz")
+        result = NotifyResult(local=local_rel, remote=[], removed=[removed_abs])
+        body = notifier._get_message_text(None, result=result)
+        assert "(removed locally after upload)" in body
+
+    def test_pruned_count_excludes_current_under_mixed_path_forms(self):
+        """The current archive must not inflate the prune count even when its path
+        form differs between local and the removed list (abspath-normalized)."""
+        notifier = _make_notifier()
+        local_rel = "new.tgz"
+        removed = [os.path.join(os.getcwd(), "new.tgz"), "/data/old1.tgz", "/data/old2.tgz"]
+        result = NotifyResult(local=local_rel, remote=[], removed=removed)
+        body = notifier._get_message_text(None, result=result)
+        # current archive (mixed form) → suffix, NOT counted among pruned old archives
+        assert "(removed locally after upload)" in body
+        assert "Pruned 2 old local archive(s)" in body
+
+    def test_failure_branch_unchanged_no_archive_lines(self):
+        notifier = _make_notifier()
+        err = ValueError("something broke")
+        result = NotifyResult(local="/data/export.tgz", remote=["bucket/x"], removed=[])
+        body = notifier._get_message_text(err, result=result)
+        assert "unrecoverable error" in body
+        assert "something broke" in body
+        assert "Archive:" not in body
+        assert "Uploaded to:" not in body
+        assert "Pruned" not in body

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from bookstack_file_exporter import run
+from bookstack_file_exporter.notify.models import NotifyResult
 
 
 def _config(run_interval):
@@ -287,7 +288,7 @@ class TestRunNotificationOnEarlyReturn:
 
         run.run(config)
 
-        mock_notif_instance.do_notify.assert_called_once_with()
+        mock_notif_instance.do_notify.assert_called_once_with(result=None)
 
     def test_empty_archive_early_return_fires_success_notification(self, monkeypatch):
         """Second early-return site: nodes existed but nothing landed in the tar
@@ -309,4 +310,77 @@ class TestRunNotificationOnEarlyReturn:
         run.run(config)
 
         mock_archiver.create_archive.assert_not_called()
-        mock_notif_instance.do_notify.assert_called_once_with()
+        mock_notif_instance.do_notify.assert_called_once_with(result=None)
+
+
+# ---------------------------------------------------------------------------
+# exporter() return value: None on early returns, NotifyResult on success
+# ---------------------------------------------------------------------------
+
+class TestExporterReturnValue:
+    def test_empty_nodes_returns_none(self, monkeypatch):
+        """empty nodes early return → exporter() returns None."""
+        config = _make_exporter_config("pages")
+        _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={}
+        )
+        result = run.exporter(config)
+        assert result is None
+
+    def test_no_exported_content_returns_none(self, monkeypatch):
+        """has_exported_content=False early return → exporter() returns None."""
+        config = _make_exporter_config("pages")
+        mock_archiver, _ = _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={10: MagicMock()}
+        )
+        mock_archiver.has_exported_content = False
+        result = run.exporter(config)
+        assert result is None
+
+    def test_success_returns_notify_result(self, monkeypatch):
+        """Happy path → exporter() returns a populated NotifyResult."""
+        config = _make_exporter_config("pages")
+        mock_archiver, _ = _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={10: MagicMock()}
+        )
+        mock_archiver.has_exported_content = True
+        mock_archiver.archive_remote.return_value = ["bucket/export.tgz"]
+        mock_archiver.clean_up.return_value = ["/local/export.tgz"]
+        mock_archiver.archive_file = "/local/export.tgz"
+
+        result = run.exporter(config)
+
+        assert isinstance(result, NotifyResult)
+        assert result.local == "/local/export.tgz"
+        assert result.remote == ["bucket/export.tgz"]
+        assert result.removed == ["/local/export.tgz"]
+
+    def test_success_path_do_notify_called_with_result(self, monkeypatch):
+        """On success, run() calls do_notify(result=<NotifyResult>)."""
+        config = _make_exporter_config("pages")
+        config.user_inputs.notifications = {"apprise_urls": ["mock://notify"]}
+        mock_archiver, _ = _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={10: MagicMock()}
+        )
+        mock_archiver.has_exported_content = True
+        mock_archiver.archive_remote.return_value = []
+        mock_archiver.clean_up.return_value = []
+        mock_archiver.archive_file = "/local/export.tgz"
+
+        mock_notif_instance = MagicMock()
+        monkeypatch.setattr(
+            "bookstack_file_exporter.run.NotifyHandler",
+            MagicMock(return_value=mock_notif_instance),
+        )
+
+        run.run(config)
+
+        call_kwargs = mock_notif_instance.do_notify.call_args
+        assert call_kwargs is not None
+        result_arg = call_kwargs.kwargs.get("result")
+        assert isinstance(result_arg, NotifyResult)
+        assert result_arg.local == "/local/export.tgz"


### PR DESCRIPTION
## Changes

Thread a small `NotifyResult(local, remote, removed)` dataclass from `exporter()` through `run()` and the apprise notify chain (`NotifyHandler.do_notify` → `_handle_apprise` → `AppRiseNotify.notify` → `_get_message_text`) so the **success** notification reports what was archived and where:

- **`Archive: <full .tgz path>`** — with a ` (removed locally after upload)` suffix when `keep_last` deleted the just-created archive (remote-only mode).
- **`Uploaded to: <dest>, ...`** — one entry per remote target (minio today; s3 still `NotImplementedError`). Minio dest is `bucket/object_path`.
- **`Pruned N old local archive(s)`** — when older archives beyond `keep_last` were culled.

Supporting return-value changes:
- `MinioArchiver.upload_backup` returns the `bucket/object_path` dest string.
- `Archiver._archive_minio` / `archive_remote` return the remote dest(s) (`list[str]`, `[]` when no remote configured).
- `Archiver.clean_up` returns the list of files it deleted (the list was already built by `_get_stale_archives` and discarded).
- New `Archiver.archive_file` read-only property (avoids reaching `_archiver.archive_file` from `run.py`).
- New `NotifyResult` dataclass in `bookstack_file_exporter/notify/models.py`.

## Motivation

The success body was generic ("completed successfully" + timestamp) — it didn't say what file was produced or where it landed. Operators running remote-only or pruning configs had no confirmation of the destination or that the local copy was intentionally removed. This depended on R3 (#120): before that, the empty/normal path was short-circuited by `sys.exit(0)` and never reached the notifier.

## Behavior change

Success notifications gain the lines above **only when an archive was actually produced**. Empty-run and failure notifications are unchanged: `exporter()` returns `None` on both early-exit paths (no nodes / nothing archived), `result` defaults to `None` everywhere, and a `None`/`local is None` result falls back to today's exact generic body. The failure branch is untouched.

The current-archive-removed suffix is derived from **abspath-normalized membership** (`abspath(local) in {abspath(p) for p in removed}`), not `os.path.exists` (racy) — the path is informational regardless of whether the file still exists.

Minor incidental: blank lines inside the existing success/failure message bodies had trailing whitespace (12 spaces) stripped to empty. No rendered/visible change (a blank line either way). The message body is slated for a proper rebuild (list-of-lines join) in the later R9 cleanup batch.

## Test plan

- `uv run pytest` — 385 passed (+23 from F1).
- `uv run pylint bookstack_file_exporter` — 9.99/10, only the pre-existing intentional `W0718` broad-except in `run.py`.
- New `tests/unit/test_notifiers.py`: `_get_message_text` success-branch formatting — None result → generic body; local-only; removed-suffix; uploaded line; prune line with correct N; failure branch unchanged; abspath normalization (relative vs absolute path forms still match).
- New `tests/unit/test_minio_archiver.py`: `upload_backup` return value (with/without path prefix; `fput_object` args).
- `tests/unit/test_archiver.py`: `clean_up()` returns deleted list for `keep_last < 0` (current archive included) and `keep_last > 0` (only old archives); `archive_remote()`/`_archive_minio()` dest returns.
- `tests/unit/test_run.py`: early returns yield `None` (→ `do_notify(result=None)`); success path returns a populated `NotifyResult`.

## In-depth

- **Dataclass over loose params:** threading one `NotifyResult` keeps the four notify-chain hops to a single optional param each instead of growing positional args; defaults (`None` / empty lists) preserve back-compat.
- **`clean_up()` return:** the deleted list already existed inside `_get_stale_archives`; surfacing it was nearly free and lets the notification report pruning truthfully rather than re-deriving it.
- **Follow-ups (out of scope):** top-level CLI exit-code/error handling (R10 candidate); the broader R1–R9 modularity sequence continues after this.
