### PR TITLE
refactor: collapse PageArchiver into NodeArchiver driver (R5)

### DIFF
--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -13,8 +13,6 @@ _META_FILE_SUFFIX = "_meta.json"
 _TAR_SUFFIX = ".tar"
 _TAR_GZ_SUFFIX = ".tgz"
 
-_EXPORT_API_PATH = "export"
-
 _FILE_EXTENSION_MAP = {
     "markdown": ".md",
     "html": ".html",
@@ -152,17 +150,29 @@ class NodeArchiver:
     def _get_node_data(self, url: str) -> bytes:
         return archiver_util.get_byte_response(url=url, http_client=self.http_client)
 
+    def _asset_page_map(self, node: Node) -> dict[int, str]:
+        """Map {page_id: page_name} of pages whose assets attach to this node."""
+        return self._descendant_page_names(node)
+
+    def _asset_parent_path(self, node: Node) -> str:
+        """Directory (relative to archive_base_path) under which page assets are written."""
+        return node.file_path
+
+    def _node_output_path(self, node: Node) -> str:
+        """Path fragment (relative to archive_base_path, no extension) for export/meta files."""
+        return f"{node.file_path}/{node.name}"
+
     def _archive_node(self, node: Node, export_format: str, data: bytes):
         file_name = (
             f"{self.archive_base_path}/"
-            f"{node.file_path}/{node.name}{_FILE_EXTENSION_MAP[export_format]}"
+            f"{self._node_output_path(node)}{_FILE_EXTENSION_MAP[export_format]}"
         )
         self.write_data(file_name, data)
 
     def _archive_node_meta(self, node: Node, meta_data: dict):
         meta_file_name = (
             f"{self.archive_base_path}/"
-            f"{node.file_path}/{node.name}{_FILE_EXTENSION_MAP['meta']}"
+            f"{self._node_output_path(node)}{_FILE_EXTENSION_MAP['meta']}"
         )
         bytes_meta = archiver_util.get_json_bytes(meta_data)
         self.write_data(meta_file_name, bytes_meta)
@@ -220,14 +230,15 @@ class NodeArchiver:
         """Download this node's descendant-page assets; return survivors grouped per page+type."""
         if not (image_map or attachment_map):
             return {}
-        page_names = self._descendant_page_names(node)
+        page_names = self._asset_page_map(node)
         grouped = {"images": {}, "attachments": {}}
         for asset_type, amap in (("images", image_map), ("attachments", attachment_map)):
             for page_id, page_name in page_names.items():
                 assets = amap.get(page_id)
                 if not assets:
                     continue
-                failed = self._archive_node_assets(asset_type, node.file_path, page_name, assets)
+                failed = self._archive_node_assets(
+                    asset_type, self._asset_parent_path(node), page_name, assets)
                 survivors = [a for a in assets if a.id_ not in failed]
                 if survivors:
                     grouped[asset_type][page_name] = survivors
@@ -287,7 +298,6 @@ class ChapterArchiver(NodeArchiver):
         self._archive_level(chapter_nodes, "chapters", "chapter")
 
 
-# pylint: disable=too-many-instance-attributes
 class PageArchiver(NodeArchiver):
     """
     PageArchiver handles all data extraction and modifications
@@ -313,98 +323,17 @@ class PageArchiver(NodeArchiver):
             asset_archiver=asset_archiver,
         )
 
+    def _asset_page_map(self, node: Node) -> dict[int, str]:
+        return {node.id_: node.name}
+
+    def _asset_parent_path(self, node: Node) -> str:
+        return node.parent.file_path
+
+    def _node_output_path(self, node: Node) -> str:
+        return node.file_path
+
     def archive(self, page_nodes: dict[int, Node]):
         """Export page contents and their images/attachments."""
-        # get assets first if requested
-        # this is because we may want to manipulate page data with modify_links flag
-        image_nodes = self._get_image_meta()
-        attachment_nodes = self._get_attachment_meta()
-        for _, page in page_nodes.items():
-            page_images = []
-            page_attachments = []
-            if page.id_ in image_nodes:
-                page_images = image_nodes[page.id_]
-            if page.id_ in attachment_nodes:
-                page_attachments = attachment_nodes[page.id_]
-            failed_images = self.archive_page_assets("images", page.parent.file_path,
-                                     page.name, page_images)
-            failed_attach = self.archive_page_assets("attachments", page.parent.file_path,
-                                     page.name, page_attachments)
-            # exclude from page_images
-            # so it doesn't attempt to get modified in markdown/html file
-            if failed_images:
-                page_images = [img for img in page_images if img.id_ not in failed_images]
-            # exclude from page_attachments
-            # so it doesn't attempt to get modified in markdown/html file
-            if failed_attach:
-                page_attachments = [attach for attach in page_attachments
-                                    if attach.id_ not in failed_attach]
-            page_assets = {"images": page_images, "attachments": page_attachments}
-            for export_format in self.export_formats:
-                try:
-                    page_data = self._get_page_data(page.id_, export_format)
-                except (HTTPError, RetryError):
-                    # one restricted/failed page export must not abort the whole run
-                    # (mirrors NodeArchiver._export_nodes for book/chapter levels)
-                    log.error(
-                        "Failed to get page data for page id=%d format=%s - skipping",
-                        page.id_, export_format,
-                    )
-                    continue
-                page_data = self._rewrite_page_data(export_format, page.name,
-                                                    page_data, page_assets)
-                self._archive_page(page, export_format, page_data)
-            if self.asset_config.export_meta:
-                self._archive_page_meta(page.file_path, page.meta)
-
-    def _rewrite_page_data(self, export_format: str, page_name: str,
-                           page_data: bytes, page_assets: dict[str, list]) -> bytes:
-        """Dispatch link rewriting for the given export format. No-op for non-rewritable formats."""
-        if export_format == 'markdown':
-            rewriter = self._modify_links
-        elif export_format == 'html':
-            rewriter = self._modify_html
-        else:
-            return page_data
-        for asset_type, nodes in page_assets.items():
-            if nodes:
-                page_data = rewriter(asset_type, page_name, page_data, nodes)
-        return page_data
-
-    def _archive_page(self, page: Node, export_format: str, data: bytes):
-        page_file_name = f"{self.archive_base_path}/" \
-            f"{page.file_path}{_FILE_EXTENSION_MAP[export_format]}"
-        self.write_data(page_file_name, data)
-
-    def _get_page_data(self, page_id: int, export_format: str) -> bytes:
-        url = f"{self.api_urls['pages']}/{page_id}/{_EXPORT_API_PATH}/{export_format}"
-        return archiver_util.get_byte_response(url=url,
-                                               http_client=self.http_client)
-
-    def _archive_page_meta(self, page_path: str, meta_data: dict[str, str | int]):
-        meta_file_name = f"{self.archive_base_path}/{page_path}{_FILE_EXTENSION_MAP['meta']}"
-        bytes_meta = archiver_util.get_json_bytes(meta_data)
-        self.write_data(file_path=meta_file_name, data=bytes_meta)
-
-    def _modify_links(self, asset_type: str,
-                      page_name: str, page_data: bytes,
-                      asset_nodes: list[ImageNode | AttachmentNode]) -> bytes:
-        """Markdown link rewriting. Short-circuits when modify_links is False."""
-        if not self.modify_links:
-            return page_data
-        return self.asset_archiver.update_asset_links(asset_type, page_name, page_data,
-                                                      asset_nodes)
-
-    def _modify_html(self, asset_type: str,
-                     page_name: str, page_data: bytes,
-                     asset_nodes: list[ImageNode | AttachmentNode]) -> bytes:
-        """HTML link rewriting. Short-circuits when modify_links is False (no bs4 parse)."""
-        if not self.modify_links:
-            return page_data
-        return self.asset_archiver.update_asset_links_html(asset_type, page_name, page_data,
-                                                           asset_nodes)
-
-    def archive_page_assets(self, asset_type: str, parent_path: str, page_name: str,
-                            asset_nodes) -> set[int]:
-        """Delegate to base _archive_node_assets; preserved for backward compatibility."""
-        return self._archive_node_assets(asset_type, parent_path, page_name, asset_nodes)
+        image_map = self._get_image_meta()
+        attachment_map = self._get_attachment_meta()
+        self._export_nodes(page_nodes, "pages", image_map, attachment_map)

--- a/tests/unit/test_asset_archiver_modify_html.py
+++ b/tests/unit/test_asset_archiver_modify_html.py
@@ -92,7 +92,7 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
     def test_archive_dispatches_html_branch(
         self, tmp_path, build_node
     ):
-        """archive should call _modify_html when format='html' and modify_links=True."""
+        """archive should invoke html rewrite (update_asset_links_html) when format='html' and modify_links=True."""
         mock_asset = MagicMock()
         config = make_mock_config(
             formats=["html"],
@@ -109,6 +109,7 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             {5: [mock_image_node]} if asset_type == "images" else {}
         )
         mock_asset.get_asset_bytes.return_value = b"img_bytes"
+        mock_asset.update_asset_links_html.return_value = b"<html>rewritten</html>"
 
         parent_node = build_node(id=1, name="my-book", slug="my-book")
         page = build_node(id=5, name="test-page", slug="test-page", parent=parent_node)
@@ -118,28 +119,40 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             return_value=b"<html><body>content</body></html>",
         ), patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
-        ), patch.object(
-            archiver, "_modify_html", wraps=archiver._modify_html
-        ) as mock_modify_html:
+        ):
             archiver.archive({5: page})
 
-        mock_modify_html.assert_called_once()
+        mock_asset.update_asset_links_html.assert_called_once()
 
     def test_modify_html_short_circuits_when_modify_links_false(
-        self, tmp_path
+        self, tmp_path, build_node
     ):
-        """_modify_html should return page_data unchanged when modify_links is False."""
+        """When modify_links is False, archive must not call update_asset_links_html."""
         mock_asset = MagicMock()
-        config = make_mock_config(formats=["html"], modify_links=False)
+        config = make_mock_config(formats=["html"], modify_links=False,
+                                  export_images=True)
         archive_dir = str(tmp_path / "bookstack-test")
         archiver = PageArchiver(archive_dir, config, MagicMock(), asset_archiver=mock_asset)
 
-        page_data = b"<html><body>test</body></html>"
-        mock_nodes = [MagicMock()]
+        mock_image_node = MagicMock()
+        mock_image_node.id_ = 1
+        mock_asset.get_asset_nodes.side_effect = lambda asset_type: (
+            {5: [mock_image_node]} if asset_type == "images" else {}
+        )
+        mock_asset.get_asset_bytes.return_value = b"img_bytes"
 
-        result = archiver._modify_html("images", "test-page", page_data, mock_nodes)
-        assert result == page_data
-        # ensure no call to update_asset_links_html
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=5, name="test-page", slug="test-page", parent=parent_node)
+
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"<html><body>test</body></html>",
+        ), patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+        ):
+            archiver.archive({5: page})
+
+        # modify_links=False: html rewrite must not be invoked
         mock_asset.update_asset_links_html.assert_not_called()
 
     def test_failed_assets_filtered_from_html_rewrite(

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,protected-access
 """Happy-path unit tests for PageArchiver."""
 from typing import Dict
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from requests.exceptions import HTTPError
@@ -59,24 +59,31 @@ class TestConstruction:
 
 
 # ---------------------------------------------------------------------------
-# 2. Export URL formation (_get_page_data)
+# 2. Export URL formation (via archive → _export_nodes)
 # ---------------------------------------------------------------------------
 
-class TestGetPageData:  # pylint: disable=too-few-public-methods  # test scaffolding stub
+class TestExportUrl:
     @pytest.mark.parametrize("export_format", ["markdown", "html", "pdf", "plaintext", "zip"])
-    def test_url_contains_export_api_path(self, page_archiver, export_format):
-        """_get_page_data should call http_client with the correct export URL."""
-        page_archiver.http_client.http_get_request.return_value.content = b"data"
-        # patch archiver_util.get_byte_response to capture the url argument
+    def test_url_contains_export_api_path(self, tmp_path, build_node, export_format):
+        """archive should call get_byte_response with the correct pages export URL."""
+        config = _make_config(formats=[export_format], export_images=False,
+                              export_attachments=False, export_meta=False)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+        archiver.asset_archiver.get_asset_nodes.return_value = {}
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=42, name="my-page", slug="my-page", parent=parent_node)
+
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response"
-        ) as mock_get_bytes:
+        ) as mock_get_bytes, patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+        ):
             mock_get_bytes.return_value = b"page content"
-            page_archiver._get_page_data(42, export_format)
+            archiver.archive({42: page})
             called_url = mock_get_bytes.call_args.kwargs["url"]
-        expected = (
-            f"https://wiki.test.example/api/pages/42/export/{export_format}"
-        )
+
+        expected = f"https://wiki.test.example/api/pages/42/export/{export_format}"
         assert called_url == expected
 
 
@@ -279,3 +286,181 @@ class TestAssetArchiverInjection:
             asset_archiver=double,
         )
         assert archiver.asset_archiver is double
+
+
+# ---------------------------------------------------------------------------
+# 9. R5: page output path = page.file_path (no /name double-suffix)
+# ---------------------------------------------------------------------------
+
+class TestPageOutputPath:
+    def test_page_content_written_to_file_path_not_file_path_slash_name(
+            self, tmp_path, build_node):
+        """Page export must be written to <base>/<page.file_path>.md, NOT <base>/<fp>/<name>.md."""
+        config = _make_config(formats=["markdown"], export_images=False,
+                              export_attachments=False, export_meta=False)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+        archiver.asset_archiver.get_asset_nodes.return_value = {}
+
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=7, name="my-page", slug="my-page", parent=parent_node)
+        # page.file_path = "my-book/my-page"
+
+        written = {}
+        archiver.write_data = written.__setitem__
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"data",
+        ):
+            archiver.archive({7: page})
+
+        expected_key = f"{archiver.archive_base_path}/my-book/my-page.md"
+        assert expected_key in written, f"Expected key {expected_key!r}, got {list(written)}"
+
+    def test_page_meta_written_to_file_path(self, tmp_path, build_node):
+        """Page meta must be <base>/<page.file_path>_meta.json."""
+        config = _make_config(formats=["markdown"], export_images=False,
+                              export_attachments=False, export_meta=True)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+        archiver.asset_archiver.get_asset_nodes.return_value = {}
+
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=7, name="my-page", slug="my-page", parent=parent_node)
+
+        written = {}
+        archiver.write_data = written.__setitem__
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"data",
+        ):
+            archiver.archive({7: page})
+
+        expected_meta_key = f"{archiver.archive_base_path}/my-book/my-page_meta.json"
+        assert expected_meta_key in written, (
+            f"Expected meta key {expected_meta_key!r}, got {list(written)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 10. R5: page assets written under parent.file_path
+# ---------------------------------------------------------------------------
+
+class TestPageAssetParentPath:
+    def test_page_image_written_under_parent_file_path(self, tmp_path, build_node):
+        """Image assets for a page must be stored under the parent book/chapter path."""
+        config = _make_config(formats=["markdown"], export_images=True,
+                              export_attachments=False, export_meta=False,
+                              modify_links=True)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=7, name="my-page", slug="my-page", parent=parent_node)
+
+        img = MagicMock(id_=42, download_url="http://x/img", uploaded_to=7)
+        img.get_relative_path = lambda page_name: f"images/{page_name}/img.png"
+
+        archiver.asset_archiver.get_asset_nodes.side_effect = (
+            lambda kind: {7: [img]} if kind == "images" else {}
+        )
+        archiver.asset_archiver.get_asset_bytes.return_value = b"PNGDATA"
+        archiver.asset_archiver.update_asset_links.side_effect = lambda *a, **kw: a[2]
+
+        written = {}
+        archiver.write_data = written.__setitem__
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"data",
+        ):
+            archiver.archive({7: page})
+
+        # asset must live under parent.file_path ("my-book"), NOT page.file_path ("my-book/my-page")
+        expected_asset_key = f"{archiver.archive_base_path}/my-book/images/my-page/img.png"
+        assert expected_asset_key in written, (
+            f"Expected {expected_asset_key!r} in written; got {list(written)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 11. R5: modify_links=False still downloads assets but does NOT rewrite
+# ---------------------------------------------------------------------------
+
+class TestModifyLinksFalseStillDownloads:
+    def test_assets_downloaded_rewrite_not_called(self, tmp_path, build_node):
+        """When modify_links is False, assets are downloaded but update_asset_links is not called."""
+        # export_images=True but modify_links=False → no rewrite
+        config = _make_config(formats=["markdown"], export_images=True,
+                              export_attachments=False, export_meta=False,
+                              modify_links=False)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=7, name="my-page", slug="my-page", parent=parent_node)
+
+        img = MagicMock(id_=42, download_url="http://x/img", uploaded_to=7)
+        img.get_relative_path = lambda page_name: f"images/{page_name}/img.png"
+
+        archiver.asset_archiver.get_asset_nodes.side_effect = (
+            lambda kind: {7: [img]} if kind == "images" else {}
+        )
+        archiver.asset_archiver.get_asset_bytes.return_value = b"PNGDATA"
+
+        written = {}
+        archiver.write_data = written.__setitem__
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"data",
+        ):
+            archiver.archive({7: page})
+
+        # Asset should still be downloaded
+        archiver.asset_archiver.get_asset_bytes.assert_called_once()
+        # But rewrite must NOT be called
+        archiver.asset_archiver.update_asset_links.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 12. R5: images-then-attachments rewrite order
+# ---------------------------------------------------------------------------
+
+class TestRewriteOrder:
+    def test_images_rewritten_before_attachments(self, tmp_path, build_node):
+        """asset_links rewrite must process images before attachments (same order as old code)."""
+        config = _make_config(formats=["markdown"], export_images=True,
+                              export_attachments=True, export_meta=False,
+                              modify_links=True)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+
+        parent_node = build_node(id=1, name="my-book", slug="my-book")
+        page = build_node(id=7, name="my-page", slug="my-page", parent=parent_node)
+
+        img = MagicMock(id_=10, download_url="http://x/img", uploaded_to=7)
+        img.get_relative_path = lambda page_name: f"images/{page_name}/img.png"
+        att = MagicMock(id_=20, download_url="http://x/att", uploaded_to=7)
+        att.get_relative_path = lambda page_name: f"attachments/{page_name}/file.pdf"
+
+        archiver.asset_archiver.get_asset_nodes.side_effect = (
+            lambda kind: {7: [img]} if kind == "images" else {7: [att]}
+        )
+        archiver.asset_archiver.get_asset_bytes.return_value = b"DATA"
+
+        rewrite_order = []
+        def _track_rewrite(asset_type, page_name, data, assets):
+            rewrite_order.append(asset_type)
+            return data
+        archiver.asset_archiver.update_asset_links.side_effect = _track_rewrite
+
+        written = {}
+        archiver.write_data = written.__setitem__
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"data",
+        ):
+            archiver.archive({7: page})
+
+        assert rewrite_order == ["images", "attachments"], (
+            f"Expected images before attachments, got {rewrite_order}"
+        )


### PR DESCRIPTION
## Changes

Route `PageArchiver` through the existing base `NodeArchiver._export_nodes`/`_download_node_assets` driver instead of its hand-reimplemented fetch/rewrite/archive/meta loop. A page is the degenerate single-page case of a book/chapter export, so the only genuine per-level differences are isolated into 3 small overridable hooks on `NodeArchiver`:

- `_asset_page_map(node)` — base: `_descendant_page_names(node)`; page: `{node.id_: node.name}`
- `_asset_parent_path(node)` — base: `node.file_path`; page: `node.parent.file_path`
- `_node_output_path(node)` — base: `f"{node.file_path}/{node.name}"`; page: `node.file_path`

`_download_node_assets`, `_archive_node`, and `_archive_node_meta` now build their paths via these hooks (base behavior unchanged). `PageArchiver.archive` becomes a thin orchestrator that populates the asset maps (the per-type `_get_*_meta` getters already self-gate) and calls `self._export_nodes(page_nodes, "pages", ...)`.

Deletes 7 now-redundant `PageArchiver` methods, each a special case of a base method: `_get_page_data`, `_rewrite_page_data`, `_modify_links`, `_modify_html`, `_archive_page`, `_archive_page_meta`, `archive_page_assets`. Also removes the now-orphaned `_EXPORT_API_PATH` constant.

Book/chapter `modify_links`-gated map population and empty-container skipping are left untouched in `_archive_level` — page/book/chapter asset-fetch asymmetry is preserved exactly.

## Motivation

`PageArchiver.archive` duplicated the base export loop (the per-format try/except/skip block was copy-paste, with a `# mirrors NodeArchiver._export_nodes` comment), and the two had started to drift. Collapsing onto the shared driver removes the duplication and leaves one implementation of the fetch/rewrite/archive path. Behavior-preserving (R5 in the modularity refactor series; follows the same charter as #127/#128).

## Test plan

- `uv run pytest` — 419 passed (was 414; +5 behavior-locking tests covering page output path, asset parent path, download-without-rewrite when `modify_links=False`, and images-before-attachments rewrite order).
- `uv run pylint bookstack_file_exporter/archiver/node_archiver.py` — 10.00/10.
- End-to-end byte-identical check against reference exports (pages/books/chapters + filtered books, live instance): file trees identical; the only differences are non-deterministic PDFs (pass-through, embed generation timestamps), one pre-existing HTML base64/scaled-image delta from an earlier change, and one page edited on the instance since the baseline. No R5-attributable output change. The edited page positively exercises the page asset-download + markdown link-rewrite path (assets land at the correct local paths).

## In-depth

- A page export now flows through the base loop, so the page fetch-error **log message** changes from `"Failed to get page data for page id=… format=…"` to the base loop's `"Failed to get pages data for node id=… format=…"`. Log text only — no change to archive output.
- `tests/unit/test_asset_archiver_modify_html.py` was updated (outside the three page/book/chapter test files): two tests asserted on the now-deleted `_modify_html` private and were retargeted to observable behavior (the `update_asset_links_html` call on the asset archiver via the public `archive()`).
- Follow-up `Fix-4` (honor `export_images`/`export_attachments` standalone at book/chapter level) builds on the seam this introduces; out of scope here.