### PR TITLE
refactor: split NodeExporter fetch from tree/relationship logic (R6)

### DIFF
--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -7,6 +7,7 @@ from requests import Response
 from bookstack_file_exporter.exporter.node import Node
 from bookstack_file_exporter.exporter.filter import NodeFilter
 from bookstack_file_exporter.common.util import HttpHelper
+from bookstack_file_exporter.exporter import selector
 
 log = logging.getLogger(__name__)
 
@@ -44,18 +45,9 @@ class NodeExporter():
         # Fetch every shelf detail regardless of filter (shelf detail contains the book
         # IDs needed for cascade suppression — those IDs are not in the list summary).
         all_shelf_nodes = self._get_parents(base_url, all_parents)
-        if self._node_filter is None:
-            return all_shelf_nodes
-        surviving = {}
-        for shelf_id, shelf_node in all_shelf_nodes.items():
-            if self._node_filter.keep(shelf_node.display_name, "shelves"):
-                surviving[shelf_id] = shelf_node
-            else:
-                log.debug("Shelf '%s' excluded by filter; suppressing its books",
-                          shelf_node.display_name)
-                # Record the child book IDs so they don't resurface as unassigned.
-                for book_entry in shelf_node.children:
-                    self._excluded_book_ids.add(book_entry['id'])
+        surviving, excluded_book_ids = selector.partition_shelves(
+            all_shelf_nodes, self._node_filter)
+        self._excluded_book_ids.update(excluded_book_ids)
         return surviving
 
     def _get_json_response(self, url: str) -> list[dict[str, str |int]]:

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -119,19 +119,8 @@ class NodeExporter():
         """
         book_url = self.api_urls["books"]
         all_books: list[dict] = self.http_client.http_get_all(book_url)
-        unassigned = []
-        for book_item in all_books:
-            book_id = book_item['id']
-            if book_id in existing_books:
-                continue
-            if book_id in self._excluded_book_ids:
-                log.debug("Book id=%d suppressed (its shelf was excluded)", book_id)
-                continue
-            book_name = book_item['name']
-            if self._node_filter and not self._node_filter.keep(book_name, "books"):
-                log.debug("Unassigned book '%s' excluded by filter", book_name)
-                continue
-            unassigned.append(book_id)
+        unassigned = selector.selectable_unassigned_books(
+            all_books, set(existing_books), self._excluded_book_ids, self._node_filter)
         if not unassigned:
             return {}
         # books with no shelf treated like a parent resource

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -76,14 +76,8 @@ class NodeExporter():
         base_url = self.api_urls["chapters"]
         chapter_nodes = {}
         for book_node in book_nodes.values():
-            for child in book_node.children:
-                if child.get('type') != 'chapter':
-                    continue
-                if self._node_filter:
-                    chapter_name = child['name']
-                    if not self._node_filter.keep(chapter_name, "chapters"):
-                        log.debug("Chapter '%s' excluded by filter", chapter_name)
-                        continue
+            for child in selector.selectable_children(
+                    book_node.children, "chapters", self._node_filter, node_type="chapter"):
                 chapter_id = child['id']
                 chapter_data = self._get_json_response(f"{base_url}/{chapter_id}")
                 chapter_nodes[chapter_id] = Node(chapter_data, book_node)
@@ -100,34 +94,18 @@ class NodeExporter():
                       filter_empty: bool, node_type: str = "") -> dict[int, Node]:
         child_nodes = {}
         for _, parent in parent_nodes.items():
-            if parent.children:
-                for child in parent.children:
-                    if node_type:
-                        # only used for Book Nodes to get children Page/Chapter Nodes
-                        # access key directly, don't create a Node if not needed
-                        # chapters and pages always have `type` from what I can tell
-                        if not child['type'] == node_type:
-                            log.debug("Book Node child of type: %s is not desired type: %s",
-                                       child['type'], node_type)
-                            continue
-                    # Pre-GET name filter: test child name before issuing the detail GET.
-                    if self._node_filter:
-                        child_name = child['name']
-                        if not self._node_filter.keep(child_name, resource_type):
-                            log.debug("'%s' (type=%s) excluded by filter",
-                                      child_name, resource_type)
-                            continue
-                    child_id = child['id']
-                    child_url = f"{base_url}/{child_id}"
-                    child_data = self._get_json_response(child_url)
-                    child_node = Node(child_data, parent)
-                    if filter_empty:
-                        # if it is not empty, add it
-                        # skip it if empty
-                        if not child_node.empty:
-                            child_nodes[child_id] = child_node
-                    else:
-                        child_nodes[child_id] = child_node
+            if not parent.children:
+                continue
+            for child in selector.selectable_children(
+                    parent.children, resource_type, self._node_filter, node_type):
+                child_id = child['id']
+                child_url = f"{base_url}/{child_id}"
+                child_data = self._get_json_response(child_url)
+                child_node = Node(child_data, parent)
+                # filter_empty needs the fetched detail (Node.empty), so it stays here.
+                if filter_empty and child_node.empty:
+                    continue
+                child_nodes[child_id] = child_node
         return child_nodes
 
     def get_unassigned_books(self, existing_books: dict[int, Node],

--- a/bookstack_file_exporter/exporter/selector.py
+++ b/bookstack_file_exporter/exporter/selector.py
@@ -57,3 +57,28 @@ def selectable_children(
             continue
         selected.append(child)
     return selected
+
+
+def selectable_unassigned_books(
+    all_books: list[dict], existing_ids: set[int],
+    excluded_ids: set[int], node_filter: NodeFilter | None,
+) -> list[int]:
+    """Pick shelfless book IDs to fetch, applying the three pre-GET gates.
+
+    1. Skip books already collected under a shelf (existing_ids).
+    2. Skip books whose shelf was dropped (excluded_ids).
+    3. When a filter is set, skip books failing the 'books' name filter.
+    """
+    selected: list[int] = []
+    for book in all_books:
+        book_id = book['id']
+        if book_id in existing_ids:
+            continue
+        if book_id in excluded_ids:
+            log.debug("Book id=%d suppressed (its shelf was excluded)", book_id)
+            continue
+        if node_filter and not node_filter.keep(book['name'], "books"):
+            log.debug("Unassigned book '%s' excluded by filter", book['name'])
+            continue
+        selected.append(book_id)
+    return selected

--- a/bookstack_file_exporter/exporter/selector.py
+++ b/bookstack_file_exporter/exporter/selector.py
@@ -33,3 +33,27 @@ def partition_shelves(
             for book_entry in shelf_node.children:
                 excluded_book_ids.add(book_entry['id'])
     return surviving, excluded_book_ids
+
+
+def selectable_children(
+    children: list[dict], resource_type: str,
+    node_filter: NodeFilter | None, node_type: str = "",
+) -> list[dict]:
+    """Apply the pre-GET type + name gate to a parent's child summaries.
+
+    Returns the child dicts that survive; the caller fetches each detail and
+    applies filter_empty afterward. node_type (when set) restricts to children
+    of that 'type' (used to pick pages vs chapters out of a book's contents).
+    """
+    selected: list[dict] = []
+    for child in children:
+        if node_type and child.get('type') != node_type:
+            log.debug("child of type: %s is not desired type: %s",
+                      child.get('type'), node_type)
+            continue
+        if node_filter and not node_filter.keep(child['name'], resource_type):
+            log.debug("'%s' (type=%s) excluded by filter",
+                      child['name'], resource_type)
+            continue
+        selected.append(child)
+    return selected

--- a/bookstack_file_exporter/exporter/selector.py
+++ b/bookstack_file_exporter/exporter/selector.py
@@ -1,0 +1,35 @@
+"""Pure filter/cascade decision functions for NodeExporter.
+
+No I/O. These functions decide *which* candidate nodes survive filtering and
+cascade suppression; NodeExporter performs the actual fetches and calls these
+before each detail GET so excluded nodes are never fetched.
+"""
+import logging
+
+from bookstack_file_exporter.exporter.node import Node
+from bookstack_file_exporter.exporter.filter import NodeFilter
+
+log = logging.getLogger(__name__)
+
+
+def partition_shelves(
+    shelf_nodes: dict[int, Node], node_filter: NodeFilter | None
+) -> tuple[dict[int, Node], set[int]]:
+    """Split fetched shelves into survivors and the book IDs to suppress.
+
+    Returns (surviving_shelves, excluded_book_ids). When no filter is
+    configured, all shelves survive and no books are suppressed.
+    """
+    if node_filter is None:
+        return shelf_nodes, set()
+    surviving: dict[int, Node] = {}
+    excluded_book_ids: set[int] = set()
+    for shelf_id, shelf_node in shelf_nodes.items():
+        if node_filter.keep(shelf_node.display_name, "shelves"):
+            surviving[shelf_id] = shelf_node
+        else:
+            log.debug("Shelf '%s' excluded by filter; suppressing its books",
+                      shelf_node.display_name)
+            for book_entry in shelf_node.children:
+                excluded_book_ids.add(book_entry['id'])
+    return surviving, excluded_book_ids

--- a/tests/unit/test_selector.py
+++ b/tests/unit/test_selector.py
@@ -36,3 +36,36 @@ def test_partition_shelves_drops_unmatched_and_records_book_ids():
     surviving, excluded = selector.partition_shelves(shelves, node_filter)
     assert set(surviving.keys()) == {1}
     assert excluded == {20, 21}
+
+
+def test_selectable_children_no_filter_no_type_returns_all():
+    children = [{"id": 1, "name": "a", "type": "page"},
+                {"id": 2, "name": "b", "type": "chapter"}]
+    result = selector.selectable_children(children, "pages", None)
+    assert result == children
+
+
+def test_selectable_children_type_gate_filters_by_type():
+    children = [{"id": 1, "name": "a", "type": "page"},
+                {"id": 2, "name": "b", "type": "chapter"}]
+    result = selector.selectable_children(children, "pages", None, node_type="page")
+    assert [c["id"] for c in result] == [1]
+
+
+def test_selectable_children_name_filter_excludes():
+    children = [{"id": 1, "name": "keep", "type": "chapter"},
+                {"id": 2, "name": "drop", "type": "chapter"}]
+    node_filter = _make_filter(chapters={"exclude": ["drop"]})
+    result = selector.selectable_children(children, "chapters", node_filter,
+                                          node_type="chapter")
+    assert [c["id"] for c in result] == [1]
+
+
+def test_selectable_children_type_and_name_gates_combined():
+    children = [{"id": 1, "name": "keep", "type": "chapter"},
+                {"id": 2, "name": "keep", "type": "page"},
+                {"id": 3, "name": "drop", "type": "chapter"}]
+    node_filter = _make_filter(chapters={"exclude": ["drop"]})
+    result = selector.selectable_children(children, "chapters", node_filter,
+                                          node_type="chapter")
+    assert [c["id"] for c in result] == [1]

--- a/tests/unit/test_selector.py
+++ b/tests/unit/test_selector.py
@@ -69,3 +69,30 @@ def test_selectable_children_type_and_name_gates_combined():
     result = selector.selectable_children(children, "chapters", node_filter,
                                           node_type="chapter")
     assert [c["id"] for c in result] == [1]
+
+
+def test_selectable_unassigned_books_skips_already_collected():
+    books = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+    result = selector.selectable_unassigned_books(books, {1}, set(), None)
+    assert result == [2]
+
+
+def test_selectable_unassigned_books_skips_excluded_ids():
+    books = [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}]
+    result = selector.selectable_unassigned_books(books, set(), {2}, None)
+    assert result == [1]
+
+
+def test_selectable_unassigned_books_applies_name_filter():
+    books = [{"id": 1, "name": "keep"}, {"id": 2, "name": "drop"}]
+    node_filter = _make_filter(books={"exclude": ["drop"]})
+    result = selector.selectable_unassigned_books(books, set(), set(), node_filter)
+    assert result == [1]
+
+
+def test_selectable_unassigned_books_all_gates_combined():
+    books = [{"id": 1, "name": "collected"}, {"id": 2, "name": "excluded"},
+             {"id": 3, "name": "drop"}, {"id": 4, "name": "keep"}]
+    node_filter = _make_filter(books={"exclude": ["drop"]})
+    result = selector.selectable_unassigned_books(books, {1}, {2}, node_filter)
+    assert result == [4]

--- a/tests/unit/test_selector.py
+++ b/tests/unit/test_selector.py
@@ -1,0 +1,38 @@
+# pylint: disable=missing-function-docstring,missing-module-docstring
+from bookstack_file_exporter.exporter import selector
+from bookstack_file_exporter.exporter.node import Node
+from bookstack_file_exporter.exporter.filter import NodeFilter
+from bookstack_file_exporter.config_helper.models import Filters, ResourceFilter
+
+
+def _make_filter(**kwargs) -> NodeFilter:
+    rf_kwargs = {k: ResourceFilter(**v) for k, v in kwargs.items()}
+    return NodeFilter(Filters(**rf_kwargs))
+
+
+def _shelf(shelf_id: int, name: str, book_ids: list[int]) -> Node:
+    meta = {
+        "id": shelf_id,
+        "slug": f"shelf-{shelf_id}",
+        "name": name,
+        "books": [{"id": bid, "name": f"book-{bid}"} for bid in book_ids],
+    }
+    return Node(meta)
+
+
+def test_partition_shelves_no_filter_passthrough():
+    shelves = {1: _shelf(1, "Keep", [10, 11])}
+    surviving, excluded = selector.partition_shelves(shelves, None)
+    assert surviving == shelves
+    assert excluded == set()
+
+
+def test_partition_shelves_drops_unmatched_and_records_book_ids():
+    shelves = {
+        1: _shelf(1, "keep-me", [10, 11]),
+        2: _shelf(2, "drop-me", [20, 21]),
+    }
+    node_filter = _make_filter(shelves={"include": ["keep-me"]})
+    surviving, excluded = selector.partition_shelves(shelves, node_filter)
+    assert set(surviving.keys()) == {1}
+    assert excluded == {20, 21}


### PR DESCRIPTION
## Changes

R6, the final refactor in the modularity charter: separate `NodeExporter` fetch (I/O) from tree/relationship logic. Approach A — functional core / imperative shell.

- New pure module `bookstack_file_exporter/exporter/selector.py` (zero I/O) with three decision functions extracted from `NodeExporter`:
  - `partition_shelves` — splits fetched shelves into survivors + the book IDs to suppress (cascade).
  - `selectable_children` — the pre-GET type + name gate for a parent's child summaries.
  - `selectable_unassigned_books` — the three pre-GET gates (already-collected / dropped-shelf / name filter) for shelfless books.
- `exporter.py` rewired to a thin shell: each fetch loop now calls `selector.<decide>(...)` **before** issuing detail GETs.
- Public `NodeExporter` API unchanged (signatures + observable behavior).
- `_excluded_book_ids` kept as instance state for the cross-method handoff; selectors compute exclusions purely, shell stores them.
- Rich gate-explanation comments migrated with the logic into the pure functions; shell keeps one-liners.

Stayed in the shell (correctly not extracted): `filter_empty` post-GET gate (needs `Node.empty` from the fetched detail), the `exclude_unassigned_books` toggle, and the `_excluded_book_ids` prune.

One documented behavior delta: `child['type']` → `child.get('type')` in the type gate — equivalent-or-safer (no KeyError on a missing `type` key).

## Motivation

`NodeExporter` interleaved network I/O directly inside tree-walking + cascade-suppression bookkeeping, so the relationship/exclusion logic could not be exercised without mocking HTTP at nearly every node. Extracting the decisions into a pure module makes that logic unit-testable without HTTP mocks and leaves a thin, readable I/O shell.

## Hard constraint preserved

The pre-GET filter optimization is intact: excluded shelves/books/chapters/pages never trigger a detail GET. All decisions happen before each fetch. The end-to-end "should never fetch excluded..." guard assertions in `test_node_exporter.py` still pass.

## Test plan

- New `tests/unit/test_selector.py` — pure tests, **zero HTTP mocks** (the acceptance win); `selector.py` at 100% coverage.
- `tests/unit/test_node_exporter.py` retained as shell integration coverage (pre-GET guarantee).
- `uv run pytest -q` → **429 passed**.
- `uv run pylint` on `selector.py` + `exporter.py` → **10.00/10**.

## In-depth

Approach B (planner/executor two-phase) was rejected: Bookstack returns child IDs only inside the parent's detail response, so the full graph can't be planned from cheap list calls — planning and fetching are inherently interleaved. No fetch orchestration (parallelism/batching) added; that would be the only thing justifying B later, at which point A's selectors become B's planner guts. No changes to `Node`, `NodeFilter`, `run.py`, or archiver.
