### PR TITLE
refactor: inject archiver construction into Archiver

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -33,13 +33,15 @@ class Archiver:
         Archiver instance with attributes that are accessible
         for use for handling bookstack exports and remote uploads.
     """
-    def __init__(self, config: ConfigNode, http_client: HttpHelper):
+    def __init__(self, config: ConfigNode, http_client: HttpHelper,
+                 node_archiver=None, minio_archiver_cls=MinioArchiver):
         self.config = config
         # for convenience
         self.base_dir = self._level_base_dir(config.base_dir_name,
                                              config.user_inputs.export_level)
         self.archive_dir = self._generate_root_folder(self.base_dir)
-        self._archiver: NodeArchiver = self._build_archiver(http_client)
+        self._archiver: NodeArchiver = node_archiver or self._build_archiver(http_client)
+        self._minio_archiver_cls = minio_archiver_cls
 
     def _build_archiver(self, http_client: HttpHelper) -> NodeArchiver:
         """Return the appropriate archiver based on the configured export level."""
@@ -105,8 +107,6 @@ class Archiver:
         """for each target, do their respective tasks; return list of remote dest strings"""
         if not self.config.object_storage_config:
             return []
-        # dict built per-call so instance-level monkey-patching of handlers
-        # propagates during tests (class-level dict captures pre-patch values)
         handlers = {
             "minio": self._archive_minio,
             "s3": self._archive_s3,
@@ -120,8 +120,8 @@ class Archiver:
         return dests
 
     def _archive_minio(self, obj_config: StorageProviderConfig) -> str:
-        minio_archiver = MinioArchiver(obj_config.access_key,
-                                       obj_config.secret_key, obj_config.config)
+        minio_archiver = self._minio_archiver_cls(obj_config.access_key,
+                                                  obj_config.secret_key, obj_config.config)
         dest = minio_archiver.upload_backup(self._archiver.archive_file)
         minio_archiver.clean_up(self._archiver.file_extension_map['tgz'])
         return dest

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -11,22 +11,17 @@ import pytest
 
 from bookstack_file_exporter.archiver.archiver import Archiver
 from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
+from bookstack_file_exporter.archiver.node_archiver import (
+    BookArchiver,
+    ChapterArchiver,
+    PageArchiver,
+)
 from tests.fixtures.mock_config import make_mock_config as _make_config
 
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
-
-@pytest.fixture
-def patched_page_archiver(monkeypatch):
-    mock = MagicMock()
-    monkeypatch.setattr(
-        "bookstack_file_exporter.archiver.archiver.PageArchiver",
-        MagicMock(return_value=mock),
-    )
-    return mock
-
 
 @pytest.fixture
 def mock_config():
@@ -40,8 +35,8 @@ def mock_config():
 
 
 @pytest.fixture
-def archiver_instance(patched_page_archiver, mock_config, mock_http_client):
-    return Archiver(mock_config, mock_http_client)
+def archiver_instance(mock_config, mock_http_client):
+    return Archiver(mock_config, mock_http_client, node_archiver=MagicMock())
 
 
 # ---------------------------------------------------------------------------
@@ -72,10 +67,9 @@ class TestLevelBaseDir:
     def test_non_pages_suffixed(self, level):
         assert Archiver._level_base_dir("bkps", level) == f"bkps_{level}"
 
-    def test_books_level_flows_into_archive_dir(self, patched_page_archiver,
-                                                mock_config, mock_http_client):
+    def test_books_level_flows_into_archive_dir(self, mock_config, mock_http_client):
         mock_config.user_inputs.export_level = "books"
-        archiver = Archiver(mock_config, mock_http_client)
+        archiver = Archiver(mock_config, mock_http_client, node_archiver=MagicMock())
         assert archiver.base_dir == "bkps_books"
         assert archiver.archive_dir.startswith("bkps_books_")
 
@@ -95,6 +89,41 @@ def test_generate_root_folder_format(monkeypatch, base_name):
 def test_archive_dir_has_timestamp_suffix(archiver_instance):
     """Archiver.archive_dir must end with _YYYY-MM-DD_HH-MM-SS."""
     assert re.search(r"_\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}$", archiver_instance.archive_dir)
+
+
+# ---------------------------------------------------------------------------
+# _build_archiver — level → type selection
+# ---------------------------------------------------------------------------
+
+class TestBuildArchiver:
+    """_build_archiver returns the correct NodeArchiver subtype for each export level."""
+
+    def test_books_level_returns_book_archiver(self, mock_http_client):
+        config = _make_config(export_level="books", formats=["markdown"])
+        config.base_dir_name = "bkps"
+        config.user_inputs.keep_last = 0
+        config.user_inputs.output_path = ""
+        config.object_storage_config = {}
+        archiver = Archiver(config, mock_http_client)
+        assert isinstance(archiver._archiver, BookArchiver)
+
+    def test_chapters_level_returns_chapter_archiver(self, mock_http_client):
+        config = _make_config(export_level="chapters", formats=["markdown"])
+        config.base_dir_name = "bkps"
+        config.user_inputs.keep_last = 0
+        config.user_inputs.output_path = ""
+        config.object_storage_config = {}
+        archiver = Archiver(config, mock_http_client)
+        assert isinstance(archiver._archiver, ChapterArchiver)
+
+    def test_pages_level_returns_page_archiver(self, mock_http_client):
+        config = _make_config(export_level="pages", formats=["markdown"])
+        config.base_dir_name = "bkps"
+        config.user_inputs.keep_last = 0
+        config.user_inputs.output_path = ""
+        config.object_storage_config = {}
+        archiver = Archiver(config, mock_http_client)
+        assert isinstance(archiver._archiver, PageArchiver)
 
 
 # ---------------------------------------------------------------------------
@@ -319,34 +348,43 @@ def test_create_export_dir_permission_error_logs_warning(
 # archive_remote
 # ---------------------------------------------------------------------------
 
-def test_archive_remote_dispatches_minio(monkeypatch, archiver_instance, mock_config):
-    """object_storage_config has 'minio' key → _archive_minio invoked."""
-    minio_mock = MagicMock()
-    mock_config.object_storage_config = {"minio": minio_mock}
-    minio_handler = MagicMock()
-    monkeypatch.setattr(archiver_instance, "_archive_minio", minio_handler)
+def test_archive_remote_dispatches_minio(archiver_instance, mock_config):
+    """object_storage_config has 'minio' key → MinioArchiver constructed via injected class."""
+    obj_config = MagicMock()
+    obj_config.access_key = "mykey"
+    obj_config.secret_key = "mysecret"
+    obj_config.config = MagicMock()
+    mock_config.object_storage_config = {"minio": obj_config}
+
+    fake_minio_instance = MagicMock()
+    fake_minio_instance.upload_backup.return_value = "bucket/path/archive.tgz"
+    fake_minio_cls = MagicMock(return_value=fake_minio_instance)
+
+    archiver_instance._minio_archiver_cls = fake_minio_cls
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
     archiver_instance.archive_remote()
-    minio_handler.assert_called_once_with(minio_mock)
+
+    fake_minio_cls.assert_called_once_with(
+        obj_config.access_key, obj_config.secret_key, obj_config.config
+    )
 
 
-def test_archive_remote_raises_on_unknown_storage_type(
-    patched_page_archiver, mock_config, mock_http_client
-):
+def test_archive_remote_raises_on_unknown_storage_type(mock_config, mock_http_client):
     """object_storage_config has unknown key → ValueError raised."""
     mock_config.object_storage_config = {"gcs": MagicMock()}
-    archiver = Archiver(mock_config, mock_http_client)
+    archiver = Archiver(mock_config, mock_http_client, node_archiver=MagicMock())
     with pytest.raises(ValueError, match="unsupported remote storage type"):
         archiver.archive_remote()
 
 
-def test_archive_remote_s3_raises_not_implemented(
-    patched_page_archiver, mock_config, mock_http_client
-):
+def test_archive_remote_s3_raises_not_implemented(mock_http_client):
     """archive_remote routes 's3' to _archive_s3 which is intentionally not implemented"""
     config = MagicMock()
     config.object_storage_config = {"s3": MagicMock()}
     config.base_dir_name = "bkps"
-    archiver = Archiver(config, MagicMock())
+    archiver = Archiver(config, mock_http_client, node_archiver=MagicMock())
     with pytest.raises(NotImplementedError, match="S3 remote storage"):
         archiver.archive_remote()
 
@@ -437,17 +475,28 @@ def test_archive_remote_returns_empty_list_when_no_config(archiver_instance, moc
     assert result == []
 
 
-def test_archive_remote_returns_minio_dest_list(monkeypatch, archiver_instance, mock_config):
+def test_archive_remote_returns_minio_dest_list(archiver_instance, mock_config):
     """Minio handler called → returned dest string collected in list."""
-    minio_config = MagicMock()
-    mock_config.object_storage_config = {"minio": minio_config}
+    obj_config = MagicMock()
+    obj_config.access_key = "k"
+    obj_config.secret_key = "s"
+    obj_config.config = MagicMock()
+    mock_config.object_storage_config = {"minio": obj_config}
     expected_dest = "my-bucket/backups/export.tgz"
-    monkeypatch.setattr(archiver_instance, "_archive_minio", MagicMock(return_value=expected_dest))
+
+    fake_minio_instance = MagicMock()
+    fake_minio_instance.upload_backup.return_value = expected_dest
+    fake_minio_cls = MagicMock(return_value=fake_minio_instance)
+
+    archiver_instance._minio_archiver_cls = fake_minio_cls
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
     result = archiver_instance.archive_remote()
     assert result == [expected_dest]
 
 
-def test_archive_minio_returns_dest_string(monkeypatch, archiver_instance):
+def test_archive_minio_returns_dest_string(archiver_instance):
     """_archive_minio returns the bucket/path dest from upload_backup."""
     obj_config = MagicMock()
     obj_config.access_key = "key"
@@ -457,15 +506,17 @@ def test_archive_minio_returns_dest_string(monkeypatch, archiver_instance):
     expected_dest = "test-bucket/backups/archive.tgz"
     mock_minio = MagicMock()
     mock_minio.upload_backup.return_value = expected_dest
-    monkeypatch.setattr(
-        "bookstack_file_exporter.archiver.archiver.MinioArchiver",
-        MagicMock(return_value=mock_minio),
-    )
+
+    fake_minio_cls = MagicMock(return_value=mock_minio)
+    archiver_instance._minio_archiver_cls = fake_minio_cls
     archiver_instance._archiver.archive_file = "/local/archive.tgz"
     archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
 
     dest = archiver_instance._archive_minio(obj_config)
     assert dest == expected_dest
+    fake_minio_cls.assert_called_once_with(
+        obj_config.access_key, obj_config.secret_key, obj_config.config
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

Add two optional, test-only construction seams to `Archiver`:

- `node_archiver=None` — inject a pre-built node archiver instance; defaults to `_build_archiver(http_client)` (the existing per-export-level construction).
- `minio_archiver_cls=MinioArchiver` — inject the minio archiver **class**; `_archive_minio` now constructs via `self._minio_archiver_cls(...)`. A class (not an instance) is injected because `MinioArchiver.__init__` does network I/O (`_validate_bucket`) and runs only when minio is configured — building it eagerly at `Archiver.__init__` would force that validation on every run, including non-remote ones.

Production callers are unchanged: `Archiver(config, http_client)` builds exactly as before. No runtime extension/registry/backend-swap API is introduced — these are optional test seams only.

`archive_remote` no longer needs the per-call handler-dict rebuild justification; its workaround comment is removed (behavior identical: empty config → `[]`, unknown key → `ValueError`, s3 → `NotImplementedError`).

Tests (`tests/unit/test_archiver.py`):
- Remove the `patched_page_archiver` module-symbol monkeypatch fixture; `archiver_instance` injects a `node_archiver` double instead.
- Retire the `_archive_minio` instance monkeypatch. The dispatch test now asserts `MinioArchiver` is constructed **via the injected class** with the correct `StorageProviderConfig` (access/secret/config), not merely that a handler was called.
- Add `TestBuildArchiver`: a direct level→type test covering `books → BookArchiver`, `chapters → ChapterArchiver`, `pages → PageArchiver` via the production construction path.

## Motivation

`Archiver` hard-constructed its node archivers and `MinioArchiver`, so tests could only inject doubles by monkeypatching module symbols — and only the `pages` level was covered that way. The per-call handler-dict rebuild existed solely so instance-level monkeypatching would propagate in tests. Injecting the construction seams retires both workarounds and closes the books/chapters construction coverage gap.

This is part of the sequenced modularity/testability refactor (item R1; design resolved in an earlier brainstorm — test seam only, scope deliberately excludes any runtime backend-swap API).

## Test plan

- `uv run pytest` → 411 passed.
- `uv run pytest tests/unit/test_archiver.py` → 44 passed.
- `uv run pylint bookstack_file_exporter` → 9.99/10 (unchanged baseline; sole message is the pre-existing `run.py` W0718).

## In-depth

- `node_archiver or self._build_archiver(...)` uses `or`-coalescing per the resolved design; safe because the only injected value is a truthy `MagicMock` and production passes `None`.
- Minio uses class injection while the node archiver uses instance injection on purpose: node-archiver args are known at `__init__` (build once), whereas minio construction must stay lazy, conditional, and side-effectful.
