### PR TITLE
refactor: make AppRiseNotifyConfig.validate() a pure predicate

### DIFF
--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -32,23 +32,30 @@ class AppRiseNotifyConfig:
         self.custom_attachment = config.custom_attachment_path
         self.on_success = config.on_success
         self.on_failure = config.on_failure
+        self._resolve_service_urls()
+
+    def _resolve_service_urls(self) -> None:
+        """Resolve env-sourced service_urls once at construction.
+
+        APPRISE_URLS arrives from the environment as a JSON string, so parse it
+        into a list when that env var is set and no config_path is used. Doing
+        this here (not in validate()) keeps validate() a pure predicate over
+        already-resolved state. The truthy guard mirrors validate()'s missing
+        check: an empty/None service_urls falls through to validate(), which
+        raises ValueError — so a parse never runs on an empty value.
+        """
+        if (not self.config_path and self.service_urls
+                and os.environ.get(_APPRISE_FIELDS["urls"]) is not None):
+            try:
+                self.service_urls = json.loads(self.service_urls)
+            # json errors can be hard to debug, add helpful log message
+            except json.decoder.JSONDecodeError as url_err:
+                log.error("Failed to parse env var for apprise urls. \
+                        Ensure proper json string format")
+                raise url_err
 
     def validate(self) -> None:
-        """validate apprise configuration"""
+        """Validate apprise configuration (pure predicate over resolved state)."""
         if not self.config_path and not self.service_urls:
             raise ValueError("""apprise config_path and service_urls are
                               missing from configuration - at least one should be set""")
-
-        # if not config path/file given, then we use service_urls
-        if not self.config_path:
-            # if not config path style, we try service_urls
-            # if service_urls defined in env, override main config file value
-            if os.environ.get(_APPRISE_FIELDS["urls"]) is not None:
-                try:
-                    new_urls = json.loads(self.service_urls)
-                    self.service_urls = new_urls
-                # json errors can be hard to debug, add helpful log message
-                except json.decoder.JSONDecodeError as url_err:
-                    log.error("Failed to parse env var for apprise urls. \
-                            Ensure proper json string format")
-                    raise url_err

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,0 +1,82 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
+"""Unit tests for AppRiseNotifyConfig env/JSON resolution and validate() purity."""
+import json
+
+import pytest
+
+from bookstack_file_exporter.config_helper import models
+from bookstack_file_exporter.config_helper.notifications import (
+    AppRiseNotifyConfig,
+    _APPRISE_FIELDS,
+)
+
+_ENV_KEY = _APPRISE_FIELDS["urls"]
+
+
+def _make_config(**overrides) -> models.AppRiseNotifyConfig:
+    base = {"service_urls": [], "config_path": ""}
+    base.update(overrides)
+    return models.AppRiseNotifyConfig(**base)
+
+
+class TestServiceUrlResolution:
+    def test_env_json_string_parsed_to_list_at_construction(self, monkeypatch):
+        monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://a", "mailto://b"]))
+        cfg = AppRiseNotifyConfig(_make_config())
+        # check_var pulls the raw env string; __init__ resolves it to a list
+        assert cfg.service_urls == ["mailto://a", "mailto://b"]
+
+    def test_config_file_urls_untouched_when_env_unset(self, monkeypatch):
+        monkeypatch.delenv(_ENV_KEY, raising=False)
+        cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://from-file"]))
+        assert cfg.service_urls == ["mailto://from-file"]
+
+    def test_config_path_skips_url_parse(self, monkeypatch):
+        # env set, but config_path present -> no JSON parse; service_urls stays
+        # the raw env string (check_var override) rather than raising on bad json
+        monkeypatch.setenv(_ENV_KEY, "not-json")
+        cfg = AppRiseNotifyConfig(_make_config(config_path="/etc/apprise.yml",
+                                               service_urls=["mailto://x"]))
+        assert cfg.service_urls == "not-json"
+
+    def test_invalid_env_json_raises_at_construction(self, monkeypatch):
+        monkeypatch.setenv(_ENV_KEY, "{not valid json")
+        with pytest.raises(json.decoder.JSONDecodeError):
+            AppRiseNotifyConfig(_make_config())
+
+    def test_empty_env_with_config_list_raises_typeerror(self, monkeypatch):
+        # fidelity edge: APPRISE_URLS="" is falsy so check_var returns the config
+        # list, but `os.environ.get(...) is not None` is still True -> json.loads
+        # runs on a list -> TypeError. Preserved verbatim from pre-refactor.
+        monkeypatch.setenv(_ENV_KEY, "")
+        with pytest.raises(TypeError):
+            AppRiseNotifyConfig(_make_config(service_urls=["mailto://x"]))
+
+
+class TestValidate:
+    def test_missing_both_raises(self, monkeypatch):
+        monkeypatch.delenv(_ENV_KEY, raising=False)
+        cfg = AppRiseNotifyConfig(_make_config(service_urls=[], config_path=""))
+        with pytest.raises(ValueError):
+            cfg.validate()
+
+    def test_config_path_only_passes(self, monkeypatch):
+        monkeypatch.delenv(_ENV_KEY, raising=False)
+        cfg = AppRiseNotifyConfig(_make_config(config_path="/etc/apprise.yml"))
+        cfg.validate()  # no raise
+
+    def test_service_urls_only_passes(self, monkeypatch):
+        monkeypatch.delenv(_ENV_KEY, raising=False)
+        cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://x"]))
+        cfg.validate()  # no raise
+
+    def test_validate_is_pure_no_env_read_no_mutation(self, monkeypatch):
+        # resolve from env at construction, then change the env: validate() must
+        # not re-read it or mutate state. Idempotent across repeated calls.
+        monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://a"]))
+        cfg = AppRiseNotifyConfig(_make_config())
+        assert cfg.service_urls == ["mailto://a"]
+        monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://changed"]))
+        cfg.validate()
+        cfg.validate()
+        assert cfg.service_urls == ["mailto://a"]


