### PR TITLE
refactor: inject AssetArchiver into NodeArchiver

### DIFF
--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -48,7 +48,7 @@ class NodeArchiver:
     """
     def __init__(self, archive_dir: str, api_urls: dict[str, str],  # pylint: disable=too-many-arguments,too-many-positional-arguments
                  export_formats: list[str], http_client: HttpHelper,
-                 export_meta: bool, asset_config=None) -> None:
+                 export_meta: bool, asset_config=None, asset_archiver=None) -> None:
         self.api_urls = api_urls
         self.export_formats = export_formats
         self.http_client = http_client
@@ -61,7 +61,9 @@ class NodeArchiver:
         self.archive_base_path = archive_dir.split("/")[-1]
         # asset handling (shared by page/book/chapter); None => disabled
         self.asset_config = asset_config
-        self.asset_archiver = AssetArchiver(api_urls, http_client) if asset_config else None
+        self.asset_archiver = asset_archiver if asset_archiver is not None else (
+            AssetArchiver(api_urls, http_client) if asset_config else None
+        )
         self.modify_links: bool = self._check_links_modify()
 
     @property
@@ -299,7 +301,8 @@ class PageArchiver(NodeArchiver):
     Returns:
         :PageArchiver: instance with methods to help collect page content from a Bookstack instance.
     """
-    def __init__(self, archive_dir: str, config: ConfigNode, http_client: HttpHelper) -> None:
+    def __init__(self, archive_dir: str, config: ConfigNode, http_client: HttpHelper,
+                 *, asset_archiver=None) -> None:
         super().__init__(
             archive_dir=archive_dir,
             api_urls=config.urls,
@@ -307,6 +310,7 @@ class PageArchiver(NodeArchiver):
             http_client=http_client,
             export_meta=config.user_inputs.assets.export_meta,
             asset_config=config.user_inputs.assets,
+            asset_archiver=asset_archiver,
         )
 
     def archive(self, page_nodes: dict[int, Node]):

