### PR TITLE
fix: resolve apprise urls in one validated env probe

### DIFF
--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -1,14 +1,18 @@
 import logging
 import os
 from http.cookiejar import DefaultCookiePolicy
+from typing import TypeVar
 from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
 import urllib3
 # pylint: disable=import-error
 import requests
 # pylint: disable=import-error
 from requests.adapters import HTTPAdapter, Retry
+from pydantic import TypeAdapter, ValidationError
 
 from bookstack_file_exporter.config_helper.models import HttpConfig
+
+T = TypeVar("T")
 
 log = logging.getLogger(__name__)
 
@@ -99,8 +103,7 @@ class HttpHelper:
             offset += count
         return all_data
 
-def check_var(env_key: str, default_val: list[str] | str,
-              required: bool = True) -> list[str] | str:
+def check_var(env_key: str, default_val: str, required: bool = True) -> str:
     """
     :param env_key: environment variable to check (takes precedence)
     :param default_val: fallback value if the env var is unset
@@ -118,4 +121,33 @@ def check_var(env_key: str, default_val: list[str] | str,
             f"{env_key} is not specified in env and is missing from configuration "
             "- at least one should be set"
         )
+    return default_val
+
+
+def resolve_env_json(env_key: str, target: type[T], default_val: T) -> T:
+    """Env-over-file for a JSON env var, parsed AND validated into `target`.
+
+    The env value is a JSON string; parse+validate it here so callers never
+    re-read os.environ (that double-probe was the empty-env TypeError bug) and so
+    env input gets the same type checking as the YAML-parsed config field. A
+    plain json.loads left the env path unvalidated: the resolved value lands on a
+    plain attribute that pydantic never re-checks, so APPRISE_URLS='"foo"' would
+    hand a bare str to apprise. TypeAdapter rejects wrong shape/element types. A
+    set-but-empty env var falls back to default_val.
+
+    :param env_key: environment variable to check (takes precedence)
+    :param target: type to validate into, e.g. list[str]
+    :param default_val: fallback if the env var is unset/empty
+    :return: validated env value if env var set, else default_val
+    :raises pydantic.ValidationError: if the env var is set but not valid `target`
+    """
+    raw = os.environ.get(env_key, "")
+    if raw:
+        try:
+            return TypeAdapter(target).validate_json(raw)
+        except ValidationError:
+            # pydantic's message names the target type, not the env var; log the
+            # env-var name so operators know which value to fix.
+            log.error("env var %s did not validate as %s", env_key, target)
+            raise
     return default_val

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -1,11 +1,5 @@
-import json
-import logging
-import os
-
 from bookstack_file_exporter.config_helper import models
-from bookstack_file_exporter.common.util import check_var
-
-log = logging.getLogger(__name__)
+from bookstack_file_exporter.common.util import resolve_env_json
 
 _APPRISE_FIELDS = {
     "urls": "APPRISE_URLS",
@@ -15,16 +9,18 @@ _APPRISE_FIELDS = {
 class AppRiseNotifyConfig:
     """
     Convenience class to hold apprise notification configuration
-    
+
     Args:
         :config: <models.AppRiseNotifyConfig> = user input configuration
