### PR TITLE
feat: CLI exit codes and graceful scheduled-mode lifecycle (F2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Command line options:
 | ------ | -------- | ----------- |
 |`-c`, `--config-file`|True|Relative or Absolute path to a valid configuration file. This configuration file is checked against a schema for validation.|
 |`-v`, `--log-level` |False, default: info|Provide a valid log level: info, debug, warning, error.|
+|`--run-once` |False|Force a single run and exit, ignoring `run_interval` in the config. Useful for a manual or CI-triggered run against a config that is otherwise set up for application (scheduled) mode.|
 
 #### Environment Variables
 See [Valid Environment Variables](#valid-environment-variables) for more options.
@@ -161,6 +162,14 @@ docker run \
     -v $(pwd)/config.yml:/export/config/config.yml:ro \
     homeylab/bookstack-file-exporter:latest
 ```
+
+#### Run Modes
+The exporter runs in one of two modes, selected automatically from your config:
+
+- **One-shot** (default): `run_interval` unset or `0` → runs once and exits. Returns exit code `0` on success, `1` on failure (clean error message; pass `-v debug` for the full traceback), and `130` on `Ctrl-C`. Pairs well with an external scheduler (Kubernetes `CronJob`, `cron`, `systemd` timer), which owns restart, backoff, and run history.
+- **Application / scheduled** (long-running): `run_interval` set → runs, sleeps `{run_interval}` seconds, repeats. For a single-container `docker compose` deployment with no external scheduler. A failed cycle is logged (and notifies, if configured) and waits for the next interval rather than crashing. Shuts down gracefully on `SIGTERM` (`docker stop`) and `SIGINT` (`Ctrl-C`), exiting `0`.
+
+Pass `--run-once` to force a single run regardless of `run_interval`.
 
 #### Docker Compose
 When using the configuration option: `run_interval`, a docker compose set up could be used to run the exporter as an always running application. The exporter will sleep and wait until `{run_interval}` seconds has elapsed before subsequent runs.

--- a/bookstack_file_exporter/__main__.py
+++ b/bookstack_file_exporter/__main__.py
@@ -1,16 +1,17 @@
 import argparse
 import logging
+import sys
 
 from bookstack_file_exporter import run
 from bookstack_file_exporter import run_args
 
-def main():
+def main() -> int:
     """run entrypoint"""
     args: argparse.Namespace = run_args.get_args()
     logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s',
                         level=run_args.get_log_level(args.log_level), datefmt='%Y-%m-%d %H:%M:%S')
-    run.entrypoint(args)
+    return run.entrypoint(args)
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -1,6 +1,7 @@
 import argparse
 import logging
-import time
+import signal
+import threading
 
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
 from bookstack_file_exporter.exporter.node import Node
@@ -13,16 +14,66 @@ from bookstack_file_exporter.notify.models import NotifyResult
 
 log = logging.getLogger(__name__)
 
-def entrypoint(args: argparse.Namespace):
-    """entrypoint for export process"""
-    config = ConfigNode(args)
-    if not config.user_inputs.run_interval:
+
+def entrypoint(args: argparse.Namespace) -> int:
+    """Entrypoint for the export process. Returns an exit code."""
+    try:
+        config = ConfigNode(args)
+    except Exception as err:  # pylint: disable=broad-except
+        log.error("Configuration error: %s", err)
+        log.debug("Traceback:", exc_info=True)
+        return 1
+
+    if getattr(args, "run_once", False) or not config.user_inputs.run_interval:
+        return _run_once(config)
+    return _run_scheduled(config)
+
+
+def _run_once(config: ConfigNode) -> int:
+    """Run the export exactly once and return an exit code."""
+    try:
         run(config)
-        return
-    while True:
-        run(config)
-        log.info("Waiting %s seconds for next run", config.user_inputs.run_interval)
-        time.sleep(config.user_inputs.run_interval)
+        return 0
+    except KeyboardInterrupt:
+        log.info("Interrupted, exiting")
+        return 130
+    except Exception as err:  # pylint: disable=broad-except
+        log.error("Export failed: %s", err)
+        log.debug("Traceback:", exc_info=True)
+        return 1
+
+
+def _run_scheduled(config: ConfigNode) -> int:
+    """Run the export on a repeating interval until a stop signal is received."""
+    stop = threading.Event()
+    interval = config.user_inputs.run_interval
+
+    def _handle_signal(signum, _frame):
+        log.info("Received signal %s, shutting down", signum)
+        stop.set()
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
+    while not stop.is_set():
+        try:
+            run(config)
+        except Exception as err:  # pylint: disable=broad-except
+            # log-and-continue: a failed cycle still waits the interval below
+            # before retrying (no busy-loop), and the failure notification has
+            # already fired inside run().
+            log.error("Export failed: %s", err)
+            log.debug("Traceback:", exc_info=True)
+
+        if stop.is_set():
+            break
+
+        log.info("Waiting %s seconds for next run", interval)
+        stop.wait(interval)
+
+    log.info("Shutdown complete")
+    return 0
+
 
 def run(config: ConfigNode):
     """run export process with error handling and notification support"""

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -33,4 +33,9 @@ def get_args() -> argparse.Namespace:
                     default='info',
                     help='Set verbosity level for logging.',
                     choices=LOG_LEVEL.keys())
+    parser.add_argument('--run-once',
+                    action='store_true',
+                    default=False,
+                    help=('Force a single run and exit regardless of'
+                          ' run_interval/run_schedule in config.'))
     return parser.parse_args()

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,0 +1,52 @@
+"""Tests for __main__.main() return type and sys.exit wiring."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+import sys
+from unittest.mock import patch
+
+from bookstack_file_exporter import run
+from bookstack_file_exporter.__main__ import main
+
+
+class TestMainReturnType:
+    def test_main_returns_int(self):
+        """main() must return an int so sys.exit() gets a proper code."""
+        with patch.object(run, "entrypoint", return_value=0), \
+             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
+             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.logging.basicConfig"):
+            result = main()
+        assert isinstance(result, int)
+
+    def test_main_propagates_entrypoint_return_value(self):
+        """main() must return exactly what entrypoint() returns."""
+        sentinel = 42
+        with patch.object(run, "entrypoint", return_value=sentinel), \
+             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
+             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.logging.basicConfig"):
+            result = main()
+        assert result == sentinel
+
+
+class TestSysExitWiring:
+    def test_sys_exit_receives_main_return_value(self):
+        """sys.exit(main()) must propagate entrypoint's int to the process exit code."""
+        sentinel = 7
+        with patch.object(run, "entrypoint", return_value=sentinel), \
+             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
+             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.logging.basicConfig"), \
+             patch("sys.exit") as mock_exit:
+            # Simulate the guard block: sys.exit(main())
+            sys.exit(main())
+        mock_exit.assert_called_once_with(sentinel)
+
+    def test_main_failure_code_reaches_sys_exit(self):
+        """A failure code (1) from entrypoint must reach sys.exit unchanged."""
+        with patch.object(run, "entrypoint", return_value=1), \
+             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
+             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.logging.basicConfig"), \
+             patch("sys.exit") as mock_exit:
+            sys.exit(main())
+        mock_exit.assert_called_once_with(1)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -2,36 +2,266 @@
 export-level node selection in run.exporter."""
 # pylint: disable=missing-class-docstring,missing-function-docstring,unused-argument
 import logging
+import signal
+import threading
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from bookstack_file_exporter import run
 from bookstack_file_exporter.notify.models import NotifyResult
 
 
-def _config(run_interval):
+def _config(run_interval, run_once=False):
+    """Return a minimal fake args + config pair for entrypoint tests."""
     return SimpleNamespace(user_inputs=SimpleNamespace(run_interval=run_interval))
 
+
+def _args(run_once=False):
+    return SimpleNamespace(run_once=run_once)
+
+
+# ---------------------------------------------------------------------------
+# entrypoint() — config build failure
+# ---------------------------------------------------------------------------
+
+class TestEntrypointConfigError:
+    def test_config_error_returns_1(self, caplog):
+        with patch.object(run, "ConfigNode", side_effect=ValueError("bad config")), \
+             caplog.at_level(logging.ERROR, logger="bookstack_file_exporter.run"):
+            result = run.entrypoint(args=_args())
+        assert result == 1
+        assert any("Configuration error" in r.message for r in caplog.records)
+
+    def test_config_error_does_not_propagate(self):
+        with patch.object(run, "ConfigNode", side_effect=RuntimeError("boom")):
+            result = run.entrypoint(args=_args())
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# _run_once() via entrypoint() — one-shot path
+# ---------------------------------------------------------------------------
+
+class TestRunOncePath:
+    def _cfg_no_interval(self):
+        return _config(run_interval=0)
+
+    def test_success_returns_0(self):
+        cfg = self._cfg_no_interval()
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run"):
+            result = run.entrypoint(args=_args())
+        assert result == 0
+
+    def test_run_raises_exception_returns_1(self, caplog):
+        cfg = self._cfg_no_interval()
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=RuntimeError("export boom")), \
+             caplog.at_level(logging.ERROR, logger="bookstack_file_exporter.run"):
+            result = run.entrypoint(args=_args())
+        assert result == 1
+        assert any("Export failed" in r.message for r in caplog.records)
+
+    def test_run_raises_exception_no_traceback_propagated(self):
+        """Exception must NOT escape entrypoint."""
+        cfg = self._cfg_no_interval()
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=RuntimeError("boom")):
+            # should not raise
+            result = run.entrypoint(args=_args())
+        assert result == 1
+
+    def test_keyboard_interrupt_returns_130(self):
+        cfg = self._cfg_no_interval()
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=KeyboardInterrupt):
+            result = run.entrypoint(args=_args())
+        assert result == 130
+
+
+# ---------------------------------------------------------------------------
+# run_once flag forces _run_once even when run_interval is set
+# ---------------------------------------------------------------------------
+
+class TestRunOnceFlag:
+    def test_run_once_flag_true_forces_single_run_even_with_interval(self):
+        cfg = _config(run_interval=60)
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run") as mock_run:
+            result = run.entrypoint(args=_args(run_once=True))
+        assert result == 0
+        assert mock_run.call_count == 1
+
+    def test_run_once_flag_false_with_no_interval_still_runs_once(self):
+        cfg = _config(run_interval=0)
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run") as mock_run:
+            result = run.entrypoint(args=_args(run_once=False))
+        assert result == 0
+        assert mock_run.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _run_scheduled() via entrypoint() — daemon path
+# ---------------------------------------------------------------------------
+
+class TestRunScheduledPath:
+    def _cfg_with_interval(self, interval=5):
+        return _config(run_interval=interval)
+
+    def test_sigterm_and_sigint_handlers_installed(self):
+        """signal.signal must be called for both SIGTERM and SIGINT."""
+        cfg = self._cfg_with_interval()
+        stop_event = threading.Event()
+
+        def _run_side_effect(_config):
+            stop_event.set()  # signal stop after first call so loop exits
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal") as mock_signal, \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        installed_signals = {c.args[0] for c in mock_signal.call_args_list}
+        assert signal.SIGTERM in installed_signals
+        assert signal.SIGINT in installed_signals
+
+    def test_cycle_exception_loop_continues(self):
+        """A per-cycle Exception must not kill the scheduled loop; run() is called again."""
+        cfg = self._cfg_with_interval(interval=1)
+        stop_event = threading.Event()
+        call_count = 0
+
+        def _run_side_effect(_config):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise RuntimeError("transient failure")
+            stop_event.set()  # exit on second call
+
+        # no-op wait so the inter-cycle interval does not actually block the test
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch.object(stop_event, "wait", return_value=False), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        assert call_count == 2
+
+    def test_failed_cycle_still_waits_before_retry(self):
+        """A failed cycle must wait the interval before retrying (no busy-loop).
+
+        Regression guard: an earlier draft used `continue` after logging the
+        error, skipping stop.wait() — so a persistently failing Bookstack would
+        hammer run() with zero delay. The failed cycle must reach stop.wait().
+        """
+        cfg = self._cfg_with_interval(interval=5)
+        stop_event = threading.Event()
+        call_count = 0
+
+        def _run_side_effect(_config):
+            nonlocal call_count
+            call_count += 1
+            raise RuntimeError("persistent failure")
+
+        def _wait_side_effect(timeout=None):
+            # stop the loop on the wait that follows the failed cycle
+            stop_event.set()
+            return False
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch.object(stop_event, "wait", side_effect=_wait_side_effect) as mock_wait, \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        # the failed cycle reached the interval wait rather than spinning
+        mock_wait.assert_called_once_with(5)
+        assert call_count == 1
+
+    def test_stop_event_exits_loop_with_0(self):
+        """When stop event is set (e.g. via signal), _run_scheduled returns 0."""
+        cfg = self._cfg_with_interval()
+        stop_event = threading.Event()
+
+        def _run_side_effect(_config):
+            stop_event.set()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+
+    def test_stop_wait_used_not_time_sleep(self):
+        """The scheduled loop must use stop.wait(interval) not time.sleep.
+
+        Simulate: run() completes normally; then stop.wait() is called and the
+        wait itself sets the event (as if a signal arrived mid-wait), causing
+        the next loop check to exit.
+        """
+        cfg = self._cfg_with_interval(interval=5)
+        stop_event = threading.Event()
+
+        # Patch stop_event.wait so that calling it sets the event (simulating
+        # SIGINT arriving during the sleep interval), then delegates to the real wait.
+        real_wait = stop_event.wait
+
+        def _wait_side_effect(timeout=None):
+            stop_event.set()
+            return real_wait(0)  # return immediately
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run"), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch.object(stop_event, "wait", side_effect=_wait_side_effect) as mock_wait, \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        # wait should have been called with the interval value
+        mock_wait.assert_called_with(5)
+
+
+# ---------------------------------------------------------------------------
+# Legacy entrypoint tests — updated for int-returning API + Event.wait loop
+# ---------------------------------------------------------------------------
 
 def test_entrypoint_runs_once_when_no_interval():
     cfg = _config(run_interval=0)
     with patch.object(run, "ConfigNode", return_value=cfg), \
          patch.object(run, "run") as mock_run:
-        run.entrypoint(args=object())
+        result = run.entrypoint(args=_args())
+    assert result == 0
     assert mock_run.call_count == 1
 
 
 def test_entrypoint_loops_when_interval_set():
     cfg = _config(run_interval=5)
-    # break out of the infinite loop after the first sleep
+    stop_event = threading.Event()
+    call_count = 0
+
+    def _run_side_effect(_config):
+        nonlocal call_count
+        call_count += 1
+        stop_event.set()  # exit after first iteration
+
     with patch.object(run, "ConfigNode", return_value=cfg), \
-         patch.object(run, "run") as mock_run, \
-         patch.object(run.time, "sleep", side_effect=InterruptedError):
-        try:
-            run.entrypoint(args=object())
-        except InterruptedError:
-            pass
-    assert mock_run.call_count == 1
+         patch.object(run, "run", side_effect=_run_side_effect), \
+         patch("bookstack_file_exporter.run.signal.signal"), \
+         patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+        result = run.entrypoint(args=_args())
+
+    assert result == 0
+    assert call_count == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

Reworks the top-level process lifecycle (F2) so both run modes behave correctly. No behavior change to the export logic itself.

- **One-shot mode** (`run_interval` unset or `0`): `main()` now returns an `int` and `sys.exit(main())` propagates it. Exit `0` on success, `1` on failure (clean logged error; full traceback only under `-v debug`), `130` on `Ctrl-C`.
- **Scheduled mode** (`run_interval` set): installs `SIGTERM`/`SIGINT` handlers and uses a `threading.Event` for interruptible sleep, so `docker stop` / `Ctrl-C` shut the daemon down gracefully (exit `0`) instead of dumping a traceback.
- **Per-cycle error policy** in scheduled mode is **log-and-continue**: a failed cycle is logged (and notifies, if configured), then waits the full interval before retrying — no crash, no busy-loop.
- New `--run-once` flag forces a single run regardless of `run_interval` (watchtower-style override).
- README documents the run modes and the new flag.

## Motivation

Previously `main()` returned `None` (no exit code), failures surfaced as raw tracebacks, and the interval loop had no signal handling — `Ctrl-C`/`SIGTERM` dumped a traceback instead of exiting cleanly, and any exception killed the daemon. This makes exit codes scriptable, errors readable, and the scheduled daemon resilient and well-behaved under orchestrators.

## Test plan

- `uv run pytest` — full suite green (446 passing; +1 new `test_main.py` plus added `test_run.py` cases).
- New/updated tests cover: exit codes (0/1/130), config-error path, `--run-once` override, signal-handler installation, log-and-continue across a failed cycle, graceful stop-event exit, and a regression test proving a failed cycle still waits the interval before retrying (anti-busy-loop guard).
- Determinism: tests patch `signal.signal` and `Event.wait` — no real signals or sleeps.
- `uv run pylint bookstack_file_exporter` — 9.99/10 (only the pre-existing broad-except `W0718` on `run()`).

## In-depth

- **Run-mode selection** stays config-driven (`run_interval` → daemon) with `--run-once` as an explicit override, rather than adding a separate mode flag.
- **Exit-code taxonomy** kept minimal (`0`/`1`/`130`); no config-vs-runtime distinction until a consumer needs it (YAGNI).
- Scoped to F2 only. Follow-ups (separate PRs): F3 cron, F4 health endpoint, Fix-4 standalone asset gate.
