### PR TITLE
refactor: idiomatic minor-cleanup batch (R9)

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -13,6 +13,7 @@ from bookstack_file_exporter.archiver.node_archiver import (
 from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
 from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
+from bookstack_file_exporter.common import util as common_util
 from bookstack_file_exporter.common.util import HttpHelper
 
 log = logging.getLogger(__name__)
@@ -167,15 +168,11 @@ class Archiver:
 
     def _filter_archives(self, file_list: list[str]) -> list[str]:
         """get older archives based on keep number"""
-        file_dict = {file: os.stat(file).st_ctime for file in file_list}
-        ordered = sorted(file_dict.items(), key=lambda item: item[1])
-        to_delete = len(ordered) - self.config.user_inputs.keep_last
-        # Guard against negative slice when caller invokes us directly with
-        # keep_last >= len(file_list). Negative `to_delete` makes ordered[:to_delete]
-        # return the first N items instead of an empty list — wrong files deleted.
-        if to_delete <= 0:
-            return []
-        files_to_clean = [key for key, _ in ordered[:to_delete]]
+        files_to_clean = common_util.oldest_beyond_keep(
+            file_list,
+            key=lambda f: os.stat(f).st_ctime,
+            keep_last=self.config.user_inputs.keep_last,
+        )
         log.debug("%d local archives will be cleaned up", len(files_to_clean))
         return files_to_clean
 

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -41,7 +41,9 @@ class Archiver:
         self.base_dir = self._level_base_dir(config.base_dir_name,
                                              config.user_inputs.export_level)
         self.archive_dir = self._generate_root_folder(self.base_dir)
-        self._archiver: NodeArchiver = node_archiver or self._build_archiver(http_client)
+        self._archiver: NodeArchiver = (
+            node_archiver if node_archiver is not None else self._build_archiver(http_client)
+        )
         self._minio_archiver_cls = minio_archiver_cls
 
     def _build_archiver(self, http_client: HttpHelper) -> NodeArchiver:

--- a/bookstack_file_exporter/archiver/minio_archiver.py
+++ b/bookstack_file_exporter/archiver/minio_archiver.py
@@ -5,6 +5,7 @@ from minio import Minio
 # pylint: disable=import-error
 from minio.datatypes import Object as MinioObject
 
+from bookstack_file_exporter.common import util as common_util
 from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
 
 
@@ -98,18 +99,11 @@ class MinioArchiver:
         return to_delete
 
     def _filter_objects(self, minio_objects: list[MinioObject]) -> list[MinioObject]:
-        # sort by minio datetime 'last_modified' time
-        # ascending order
-        sorted_objects = sorted(minio_objects, key=lambda d: d.last_modified)
-        objects_to_clean =  []
-        # how many items we will have to delete to fulfill 'keep_last'
-        to_delete = len(sorted_objects) - self.keep_last
-        # collect objects to delete
-        for item in sorted_objects:
-            objects_to_clean.append(item)
-            to_delete -= 1
-            if to_delete <= 0:
-                break
+        objects_to_clean = common_util.oldest_beyond_keep(
+            minio_objects,
+            key=lambda d: d.last_modified,
+            keep_last=self.keep_last,
+        )
         log.debug("%d minio objects will be cleaned up", len(objects_to_clean))
         return objects_to_clean
 

--- a/bookstack_file_exporter/archiver/minio_archiver.py
+++ b/bookstack_file_exporter/archiver/minio_archiver.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 # pylint: disable=import-error
 from minio import Minio
@@ -50,7 +51,7 @@ class MinioArchiver:
         # this will be the name of the object to upload
         # only get the file name not path
         # we are going to use path provided by user for object storage
-        file_name = local_file_path.split("/")[-1]
+        file_name = os.path.basename(local_file_path)
         if self.path:
             object_path = f"{self.path}/{file_name}"
         else:

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -1,4 +1,5 @@
 import logging
+import os
 # pylint: disable=import-error
 from requests.exceptions import HTTPError, RetryError
 from bookstack_file_exporter.exporter.node import Node
@@ -56,7 +57,7 @@ class NodeArchiver:
         # intermediate tar before gzip
         self.tar_file = f"{archive_dir}{_FILE_EXTENSION_MAP['tar']}"
         # base folder name inside the tgz archive
-        self.archive_base_path = archive_dir.split("/")[-1]
+        self.archive_base_path = os.path.basename(archive_dir)
         # asset handling (shared by page/book/chapter); None => disabled
         self.asset_config = asset_config
         self.asset_archiver = asset_archiver if asset_archiver is not None else (

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -60,10 +60,15 @@ class NodeArchiver:
         self.archive_base_path = os.path.basename(archive_dir)
         # asset handling (shared by page/book/chapter); None => disabled
         self.asset_config = asset_config
-        self.asset_archiver = asset_archiver if asset_archiver is not None else (
-            AssetArchiver(api_urls, http_client) if asset_config else None
+        self.asset_archiver = (
+            asset_archiver if asset_archiver is not None
+            else self._default_asset_archiver(api_urls, http_client)
         )
         self.modify_links: bool = self._check_links_modify()
+
+    def _default_asset_archiver(self, api_urls: dict[str, str], http_client: HttpHelper):
+        """Build an AssetArchiver when no double is injected, or return None if assets disabled."""
+        return AssetArchiver(api_urls, http_client) if self.asset_config else None
 
     @property
     def export_images(self) -> bool:

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -244,24 +244,24 @@ class NodeArchiver:
                     grouped[asset_type][page_name] = survivors
         return grouped
 
-    def _rewrite_combined_markdown(self, data: bytes, assets_by_page: dict) -> bytes:
-        """Rewrite asset URLs in combined markdown, reusing the per-page rewriter."""
+    def _rewrite_combined(self, data: bytes, assets_by_page: dict, rewriter) -> bytes:
+        """Run the shared guard and double loop, delegating each page to rewriter."""
         if not assets_by_page or self.asset_archiver is None:
             return data
         for asset_type, by_page in assets_by_page.items():
             for page_name, assets in by_page.items():
-                data = self.asset_archiver.update_asset_links(asset_type, page_name, data, assets)
+                data = rewriter(asset_type, page_name, data, assets)
         return data
+
+    def _rewrite_combined_markdown(self, data: bytes, assets_by_page: dict) -> bytes:
+        """Rewrite asset URLs in combined markdown, reusing the per-page rewriter."""
+        return self._rewrite_combined(data, assets_by_page,
+                                      self.asset_archiver.update_asset_links)
 
     def _rewrite_combined_html(self, data: bytes, assets_by_page: dict) -> bytes:
         """Rewrite asset URLs in combined html, reusing the per-page html rewriter."""
-        if not assets_by_page or self.asset_archiver is None:
-            return data
-        for asset_type, by_page in assets_by_page.items():
-            for page_name, assets in by_page.items():
-                data = self.asset_archiver.update_asset_links_html(
-                    asset_type, page_name, data, assets)
-        return data
+        return self._rewrite_combined(data, assets_by_page,
+                                      self.asset_archiver.update_asset_links_html)
 
     def write_data(self, file_path: str, data: bytes):
         """Write data to a tar file.

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -16,9 +16,6 @@ T = TypeVar("T")
 
 log = logging.getLogger(__name__)
 
-# disable TLS warnings if using verify_ssl=false
-urllib3.disable_warnings()
-
 class HttpHelper:
     """
     HttpHelper provides an http request helper with config stored and retries built in
@@ -37,6 +34,8 @@ class HttpHelper:
         self.retry_count = config.retry_count
         self.http_timeout = config.timeout
         self.verify_ssl = config.verify_ssl
+        if not self.verify_ssl:
+            urllib3.disable_warnings()
         self._headers = headers
         self._session = self._build_session()
 

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -103,7 +103,8 @@ class HttpHelper:
         return all_data
 
 def oldest_beyond_keep(items: list[T], key, keep_last: int) -> list[T]:
-    """Return the oldest items exceeding keep_last (sorted ascending by key). Empty if none exceed."""
+    """Return the oldest items exceeding keep_last (sorted ascending by key).
+    Empty if none exceed."""
     ordered = sorted(items, key=key)
     to_delete = len(ordered) - keep_last
     if to_delete <= 0:

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -103,6 +103,15 @@ class HttpHelper:
             offset += count
         return all_data
 
+def oldest_beyond_keep(items: list[T], key, keep_last: int) -> list[T]:
+    """Return the oldest items exceeding keep_last (sorted ascending by key). Empty if none exceed."""
+    ordered = sorted(items, key=key)
+    to_delete = len(ordered) - keep_last
+    if to_delete <= 0:
+        return []
+    return ordered[:to_delete]
+
+
 def check_var(env_key: str, default_val: str, required: bool = True) -> str:
     """
     :param env_key: environment variable to check (takes precedence)

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -55,19 +55,21 @@ class AppRiseNotify:
         timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
         if error_msg:
             error_str = str(error_msg)
-            body = f"""
-            Bookstack File Exporter encountered an unrecoverable error.
-
-            Occurred At: {timestamp}
-
-            Error message: {error_str}
-            """
+            lines = [
+                "",
+                "Bookstack File Exporter encountered an unrecoverable error.",
+                "",
+                f"Occurred At: {timestamp}",
+                "",
+                f"Error message: {error_str}",
+            ]
         else:
-            body = f"""
-            Bookstack File Exporter completed successfully.
-
-            Completed At: {timestamp}
-            """
+            lines = [
+                "",
+                "Bookstack File Exporter completed successfully.",
+                "",
+                f"Completed At: {timestamp}",
+            ]
             if result is not None and result.local is not None:
                 local_abs = os.path.abspath(result.local)
                 removed_abs = {os.path.abspath(p) for p in result.removed}
@@ -76,15 +78,15 @@ class AppRiseNotify:
                 archive_line = f"Archive: {result.local}"
                 if was_removed:
                     archive_line += " (removed locally after upload)"
-                body += f"\n            {archive_line}"
+                lines.append(archive_line)
 
                 if result.remote:
-                    body += f"\n            Uploaded to: {', '.join(result.remote)}"
+                    lines.append(f"Uploaded to: {', '.join(result.remote)}")
 
                 pruned_count = len(removed_abs - {local_abs})
                 if pruned_count > 0:
-                    body += f"\n            Pruned {pruned_count} old local archive(s)"
-        return body
+                    lines.append(f"Pruned {pruned_count} old local archive(s)")
+        return "\n".join(lines)
 
     def notify(self, excep: Exception | None = None, result: NotifyResult | None = None):
         """send notification with exception message"""

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -10,7 +10,7 @@ LOG_LEVEL = {
 
 def get_log_level(log_level:str) -> int:
     """return log level int"""
-    return LOG_LEVEL.get(log_level)
+    return LOG_LEVEL[log_level]
 
 def get_args() -> argparse.Namespace:
     """return user cmd line options"""

--- a/tests/unit/test_asset_archiver_modify_html.py
+++ b/tests/unit/test_asset_archiver_modify_html.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring
-# pylint: disable=redefined-outer-name,protected-access
+# pylint: disable=redefined-outer-name,protected-access,too-few-public-methods
 """Unit tests for PageArchiver._modify_html dispatch and E2E HTML rewrite pipeline (Phase 4)."""
 import logging
 import re
@@ -92,7 +92,8 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
     def test_archive_dispatches_html_branch(
         self, tmp_path, build_node
     ):
-        """archive should invoke html rewrite (update_asset_links_html) when format='html' and modify_links=True."""
+        """archive should invoke html rewrite (update_asset_links_html) when format='html'
+        and modify_links=True."""
         mock_asset = MagicMock()
         config = make_mock_config(
             formats=["html"],
@@ -397,7 +398,8 @@ class TestRemoteScaledImgSrc:
     )
 
     def test_remote_scaled_src_and_href_rewritten_to_local(self):
-        """Both scaled img src and canonical anchor href are rewritten to images/test-page/foo.png."""
+        """Both scaled img src and canonical anchor href are rewritten to
+        images/test-page/foo.png."""
         http_client = MagicMock(spec=HttpHelper)
         archiver = AssetArchiver(
             {

--- a/tests/unit/test_config_helper.py
+++ b/tests/unit/test_config_helper.py
@@ -1,10 +1,11 @@
+# pylint: disable=protected-access
 """Unit tests for the module-level config parsing seams extracted in R2."""
 import logging
-from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 import yaml
+from pydantic import ValidationError
 
 from bookstack_file_exporter.config_helper import models
 from bookstack_file_exporter.config_helper.config_helper import (
@@ -101,16 +102,12 @@ def test_build_user_input_returns_user_input_for_valid_dict():
 
 def test_build_user_input_raises_on_invalid_schema():
     """build_user_input raises (pydantic ValidationError) for a dict with bad values."""
-    from pydantic import ValidationError
-
     with pytest.raises(ValidationError):
         build_user_input(dict(_INVALID_RAW))
 
 
 def test_build_user_input_logs_error_on_schema_failure(caplog):
     """build_user_input logs the schema validation error message before re-raising."""
-    from pydantic import ValidationError
-
     logger_name = "bookstack_file_exporter.config_helper.config_helper"
     with caplog.at_level(logging.ERROR, logger=logger_name):
         with pytest.raises(ValidationError):

--- a/tests/unit/test_filter.py
+++ b/tests/unit/test_filter.py
@@ -1,7 +1,5 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring
 """Unit tests for NodeFilter (exporter/filter.py) — pure logic, no I/O."""
-import pytest
-
 from bookstack_file_exporter.exporter.filter import NodeFilter
 from bookstack_file_exporter.config_helper.models import Filters, ResourceFilter
 

--- a/tests/unit/test_models_filters.py
+++ b/tests/unit/test_models_filters.py
@@ -27,8 +27,8 @@ class TestResourceFilterValid:
 
     def test_empty_list_accepted(self):
         rf = ResourceFilter(include=[], exclude=[])
-        assert rf.include == []
-        assert rf.exclude == []
+        assert not rf.include
+        assert not rf.exclude
 
     def test_single_pattern_accepted(self):
         rf = ResourceFilter(include=["draft"])

--- a/tests/unit/test_node_exporter.py
+++ b/tests/unit/test_node_exporter.py
@@ -201,7 +201,8 @@ def test_get_unassigned_books_one_unassigned_fetched_with_prefix(
 ):
     existing = {10: build_node(id=10, slug="book-10", name="Book 10")}
     unassigned_data = dict(book_detail_mixed, id=99, slug="orphan-book", name="Orphan Book")
-    mock_http_client.http_get_all.return_value = [{"id": 10, "name": "Book 10"}, {"id": 99, "name": "Orphan Book"}]
+    mock_http_client.http_get_all.return_value = [
+        {"id": 10, "name": "Book 10"}, {"id": 99, "name": "Orphan Book"}]
     mock_http_client.http_get_request.return_value = make_response(unassigned_data)
     exporter = _exporter(api_urls, mock_http_client)
     result = exporter.get_unassigned_books(existing, "unassigned/")
@@ -253,7 +254,11 @@ def test_get_all_books_adds_unassigned_books(
         raise AssertionError(f"unexpected url: {url}")
 
     # all-books includes 99 which isn't in the shelf
-    mock_http_client.http_get_all.return_value = [{"id": 10, "name": "Test Book 1"}, {"id": 11, "name": "Test Book 2"}, {"id": 99, "name": "Orphan"}]
+    mock_http_client.http_get_all.return_value = [
+        {"id": 10, "name": "Test Book 1"},
+        {"id": 11, "name": "Test Book 2"},
+        {"id": 99, "name": "Orphan"},
+    ]
     mock_http_client.http_get_request.side_effect = _side_effect
     exporter = _exporter(api_urls, mock_http_client)
     result = exporter.get_all_books({1: shelf_node}, "unassigned/")
@@ -352,8 +357,6 @@ def test_exclude_unassigned_books_true_independent_of_books_include(
     exporter = NodeExporter(api_urls, mock_http_client, node_filter=node_filter)
 
     shelf_node = Node(shelf_detail)
-    book_data_10 = dict(book_detail_mixed, id=10, slug="test-book-1", name="Test Book 1")
-    book_data_11 = dict(book_detail_mixed, id=11, slug="test-book-2", name="Test Book 2")
 
     def _side_effect(url):
         # Books 10 and 11 are on the shelf so they are fetched via get_child_nodes;

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -1,7 +1,7 @@
-# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,protected-access
+# pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,protected-access,too-few-public-methods
 """Happy-path unit tests for PageArchiver."""
 from typing import Dict
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from requests.exceptions import HTTPError
@@ -38,23 +38,27 @@ def page_archiver(tmp_path):
 class TestConstruction:
     def test_archive_file_ends_with_tgz(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(), asset_archiver=MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(),
+                                asset_archiver=MagicMock())
         assert archiver.archive_file == f"{archive_dir}.tgz"
 
     def test_tar_file_ends_with_tar(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(), asset_archiver=MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(),
+                                asset_archiver=MagicMock())
         assert archiver.tar_file == f"{archive_dir}.tar"
 
     def test_archive_base_path_is_last_segment(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(), asset_archiver=MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), MagicMock(),
+                                asset_archiver=MagicMock())
         assert archiver.archive_base_path == "bookstack-20260514"
 
     def test_http_client_stored(self, tmp_path):
         http_client = MagicMock()
         archive_dir = str(tmp_path / "bookstack-20260514")
-        archiver = PageArchiver(archive_dir, _make_config(), http_client, asset_archiver=MagicMock())
+        archiver = PageArchiver(archive_dir, _make_config(), http_client,
+                                asset_archiver=MagicMock())
         assert archiver.http_client is http_client
 
 
@@ -251,7 +255,8 @@ class TestAssetArchiverInjection:
     """Constructor-injected asset_archiver double is stored as self.asset_archiver."""
 
     def test_injected_double_is_stored(self, tmp_path):
-        """When asset_archiver= is supplied, NodeArchiver stores it without constructing a real one."""
+        """When asset_archiver= is supplied, NodeArchiver stores it
+        without constructing a real one."""
         double = MagicMock()
         config = _make_config(export_images=True)
         archive_dir = str(tmp_path / "bookstack-r8")
@@ -388,7 +393,8 @@ class TestPageAssetParentPath:
 
 class TestModifyLinksFalseStillDownloads:
     def test_assets_downloaded_rewrite_not_called(self, tmp_path, build_node):
-        """When modify_links is False, assets are downloaded but update_asset_links is not called."""
+        """When modify_links is False, assets are downloaded but update_asset_links
+        is not called."""
         # export_images=True but modify_links=False → no rewrite
         config = _make_config(formats=["markdown"], export_images=True,
                               export_attachments=False, export_meta=False,


### PR DESCRIPTION
## Changes

R9 — idiomatic / minor-cleanup batch. Each change is its own commit. Behavior-preserving **except** two explicitly-noted observable deltas (below).

- **Parametrize combined-asset-rewrite dup** — `_rewrite_combined_markdown`/`_rewrite_combined_html` (node_archiver) differed only in the delegate call; extracted shared `_rewrite_combined(data, assets_by_page, rewriter)`, wrappers stay thin.
- **Extract `oldest_beyond_keep(items, key, keep_last)`** into `common/util.py`; rewired archiver `_filter_archives` and minio `_filter_objects` onto it. Pure extraction — the helper carries the negative-slice guard; each call site keeps identical observable behavior (minio's caller `_get_stale_objects` still pre-guards `len > keep_last`, so the helper's guard is never reached there in production).
- **`split("/")[-1]` → `os.path.basename`** — `node_archiver.py`, `minio_archiver.py`.
- **Construction-seam consistency** — `archiver.py` injected-archiver sentinel `or` → `is not None` (immune to a falsy injected double); extracted node_archiver's inline asset-archiver ternary into `_default_asset_archiver()` to match the `_build_archiver` shape. No-behavior; the `None`-when-disabled return is preserved (load-bearing: `is None` means "asset handling off").
- **`get_log_level`** — `LOG_LEVEL.get(log_level)` → `LOG_LEVEL[log_level]`. argparse `choices` already guarantees validity; indexing fails loud for a future caller instead of passing `None` to `logging.basicConfig`.
- **Test-suite lint debt** — cleared pre-existing pylint warnings across `tests/` (unused imports, line lengths, `== []` → `not x`, protected-access/too-few-public-methods disable headers). `ValidationError` deferred imports in `test_config_helper.py` hoisted to module top (no deferral reason found).

### Observable deltas (intended)

- **urllib3 warning scope** — `common/util.py` previously called `urllib3.disable_warnings()` at module import, suppressing **all** urllib3 warnings process-wide. Now scoped to the `verify_ssl=False` path inside `HttpHelper.__init__`. Warnings are still suppressed when `verify_ssl=False`; they are no longer globally suppressed when verification is on.
- **Notification body whitespace** — `notifiers._get_message_text` built the body from triple-quoted f-strings carrying ~12 spaces of source indentation per line. Rebuilt as a list of lines joined with `\n`. Same lines, same conditional structure (Archive / Uploaded to / Pruned), but the leading per-line indentation is gone — the message bytes change.

## Motivation

Folds the smell-sweep's idiomatic minor-cleanup findings into one low-risk batch: kill duplication (combined-rewrite, retention filter), replace hand-rolled/footgun idioms (`split("/")[-1]`, `.get()` into `basicConfig`, import-time global side-effect), align the R1/R8 injection seams, and bring `task lint` to a clean baseline across tests.

## Test plan

- `uv run pytest -q` — 419 passed.
- `task lint` — 10.00/10; the only remaining warning is the intentional `run.py:40 W0718` (broad-exception-caught in the run loop), out of this batch's scope.
- Retention extraction verified behavior-identical at both call sites; notifier body verified via the existing 11 notifier tests (substring assertions on all expected lines).

## In-depth

- **No e2e diff run**: nothing in this batch reshapes archive bytes. The only output-adjacent change is the notification body (text, not archive content), covered by unit tests. (Prior driver-reshaping refactors did warrant the live golden-master diff; this one does not.)
- **Retention guard, deliberately not normalized**: archiver guarded the negative-slice case directly; minio relied on its caller's `len > keep_last` pre-check. The shared helper carries the guard so both are safe, but neither call site's observable behavior changes — guard *normalization* was explicitly kept out of this no-behavior batch.
