### PR TITLE
fix: raise clear error on empty config file

### DIFF
--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -17,10 +17,13 @@ def load_yaml_config(path: str) -> dict:
         raise FileNotFoundError(path)
     with open(path, encoding="utf-8") as yaml_stream:
         try:
-            return yaml.safe_load(yaml_stream)
+            data = yaml.safe_load(yaml_stream)
         except yaml.YAMLError:
             log.error("Failed to load yaml configuration file")
             raise
+    if data is None:                       # empty / whitespace-only file
+        raise ValueError(f"Config file is empty or has no YAML content: {path}")
+    return data
 
 
 def check_legacy_modify_markdown(raw: dict) -> None:

--- a/tests/unit/test_config_helper.py
+++ b/tests/unit/test_config_helper.py
@@ -49,6 +49,16 @@ def test_load_yaml_config_returns_parsed_dict(tmp_path):
     assert result["formats"] == ["markdown"]
 
 
+@pytest.mark.parametrize("content", ["", "   \n  \n"])
+def test_load_yaml_config_raises_value_error_on_empty_file(tmp_path, content):
+    """An empty / whitespace-only config yields a clear ValueError, not AttributeError."""
+    empty = tmp_path / "empty.yml"
+    empty.write_text(content, encoding="utf-8")
+
+    with pytest.raises(ValueError, match="empty"):
+        load_yaml_config(str(empty))
+
+
 def test_load_yaml_config_raises_yaml_error_on_invalid_yaml(tmp_path):
     """load_yaml_config must propagate yaml.YAMLError for malformed YAML."""
     bad_yaml = tmp_path / "bad.yml"


### PR DESCRIPTION
## Changes
- `load_yaml_config` (`config_helper.py`) now raises a clear `ValueError` when the config file is empty or whitespace-only, instead of returning `None`.
- Added a parametrized regression test (`tests/unit/test_config_helper.py`) covering empty `""` and whitespace-only inputs.

The existing `FileNotFoundError` and `yaml.YAMLError` paths are unchanged.

## Motivation
An empty / whitespace-only config made `yaml.safe_load` return `None`, which flowed downstream into `check_legacy_modify_markdown` → `raw.get("assets", {})` → an opaque `AttributeError` traceback. It still exited non-zero, but gave the user no hint that their config was empty. The guard makes `load_yaml_config` honor its `-> dict` contract and fail with an actionable message.

## Test plan
- `uv run pytest tests/unit/test_config_helper.py -k empty -v` — confirmed RED (DID NOT RAISE) before the fix, then green after.
- `uv run pytest -q` — 408 passed.
- `uv run pylint bookstack_file_exporter/config_helper/config_helper.py` — 10.00/10 (no change from baseline).