### PR DESCRIPTION
## Changes

Makes `AppRiseNotifyConfig.validate()` a pure predicate. The `APPRISE_URLS` env read and the JSON parse of `service_urls` move out of `validate()` and into `__init__` (new private `_resolve_service_urls()`). `validate()` now does only the "at least one of `config_path`/`service_urls`" check — no I/O, no mutation.

Part of the sequenced modularity/testability refactor (item R7). Behavior-preserving `refactor:`, off fresh `main`.

## Motivation

`validate()` previously mixed pure validation with side effects — it re-read the environment and `json.loads`+mutated `self.service_urls`. That coupling made the predicate untestable in isolation and surprising (a "validate" call mutating state). Resolving env/JSON once at construction leaves `validate()` a clean predicate over already-resolved state.

## Behavior preservation

Observable behavior is identical. Key points:

- The original parse ran only *after* `validate()`'s missing-check, so it never executed on a falsy `service_urls`. The new guard (`not config_path and service_urls and os.environ.get(APPRISE_URLS) is not None`) reproduces that ordering.
- Invalid-JSON (`JSONDecodeError`) and the `env="" + list` (`TypeError`) edge now raise at **construction** instead of `validate()`. The sole caller (`notify/handler.py`) constructs and validates back-to-back in one scope, so propagation to the caller is unchanged.

## Test plan

New `tests/unit/test_notifications.py` locks observable behavior:

- env JSON string → parsed to list at construction
- env unset → config-file list passed through untouched
- `config_path` set → parse skipped (env override left as raw string)
- invalid env JSON → `JSONDecodeError` at construction
- `env="" + non-empty list` → `TypeError` (verbatim pre-refactor edge)
- neither `config_path` nor `service_urls` → `ValueError`
- `validate()` purity: mutate env after construction, call twice → `service_urls` unchanged (no re-read, no mutation, idempotent)

Verification:
- `uv run pytest` — 397 passed (9 new)
- `uv run pylint bookstack_file_exporter` — 9.99/10 (only the pre-existing intentional `W0718` in `run.py`); new test file 10.00/10
- 100% line+branch coverage on `config_helper/notifications.py`

## In-depth

`validate()` is now safe to call repeatedly and in tests without an environment or monkeypatching. The one semantic nuance — exception location shifting from `validate()` to `__init__` — is caller-transparent given the single back-to-back call site, and is called out above rather than left implicit. No behavior change was made to `check_var`'s env-override semantics.
