### PR TITLE
refactor: extract shared markdown URL token-walk

### DIFF
--- a/bookstack_file_exporter/archiver/asset_archiver.py
+++ b/bookstack_file_exporter/archiver/asset_archiver.py
@@ -123,6 +123,43 @@ class AssetNode:
         return [u for u in dict.fromkeys([*extracted, self.page_url]) if u]
 
     @staticmethod
+    def _walk_md_urls(md_str: str) -> list[str]:
+        """Walk markdown-it-py tokens and return all image src and link href values.
+
+        Uses markdown-it-py for spec-compliant parsing — handles URLs with
+        parentheses and alt-text containing parens without regex brittleness.
+
+        Token shapes:
+          `image` = single self-contained token for a markdown image.
+            markdown: ![alt](URL)
+            tokens:   image(src=URL, alt=alt)
+
+          `link_open` = opening half of a link pair; text and link_close follow.
+          We only need the opener's href; link_close has no attrs.
+            markdown: [text](URL)
+            tokens:   link_open(href=URL), text("text"), link_close
+
+          For BookStack's anchor-wrapped image (click-to-zoom) shape, both
+          branches fire on the same construct:
+            markdown: [![alt](inner)](outer)
+            tokens:   link_open(href=outer), image(src=inner), link_close
+            result:   [outer, inner]
+
+          Attachments don't normally render as images, but links.markdown is
+          user-controllable so the image branch is handled defensively.
+        """
+        if not md_str:
+            return []
+        urls = []
+        for block_token in _md.parse(md_str):
+            for token in (block_token.children or []):
+                if token.type == 'image':
+                    urls.append(token.attrs['src'])
+                elif token.type == 'link_open':
+                    urls.append(token.attrs['href'])
+        return urls
+
+    @staticmethod
     def _get_md_url_strs(asset_data: dict[str, int | str]) -> list[str]:
         """Extract image src and link href values from content.markdown.
         Uses markdown-it-py for spec-compliant parsing — handles URLs with
@@ -130,29 +167,7 @@ class AssetNode:
         md_str = ""
         if 'content' in asset_data and 'markdown' in asset_data.get('content', {}):
             md_str = asset_data['content']['markdown']
-        if not md_str:
-            return []
-        urls = []
-        for block_token in _md.parse(md_str):
-            for token in (block_token.children or []):
-                # `image` = single self-contained token for a markdown image.
-                #   markdown: ![alt](URL)
-                #   tokens:   image(src=URL, alt=alt)
-                if token.type == 'image':
-                    urls.append(token.attrs['src'])
-                # `link_open` = opening half of a link pair; text and link_close
-                # follow. We only need the opener's href; link_close has no attrs.
-                #   markdown: [text](URL)
-                #   tokens:   link_open(href=URL), text("text"), link_close
-                #
-                # For BookStack's anchor-wrapped image (click-to-zoom) shape,
-                # both branches fire on the same construct:
-                #   markdown: [![alt](inner)](outer)
-                #   tokens:   link_open(href=outer), image(src=inner), link_close
-                #   result:   [outer, inner]
-                elif token.type == 'link_open':
-                    urls.append(token.attrs['href'])
-        return urls
+        return AssetNode._walk_md_urls(md_str)
 
     @staticmethod
     def _get_html_url_strs(asset_data: dict[str, int | str]) -> list[str]:
@@ -220,25 +235,7 @@ class AttachmentNode(AssetNode):
         md_str = ""
         if 'links' in asset_data and 'markdown' in asset_data.get('links', {}):
             md_str = asset_data['links']['markdown']
-        if not md_str:
-            return []
-        urls = []
-        for block_token in _md.parse(md_str):
-            for token in (block_token.children or []):
-                # `image` = single self-contained token for a markdown image.
-                # Attachments don't normally render as images, but links.markdown
-                # is user-controllable so we handle defensively.
-                #   markdown: ![alt](URL)
-                #   tokens:   image(src=URL, alt=alt)
-                if token.type == 'image':
-                    urls.append(token.attrs['src'])
-                # `link_open` = opening half of a link pair; this is the normal
-                # shape BookStack returns for attachment links.
-                #   markdown: [file.dat](URL)
-                #   tokens:   link_open(href=URL), text("file.dat"), link_close
-                elif token.type == 'link_open':
-                    urls.append(token.attrs['href'])
-        return urls
+        return AssetNode._walk_md_urls(md_str)
 
     @staticmethod
     def _get_html_url_strs(asset_data: dict[str, int | str | dict]) -> list[str]:

--- a/tests/unit/test_asset_archiver_core.py
+++ b/tests/unit/test_asset_archiver_core.py
@@ -121,6 +121,21 @@ class TestPhase1MdFixes:
             "https://wiki.example.com/uploads/images/gallery/2024-01/screenshot.png"
         ) in result
 
+    def test_get_md_url_strs_anchor_wrapped_order_outer_then_inner(
+        self, image_api_content
+    ):
+        """Token walk on [![alt](INNER)](OUTER) yields link_open(href=OUTER) before
+        image(src=INNER), so the result order must be [OUTER, INNER]."""
+        outer_url = (
+            "https://wiki.example.com/uploads/images/gallery/2024-01/screenshot.png"
+        )
+        inner_url = (
+            "https://wiki.example.com/uploads/images/gallery/2024-01/"
+            "scaled-1680-/screenshot.png"
+        )
+        result = ImageNode._get_md_url_strs(image_api_content)
+        assert result == [outer_url, inner_url]
+
     def test_get_md_url_strs_attachment_returns_url(self, attachment_api_content):
         """_get_md_url_strs on attachment should return the href URL."""
         result = AttachmentNode._get_md_url_strs(attachment_api_content)


### PR DESCRIPTION
Both AssetNode and AttachmentNode._get_md_url_strs ran an identical token-walk loop over markdown-it-py tokens. Extract it into a shared AssetNode._walk_md_urls(md_str) static helper and delegate from both callers, eliminating the duplicate loop.

Add a test that locks the [outer, inner] ordering from the anchor-wrapped image shape before refactoring.