-    
+
     Returns:
         AppRiseNotifyConfig instance for holding configuration
     """
     def __init__(self, config: models.AppRiseNotifyConfig):
-        self.service_urls: str | list = check_var(_APPRISE_FIELDS["urls"],
-                                  config.service_urls, required=False)
+        # env (JSON array string) wins over the config-file list; resolved +
+        # validated once here. `or []` keeps the []-not-None guarantee.
+        self.service_urls = resolve_env_json(_APPRISE_FIELDS["urls"], list[str],
+                                             config.service_urls or [])
         self.config_path = config.config_path
         self.plugin_paths = config.plugin_paths
         self.storage_path = config.storage_path
@@ -32,27 +28,6 @@ class AppRiseNotifyConfig:
         self.custom_attachment = config.custom_attachment_path
         self.on_success = config.on_success
         self.on_failure = config.on_failure
-        self._resolve_service_urls()
-
-    def _resolve_service_urls(self) -> None:
-        """Resolve env-sourced service_urls once at construction.
-
-        APPRISE_URLS arrives from the environment as a JSON string, so parse it
-        into a list when that env var is set and no config_path is used. Doing
-        this here (not in validate()) keeps validate() a pure predicate over
-        already-resolved state. The truthy guard mirrors validate()'s missing
-        check: an empty/None service_urls falls through to validate(), which
-        raises ValueError — so a parse never runs on an empty value.
-        """
-        if (not self.config_path and self.service_urls
-                and os.environ.get(_APPRISE_FIELDS["urls"]) is not None):
-            try:
-                self.service_urls = json.loads(self.service_urls)
-            # json errors can be hard to debug, add helpful log message
-            except json.decoder.JSONDecodeError as url_err:
-                log.error("Failed to parse env var for apprise urls. \
-                        Ensure proper json string format")
-                raise url_err
 
     def validate(self) -> None:
         """Validate apprise configuration (pure predicate over resolved state)."""

--- a/tests/unit/test_common_util.py
+++ b/tests/unit/test_common_util.py
@@ -1,8 +1,11 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring
 """Unit tests for common utility functions."""
-import pytest
+import json
 
-from bookstack_file_exporter.common.util import check_var
+import pytest
+from pydantic import ValidationError
+
+from bookstack_file_exporter.common.util import check_var, resolve_env_json
 
 
 def test_check_var_env_wins_over_default(monkeypatch):
@@ -37,13 +40,6 @@ def test_check_var_unset_no_default_raises(monkeypatch):
         check_var("MY_TEST_RAISES", "")
 
 
-def test_check_var_unset_list_default_returns_list(monkeypatch):
-    """Env var unset, list default → list returned as-is."""
-    monkeypatch.delenv("MY_TEST_LIST_DEFAULT", raising=False)
-    result = check_var("MY_TEST_LIST_DEFAULT", ["a", "b"], required=True)
-    assert result == ["a", "b"]
-
-
 def test_check_var_env_takes_precedence(monkeypatch):
     monkeypatch.setenv("MY_KEY", "from-env")
     assert check_var("MY_KEY", "from-config") == "from-env"
@@ -62,4 +58,44 @@ def test_check_var_required_missing_raises(monkeypatch):
 
 def test_check_var_optional_missing_returns_default(monkeypatch):
     monkeypatch.delenv("MY_KEY", raising=False)
-    assert check_var("MY_KEY", [], required=False) == []
+    assert check_var("MY_KEY", "", required=False) == ""
+
+
+class TestResolveEnvJson:
+    def test_env_json_parsed(self, monkeypatch):
+        monkeypatch.setenv("MY_URLS", json.dumps(["mailto://a", "mailto://b"]))
+        assert resolve_env_json("MY_URLS", list[str], []) == ["mailto://a", "mailto://b"]
+
+    def test_env_wins_over_default(self, monkeypatch):
+        monkeypatch.setenv("MY_URLS", json.dumps(["mailto://env"]))
+        assert resolve_env_json("MY_URLS", list[str], ["mailto://file"]) == ["mailto://env"]
+
+    def test_env_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("MY_URLS", raising=False)
+        assert resolve_env_json("MY_URLS", list[str], ["mailto://file"]) == ["mailto://file"]
+
+    def test_env_empty_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("MY_URLS", "")
+        assert resolve_env_json("MY_URLS", list[str], ["mailto://file"]) == ["mailto://file"]
+
+    def test_default_returned_unchanged(self, monkeypatch):
+        # helper is pure: it returns default_val as-is (no None->[] coercion;
+        # that now lives at the caller). See test_notifications for the []-guard.
+        monkeypatch.delenv("MY_URLS", raising=False)
+        assert resolve_env_json("MY_URLS", list[str], None) is None
+
+    def test_bad_json_raises(self, monkeypatch):
+        monkeypatch.setenv("MY_URLS", "{not valid json")
+        with pytest.raises(ValidationError):
+            resolve_env_json("MY_URLS", list[str], [])
+
+    def test_non_list_json_raises(self, monkeypatch):
+        # valid JSON but wrong shape: a bare str must not pass as list[str]
+        monkeypatch.setenv("MY_URLS", '"mailto://a"')
+        with pytest.raises(ValidationError):
+            resolve_env_json("MY_URLS", list[str], [])
+
+    def test_wrong_element_type_raises(self, monkeypatch):
+        monkeypatch.setenv("MY_URLS", json.dumps([1, 2]))
+        with pytest.raises(ValidationError):
+            resolve_env_json("MY_URLS", list[str], [])

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -3,6 +3,7 @@
 import json
 
 import pytest
+from pydantic import ValidationError
 
 from bookstack_file_exporter.config_helper import models
 from bookstack_file_exporter.config_helper.notifications import (
@@ -23,7 +24,7 @@ class TestServiceUrlResolution:
     def test_env_json_string_parsed_to_list_at_construction(self, monkeypatch):
         monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://a", "mailto://b"]))
         cfg = AppRiseNotifyConfig(_make_config())
-        # check_var pulls the raw env string; __init__ resolves it to a list
+        # __init__ resolves the raw env JSON string into a validated list
         assert cfg.service_urls == ["mailto://a", "mailto://b"]
 
     def test_config_file_urls_untouched_when_env_unset(self, monkeypatch):
@@ -31,26 +32,35 @@ class TestServiceUrlResolution:
         cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://from-file"]))
         assert cfg.service_urls == ["mailto://from-file"]
 
-    def test_config_path_skips_url_parse(self, monkeypatch):
-        # env set, but config_path present -> no JSON parse; service_urls stays
-        # the raw env string (check_var override) rather than raising on bad json
-        monkeypatch.setenv(_ENV_KEY, "not-json")
-        cfg = AppRiseNotifyConfig(_make_config(config_path="/etc/apprise.yml",
-                                               service_urls=["mailto://x"]))
-        assert cfg.service_urls == "not-json"
+    def test_none_config_urls_resolve_to_empty_list(self, monkeypatch):
+        # caller's `or []` keeps the []-not-None guarantee the helper dropped
+        monkeypatch.delenv(_ENV_KEY, raising=False)
+        cfg = AppRiseNotifyConfig(_make_config(service_urls=None))
+        assert cfg.service_urls == []
+
+    def test_env_parsed_even_with_config_path(self, monkeypatch):
+        # env is resolved unconditionally now; config_path no longer suppresses it
+        monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://x"]))
+        cfg = AppRiseNotifyConfig(_make_config(config_path="/etc/apprise.yml"))
+        assert cfg.service_urls == ["mailto://x"]
 
     def test_invalid_env_json_raises_at_construction(self, monkeypatch):
         monkeypatch.setenv(_ENV_KEY, "{not valid json")
-        with pytest.raises(json.decoder.JSONDecodeError):
+        with pytest.raises(ValidationError):
             AppRiseNotifyConfig(_make_config())
 
-    def test_empty_env_with_config_list_raises_typeerror(self, monkeypatch):
-        # fidelity edge: APPRISE_URLS="" is falsy so check_var returns the config
-        # list, but `os.environ.get(...) is not None` is still True -> json.loads
-        # runs on a list -> TypeError. Preserved verbatim from pre-refactor.
+    def test_non_list_env_json_raises_at_construction(self, monkeypatch):
+        # valid JSON but a bare str: must fail loud, not reach apprise as a str
+        monkeypatch.setenv(_ENV_KEY, '"mailto://a"')
+        with pytest.raises(ValidationError):
+            AppRiseNotifyConfig(_make_config())
+
+    def test_empty_env_falls_back_to_config_list(self, monkeypatch):
+        # APPRISE_URLS="" (set but empty) falls back to the config list instead
+        # of crashing with TypeError (the old double-env-probe bug).
         monkeypatch.setenv(_ENV_KEY, "")
-        with pytest.raises(TypeError):
-            AppRiseNotifyConfig(_make_config(service_urls=["mailto://x"]))
+        cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://x"]))
+        assert cfg.service_urls == ["mailto://x"]
 
 
 class TestValidate:


### PR DESCRIPTION
## Changes
- Split the dual-type `check_var` (`list[str] | str`) into a str-only `check_var` plus a new generic `resolve_env_json(env_key, target, default_val)` helper in `common/util.py`.
- `resolve_env_json` probes the env once, then parses **and type-validates** the JSON via pydantic `TypeAdapter(target).validate_json`. On failure it logs the env-var name and re-raises `pydantic.ValidationError`.
- `notifications.py` now resolves `service_urls` through `resolve_env_json(_APPRISE_FIELDS["urls"], list[str], config.service_urls or [])`; deletes `_resolve_service_urls` and drops the `os`/`json`/`logging` imports. `validate()` stays a pure predicate.

## Motivation
Two bugs on the apprise env path:

1. **Empty-env `TypeError`.** With `APPRISE_URLS=""` (set but empty) AND a config-file `service_urls` list, `notifications.py` re-read `os.environ` after `check_var` had already resolved env-vs-file. The second probe (`os.environ.get(...) is not None`) was True while `service_urls` was a list, so `json.loads` ran on a list → `TypeError`. A container/k8s env-templating footgun. Root cause was a double env-probe; the fix lets one helper own probe + parse.

2. **Validation gap.** The env-resolved `service_urls` lands on a plain attribute of `AppRiseNotifyConfig` (not a pydantic field), so pydantic's `list[str]` constraint — which only guards the YAML-parsed value — never saw env input. A plain `json.loads` let `APPRISE_URLS='"foo"'` hand a bare str to apprise. `TypeAdapter(list[str])` now rejects non-list / wrong-element-type env values up front.

## Behavior change
On malformed / non-list / wrong-element `APPRISE_URLS`, construction now raises `pydantic.ValidationError` (previously: `TypeError` on the empty-env edge, or a silently-wrong bare str reaching apprise). Valid configs are unaffected. The caller's `or []` preserves the `[]`-not-`None` guarantee the generic helper no longer coerces.

## Test plan
- `uv run pytest` → 406 passed.
- `task lint` (pylint) → unchanged; the two changed source files rate 10.00/10.
- New/updated unit tests cover: empty-env fallback (no `TypeError`), env-over-file precedence, malformed JSON / bare-str / wrong-element → `ValidationError`, and the caller's `None → []` guard.

## In-depth
`resolve_env_json` is the generic, in-stack (pydantic already a direct dep) equivalent of Go's unmarshal-into-target. Full `pydantic-settings` migration remains deferred — the project has 47 nested config fields but only 5 flat env vars (all secrets), and history shows new config always lands in YAML, not env. Tracked in the env-config plan doc.