--- a/tests/unit/test_asset_archiver_modify_html.py
+++ b/tests/unit/test_asset_archiver_modify_html.py
@@ -24,45 +24,41 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
     test scaffolding stub — PageArchiver tests intentionally cover a single entry point.
     """
 
-    def _make_archiver(self, tmp_path, monkeypatch, **config_kwargs):
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+    def _make_archiver(self, tmp_path, **config_kwargs):
         config = make_mock_config(**config_kwargs)
         archive_dir = str(tmp_path / "bookstack-test")
-        return PageArchiver(archive_dir, config, MagicMock())
+        return PageArchiver(archive_dir, config, MagicMock(), asset_archiver=MagicMock())
 
-    def test_check_links_modify_true_for_html_format(self, tmp_path, monkeypatch):
+    def test_check_links_modify_true_for_html_format(self, tmp_path):
         archiver = self._make_archiver(
-            tmp_path, monkeypatch,
+            tmp_path,
             formats=["html"],
             modify_links=True,
             export_images=True,
         )
         assert archiver.modify_links is True
 
-    def test_check_links_modify_true_for_markdown_format(self, tmp_path, monkeypatch):
+    def test_check_links_modify_true_for_markdown_format(self, tmp_path):
         archiver = self._make_archiver(
-            tmp_path, monkeypatch,
+            tmp_path,
             formats=["markdown"],
             modify_links=True,
             export_images=True,
         )
         assert archiver.modify_links is True
 
-    def test_check_links_modify_true_for_both_formats(self, tmp_path, monkeypatch):
+    def test_check_links_modify_true_for_both_formats(self, tmp_path):
         archiver = self._make_archiver(
-            tmp_path, monkeypatch,
+            tmp_path,
             formats=["markdown", "html"],
             modify_links=True,
             export_images=True,
         )
         assert archiver.modify_links is True
 
-    def test_check_links_modify_false_when_no_assets(self, tmp_path, monkeypatch):
+    def test_check_links_modify_false_when_no_assets(self, tmp_path):
         archiver = self._make_archiver(
-            tmp_path, monkeypatch,
+            tmp_path,
             formats=["html"],
             modify_links=True,
             export_images=False,
@@ -70,9 +66,9 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
         )
         assert archiver.modify_links is False
 
-    def test_check_links_modify_false_when_format_not_rewritable(self, tmp_path, monkeypatch):
+    def test_check_links_modify_false_when_format_not_rewritable(self, tmp_path):
         archiver = self._make_archiver(
-            tmp_path, monkeypatch,
+            tmp_path,
             formats=["pdf"],
             modify_links=True,
             export_images=True,
@@ -80,12 +76,12 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
         assert archiver.modify_links is False
 
     def test_warning_when_modify_links_true_but_no_rewritable_format(
-        self, tmp_path, monkeypatch, caplog
+        self, tmp_path, caplog
     ):
         logger_name = "bookstack_file_exporter.archiver.node_archiver"
         with caplog.at_level(logging.WARNING, logger=logger_name):
             self._make_archiver(
-                tmp_path, monkeypatch,
+                tmp_path,
                 formats=["pdf"],
                 modify_links=True,
                 export_images=True,
@@ -94,24 +90,17 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
         assert any("MODIFY_LINKS" in m or "rewritable" in m.lower() for m in warning_msgs)
 
     def test_archive_dispatches_html_branch(
-        self, tmp_path, monkeypatch, build_node
+        self, tmp_path, build_node
     ):
         """archive should call _modify_html when format='html' and modify_links=True."""
-        mock_asset_archiver_class = MagicMock()
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            mock_asset_archiver_class,
-        )
+        mock_asset = MagicMock()
         config = make_mock_config(
             formats=["html"],
             modify_links=True,
             export_images=True,
         )
         archive_dir = str(tmp_path / "bookstack-test")
-        archiver = PageArchiver(archive_dir, config, MagicMock())
-
-        mock_asset = MagicMock()
-        archiver.asset_archiver = mock_asset
+        archiver = PageArchiver(archive_dir, config, MagicMock(), asset_archiver=mock_asset)
 
         # Set up mock asset nodes
         mock_image_node = MagicMock()
@@ -137,19 +126,13 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
         mock_modify_html.assert_called_once()
 
     def test_modify_html_short_circuits_when_modify_links_false(
-        self, tmp_path, monkeypatch
+        self, tmp_path
     ):
         """_modify_html should return page_data unchanged when modify_links is False."""
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+        mock_asset = MagicMock()
         config = make_mock_config(formats=["html"], modify_links=False)
         archive_dir = str(tmp_path / "bookstack-test")
-        archiver = PageArchiver(archive_dir, config, MagicMock())
-
-        mock_asset = MagicMock()
-        archiver.asset_archiver = mock_asset
+        archiver = PageArchiver(archive_dir, config, MagicMock(), asset_archiver=mock_asset)
 
         page_data = b"<html><body>test</body></html>"
         mock_nodes = [MagicMock()]
@@ -160,24 +143,17 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
         mock_asset.update_asset_links_html.assert_not_called()
 
     def test_failed_assets_filtered_from_html_rewrite(
-        self, tmp_path, monkeypatch, build_node
+        self, tmp_path, build_node
     ):
         """Failed assets should be excluded from both md and html rewrite paths."""
-        mock_asset_archiver_class = MagicMock()
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            mock_asset_archiver_class,
-        )
+        mock_asset = MagicMock()
         config = make_mock_config(
             formats=["html"],
             modify_links=True,
             export_images=True,
         )
         archive_dir = str(tmp_path / "bookstack-test")
-        archiver = PageArchiver(archive_dir, config, MagicMock())
-
-        mock_asset = MagicMock()
-        archiver.asset_archiver = mock_asset
+        archiver = PageArchiver(archive_dir, config, MagicMock(), asset_archiver=mock_asset)
 
         mock_image_node = MagicMock()
         mock_image_node.id_ = 42
@@ -206,24 +182,17 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
         )
 
     def test_partially_failed_assets_excluded_from_html_rewrite(  # pylint: disable=too-many-locals
-        self, tmp_path, monkeypatch, build_node
+        self, tmp_path, build_node
     ):
         """When some assets fail, only successful nodes are passed to update_asset_links_html."""
-        mock_asset_archiver_class = MagicMock()
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            mock_asset_archiver_class,
-        )
+        mock_asset = MagicMock()
         config = make_mock_config(
             formats=["html"],
             modify_links=True,
             export_images=True,
         )
         archive_dir = str(tmp_path / "bookstack-test")
-        archiver = PageArchiver(archive_dir, config, MagicMock())
-
-        mock_asset = MagicMock()
-        archiver.asset_archiver = mock_asset
+        archiver = PageArchiver(archive_dir, config, MagicMock(), asset_archiver=mock_asset)
 
         good_node = MagicMock(spec=ImageNode)
         good_node.id_ = 10

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from requests.exceptions import HTTPError
 
-from bookstack_file_exporter.archiver.node_archiver import PageArchiver
+from bookstack_file_exporter.archiver.node_archiver import NodeArchiver, PageArchiver
 from bookstack_file_exporter.exporter.node import Node
 
 
@@ -23,16 +23,12 @@ def _make_page_node(build_node, page_id: int, slug: str, parent: Node) -> Node:
 
 
 @pytest.fixture
-def page_archiver(tmp_path, monkeypatch):
+def page_archiver(tmp_path):
     """Construct a PageArchiver with all external collaborators mocked."""
-    monkeypatch.setattr(
-        "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-        MagicMock(),
-    )
     config = _make_config()
     http_client = MagicMock()
     archive_dir = str(tmp_path / "bookstack-20260514")
-    return PageArchiver(archive_dir, config, http_client)
+    return PageArchiver(archive_dir, config, http_client, asset_archiver=MagicMock())
 
 
 # ---------------------------------------------------------------------------
@@ -40,41 +36,25 @@ def page_archiver(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 class TestConstruction:
-    def test_archive_file_ends_with_tgz(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+    def test_archive_file_ends_with_tgz(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(), asset_archiver=MagicMock())
         assert archiver.archive_file == f"{archive_dir}.tgz"
 
-    def test_tar_file_ends_with_tar(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+    def test_tar_file_ends_with_tar(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(), asset_archiver=MagicMock())
         assert archiver.tar_file == f"{archive_dir}.tar"
 
-    def test_archive_base_path_is_last_segment(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+    def test_archive_base_path_is_last_segment(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(), asset_archiver=MagicMock())
         assert archiver.archive_base_path == "bookstack-20260514"
 
-    def test_http_client_stored(self, tmp_path, monkeypatch):
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+    def test_http_client_stored(self, tmp_path):
         http_client = MagicMock()
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), http_client)
+        archiver = PageArchiver(archive_dir, _make_config(), http_client, asset_archiver=MagicMock())
         assert archiver.http_client is http_client
 
 
@@ -162,17 +142,14 @@ class TestWriteData:  # pylint: disable=too-few-public-methods  # test scaffoldi
 # ---------------------------------------------------------------------------
 
 class TestArchivePages:
-    def test_each_page_node_written_once_per_format(self, tmp_path, monkeypatch, build_node):
+    def test_each_page_node_written_once_per_format(self, tmp_path, build_node):
         """archive should write one file per page per format."""
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+        mock_asset = MagicMock()
         config = _make_config(formats=["markdown"], export_images=False,
                                export_attachments=False, export_meta=False)
         http_client = MagicMock()
         archive_dir = str(tmp_path / "bookstack-test")
-        archiver = PageArchiver(archive_dir, config, http_client)
+        archiver = PageArchiver(archive_dir, config, http_client, asset_archiver=mock_asset)
 
         # Make asset_archiver return empty dicts (no images / attachments)
         archiver.asset_archiver.get_asset_nodes.return_value = {}
@@ -195,17 +172,14 @@ class TestArchivePages:
         # 2 pages × 1 format = 2 write_tar calls
         assert mock_write_tar.call_count == 2
 
-    def test_archive_respects_multiple_formats(self, tmp_path, monkeypatch, build_node):
+    def test_archive_respects_multiple_formats(self, tmp_path, build_node):
         """archive should call write_tar once per page per format."""
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+        mock_asset = MagicMock()
         config = _make_config(formats=["markdown", "html"], export_images=False,
                                export_attachments=False, export_meta=False)
         http_client = MagicMock()
         archive_dir = str(tmp_path / "bookstack-multi")
-        archiver = PageArchiver(archive_dir, config, http_client)
+        archiver = PageArchiver(archive_dir, config, http_client, asset_archiver=mock_asset)
         archiver.asset_archiver.get_asset_nodes.return_value = {}
 
         parent_node = build_node(id=1, name="a-book", slug="a-book")
@@ -223,15 +197,13 @@ class TestArchivePages:
         # 1 page × 2 formats = 2 write_tar calls
         assert mock_write_tar.call_count == 2
 
-    def test_failed_page_format_skipped_run_continues(self, tmp_path, monkeypatch, build_node):
+    def test_failed_page_format_skipped_run_continues(self, tmp_path, build_node):
         """A 403/404 on one page-format export is skipped, not fatal; others still written."""
-        monkeypatch.setattr(
-            "bookstack_file_exporter.archiver.node_archiver.AssetArchiver",
-            MagicMock(),
-        )
+        mock_asset = MagicMock()
         config = _make_config(formats=["markdown"], export_images=False,
                               export_attachments=False, export_meta=False)
-        archiver = PageArchiver(str(tmp_path / "bookstack-skip"), config, MagicMock())
+        archiver = PageArchiver(str(tmp_path / "bookstack-skip"), config, MagicMock(),
+                                asset_archiver=mock_asset)
         archiver.asset_archiver.get_asset_nodes.return_value = {}
 
         parent_node = build_node(id=1, name="a-book", slug="a-book")
@@ -262,3 +234,48 @@ class TestArchivePages:
 def test_page_archiver_has_no_verify_ssl_property():
     """verify_ssl was broken (read nonexistent Assets field); confirm it is gone."""
     assert not hasattr(PageArchiver, "verify_ssl")
+
+
+# ---------------------------------------------------------------------------
+# 8. R8: asset_archiver injection seam
+# ---------------------------------------------------------------------------
+
+class TestAssetArchiverInjection:
+    """Constructor-injected asset_archiver double is stored as self.asset_archiver."""
+
+    def test_injected_double_is_stored(self, tmp_path):
+        """When asset_archiver= is supplied, NodeArchiver stores it without constructing a real one."""
+        double = MagicMock()
+        config = _make_config(export_images=True)
+        archive_dir = str(tmp_path / "bookstack-r8")
+        archiver = PageArchiver(archive_dir, config, MagicMock(), asset_archiver=double)
+        assert archiver.asset_archiver is double
+
+    def test_no_injection_no_asset_config_is_none(self, tmp_path):
+        """When asset_archiver= not supplied and asset_config=None, asset_archiver is None."""
+        archive_dir = str(tmp_path / "bookstack-r8-none")
+        # Direct NodeArchiver construction: asset_config=None => no AssetArchiver built
+        archiver = NodeArchiver(
+            archive_dir=archive_dir,
+            api_urls={"images": "https://x", "attachments": "https://y"},
+            export_formats=["markdown"],
+            http_client=MagicMock(),
+            export_meta=False,
+            asset_config=None,
+        )
+        assert archiver.asset_archiver is None
+
+    def test_injected_double_overrides_real_construction(self, tmp_path):
+        """When asset_archiver= injected and asset_config is truthy, the injected double wins."""
+        double = MagicMock()
+        archive_dir = str(tmp_path / "bookstack-r8-override")
+        archiver = NodeArchiver(
+            archive_dir=archive_dir,
+            api_urls={"images": "https://x", "attachments": "https://y"},
+            export_formats=["markdown"],
+            http_client=MagicMock(),
+            export_meta=False,
+            asset_config=MagicMock(),  # truthy: without injection, would build real AssetArchiver
+            asset_archiver=double,
+        )
+        assert archiver.asset_archiver is double


### PR DESCRIPTION
## Changes

Add an optional, test-only construction seam to `NodeArchiver`:

- `asset_archiver=None` — inject a pre-built `AssetArchiver` instance. Defaults to the existing inline construction: `AssetArchiver(api_urls, http_client)` when `asset_config` is set, else `None` (asset handling disabled). Selection uses an `is not None` sentinel so a caller-supplied double is honored even if it were falsy.
- `PageArchiver` overrides `__init__` with a `config`-based signature; it now takes a keyword-only `asset_archiver` and forwards it to `super().__init__(...)`. `BookArchiver`/`ChapterArchiver` don't override `__init__`, so they inherit the seam directly.

Production callers are unchanged: `NodeArchiver(...)`/`PageArchiver(archive_dir, config, http_client)` build exactly as before. `AssetArchiver.__init__` does no I/O (stores urls/http_client, builds a dispatch map), so instance injection is safe — no laziness needed, unlike R1's minio class seam.

Tests:
- Retire 13 module-symbol monkeypatches (`monkeypatch.setattr("...node_archiver.AssetArchiver", ...)`) across `test_page_archiver.py` (8) and `test_asset_archiver_modify_html.py` (5); inject `asset_archiver=MagicMock()` via the constructor instead.
- Add `TestAssetArchiverInjection`: injected double is stored, overrides real construction, and `None` is preserved when no asset config.
- The real-`AssetArchiver` E2E (`TestE2eHtmlRewrite.test_html_image_url_rewritten_to_local_path`) is left unchanged.

## Motivation

`NodeArchiver` hard-constructed `AssetArchiver` inline, so tests could only substitute a double by monkeypatching the module symbol. Injecting the instance retires that workaround and matches the R1 seam pattern.

Part of the sequenced modularity/testability refactor (item R8; reuses R1's injection idiom — test seam only, no runtime backend-swap API).

## Test plan

- `uv run pytest` → 414 passed.
- `uv run pytest tests/unit/test_page_archiver.py tests/unit/test_asset_archiver_modify_html.py` → 39 passed.
- `uv run pylint bookstack_file_exporter` → 9.99/10 (unchanged baseline; sole message is the pre-existing `run.py` W0718).

## In-depth

- Instance injection (vs R1's minio class injection) is the right call because `AssetArchiver.__init__` is side-effect-free — there's nothing to keep lazy or conditional.
- Sentinel chosen as `asset_archiver if asset_archiver is not None else (...)` rather than `or`-coalescing: the `or` form keys off truthiness and would silently drop a falsy injected double. No current caller injects a falsy archiver, so this is correctness-on-paper, but it's the precise sentinel. R1's twin line (`node_archiver or ...`) is queued to match in the R9 cleanup batch rather than churning a standalone PR on merged code.
