### PR TITLE
feat: add opt-in JSON-structured logging toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Command line options:
 | ------ | -------- | ----------- |
 |`-c`, `--config-file`|True|Relative or Absolute path to a valid configuration file. This configuration file is checked against a schema for validation.|
 |`-v`, `--log-level` |False, default: info|Provide a valid log level: info, debug, warning, error.|
+|`--log-format` |False, default: text|Log output format. `text` (default) or `json` for JSON Lines. CLI overrides the `LOG_FORMAT` env var.|
 |`--run-once` |False|Force a single run and exit, ignoring `run_interval` in the config. Useful for a manual or CI-triggered run against a config that is otherwise set up for application (scheduled) mode.|
 
 #### Environment Variables
@@ -132,6 +133,23 @@ export LOG_LEVEL=debug
 
 # using pip
 python -m bookstack_file_exporter -c <path_to_config_file>
+```
+
+### Log Format
+
+By default logs are human-readable text. Set JSON Lines output (one JSON object
+per line) for log aggregators (Loki/ELK/CloudWatch):
+
+- CLI: `--log-format json`
+- Env (containers): `LOG_FORMAT=json`
+
+The CLI flag overrides the env var; default is `text`. An unrecognized
+`LOG_FORMAT` value falls back to `text` with a warning.
+
+Sample JSON line:
+
+```json
+{"timestamp": "2026-06-21T05:03:59Z", "level": "INFO", "logger": "bookstack_file_exporter.run", "message": "Beginning run"}
 ```
 
 ### Run via Docker
@@ -326,6 +344,7 @@ More descriptions can be found for each section below:
 #### Valid Environment Variables
 General
 - `LOG_LEVEL`: default: `info`. Provide a valid log level: info, debug, warning, error.
+- `LOG_FORMAT`: default: `text`. Set to `json` for JSON Lines output. See [Log Format](#log-format).
 
 [Bookstack Credentials](#authentication)
 - `BOOKSTACK_TOKEN_ID`

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ The CLI flag overrides the env var; default is `text`. An unrecognized
 Sample JSON line:
 
 ```json
-{"timestamp": "2026-06-21T05:03:59Z", "level": "INFO", "logger": "bookstack_file_exporter.run", "message": "Beginning run"}
+{"timestamp": "2026-06-21T05:03:59.123Z", "level": "INFO", "logger": "bookstack_file_exporter.run", "message": "Beginning run"}
 ```
 
 ### Run via Docker

--- a/bookstack_file_exporter/__main__.py
+++ b/bookstack_file_exporter/__main__.py
@@ -7,9 +7,9 @@ from bookstack_file_exporter import run_args
 from bookstack_file_exporter.common import logging as bfe_logging
 
 
-def main() -> int:
-    """run entrypoint"""
-    args: argparse.Namespace = run_args.get_args()
+def main(argv=None) -> int:
+    """run entrypoint (argv=None -> sys.argv)"""
+    args: argparse.Namespace = run_args.get_args(argv)
     logging.basicConfig(
         level=run_args.get_log_level(args.log_level),
         handlers=[bfe_logging.build_handler(run_args.resolve_log_format(args))])

--- a/bookstack_file_exporter/__main__.py
+++ b/bookstack_file_exporter/__main__.py
@@ -6,6 +6,7 @@ from bookstack_file_exporter import run
 from bookstack_file_exporter import run_args
 from bookstack_file_exporter.common import logging as bfe_logging
 
+
 def main() -> int:
     """run entrypoint"""
     args: argparse.Namespace = run_args.get_args()

--- a/bookstack_file_exporter/__main__.py
+++ b/bookstack_file_exporter/__main__.py
@@ -4,12 +4,14 @@ import sys
 
 from bookstack_file_exporter import run
 from bookstack_file_exporter import run_args
+from bookstack_file_exporter.common import logging as bfe_logging
 
 def main() -> int:
     """run entrypoint"""
     args: argparse.Namespace = run_args.get_args()
-    logging.basicConfig(format='%(asctime)s [%(levelname)s] %(message)s',
-                        level=run_args.get_log_level(args.log_level), datefmt='%Y-%m-%d %H:%M:%S')
+    logging.basicConfig(
+        level=run_args.get_log_level(args.log_level),
+        handlers=[bfe_logging.build_handler(run_args.resolve_log_format(args))])
     return run.entrypoint(args)
 
 

--- a/bookstack_file_exporter/common/logging.py
+++ b/bookstack_file_exporter/common/logging.py
@@ -17,9 +17,10 @@ class JsonFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord) -> str:
         record.message = record.getMessage()
+        ts = datetime.fromtimestamp(record.created, tz=timezone.utc)
         out = {
-            "timestamp": datetime.fromtimestamp(
-                record.created, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            # millisecond precision so aggregators can order within a second
+            "timestamp": f"{ts.strftime('%Y-%m-%dT%H:%M:%S')}.{int(record.msecs):03d}Z",
             "level": record.levelname,
             "logger": record.name,
             "message": record.message,
@@ -29,6 +30,8 @@ class JsonFormatter(logging.Formatter):
                 out[key] = val
         if record.exc_info:
             out["exc_info"] = self.formatException(record.exc_info)
+        if record.stack_info:
+            out["stack_info"] = self.formatStack(record.stack_info)
         return json.dumps(out, default=str)
 
 

--- a/bookstack_file_exporter/common/logging.py
+++ b/bookstack_file_exporter/common/logging.py
@@ -30,3 +30,17 @@ class JsonFormatter(logging.Formatter):
         if record.exc_info:
             out["exc_info"] = self.formatException(record.exc_info)
         return json.dumps(out, default=str)
+
+
+_TEXT_FMT = "%(asctime)s [%(levelname)s] %(message)s"
+_DATE_FMT = "%Y-%m-%d %H:%M:%S"
+
+
+def build_handler(log_format: str) -> logging.StreamHandler:
+    """Return a stream handler whose formatter matches `log_format`."""
+    handler = logging.StreamHandler()
+    if log_format == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(_TEXT_FMT, datefmt=_DATE_FMT))
+    return handler

--- a/bookstack_file_exporter/common/logging.py
+++ b/bookstack_file_exporter/common/logging.py
@@ -1,0 +1,32 @@
+import json
+import logging
+from datetime import datetime, timezone
+
+# Standard LogRecord attributes; anything else on a record is a user-supplied
+# `extra={}` field and gets merged into the JSON output.
+_RESERVED_ATTRS = frozenset({
+    "args", "asctime", "created", "exc_info", "exc_text", "filename",
+    "funcName", "levelname", "levelno", "lineno", "module", "msecs",
+    "message", "msg", "name", "pathname", "process", "processName",
+    "relativeCreated", "stack_info", "thread", "threadName", "taskName",
+})
+
+
+class JsonFormatter(logging.Formatter):
+    """Render each LogRecord as one JSON object (JSON Lines)."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        record.message = record.getMessage()
+        out = {
+            "timestamp": datetime.fromtimestamp(
+                record.created, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.message,
+        }
+        for key, val in record.__dict__.items():
+            if key not in _RESERVED_ATTRS:
+                out[key] = val
+        if record.exc_info:
+            out["exc_info"] = self.formatException(record.exc_info)
+        return json.dumps(out, default=str)

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -88,7 +88,7 @@ def run(config: ConfigNode):
         try:
             notif = NotifyHandler(config.user_inputs.notifications)
             notif.do_notify(run_err)
-        except Exception as notif_err:
+        except Exception as notif_err:  # pylint: disable=broad-exception-caught
             log.error("Failed to send notification: %s", str(notif_err))
         # raise original error instead of notification error
         raise run_err

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -14,6 +14,7 @@ LOG_LEVEL = {
 LOG_FORMAT = ("text", "json")
 _LOG_FORMAT_ENV = "LOG_FORMAT"
 
+
 def get_log_level(log_level:str) -> int:
     """return log level int"""
     return LOG_LEVEL[log_level]

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -19,8 +19,8 @@ def get_log_level(log_level:str) -> int:
     """return log level int"""
     return LOG_LEVEL[log_level]
 
-def get_args() -> argparse.Namespace:
-    """return user cmd line options"""
+def get_args(argv=None) -> argparse.Namespace:
+    """return user cmd line options (argv=None -> sys.argv)"""
     parser = argparse.ArgumentParser(description='BookStack File Exporter')
     parser.add_argument('-c',
                     '--config-file',
@@ -51,7 +51,7 @@ def get_args() -> argparse.Namespace:
                     help=('Log output format. CLI overrides the LOG_FORMAT'
                           ' env var; default text.'),
                     choices=LOG_FORMAT)
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
 def resolve_log_format(args: argparse.Namespace) -> str:

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -1,5 +1,8 @@
 import argparse
 import logging
+import os
+
+log = logging.getLogger(__name__)
 
 LOG_LEVEL = {
     'debug': logging.DEBUG,
@@ -7,6 +10,9 @@ LOG_LEVEL = {
     'warning': logging.WARNING,
     'error': logging.ERROR
 }
+
+LOG_FORMAT = ("text", "json")
+_LOG_FORMAT_ENV = "LOG_FORMAT"
 
 def get_log_level(log_level:str) -> int:
     """return log level int"""
@@ -38,4 +44,28 @@ def get_args() -> argparse.Namespace:
                     default=False,
                     help=('Force a single run and exit regardless of'
                           ' run_interval/run_schedule in config.'))
+    parser.add_argument('--log-format',
+                    type=str.lower,
+                    default=None,
+                    help=('Log output format. CLI overrides the LOG_FORMAT'
+                          ' env var; default text.'),
+                    choices=LOG_FORMAT)
     return parser.parse_args()
+
+
+def resolve_log_format(args: argparse.Namespace) -> str:
+    """Resolve log format: CLI flag, else LOG_FORMAT env, else text.
+
+    An invalid env value falls back to text (does not crash a container).
+    """
+    if args.log_format is not None:
+        return args.log_format  # argparse `choices` already validated this
+    env_val = os.environ.get(_LOG_FORMAT_ENV)
+    if env_val is None:
+        return "text"
+    env_val = env_val.lower()
+    if env_val in LOG_FORMAT:
+        return env_val
+    log.warning("Invalid %s '%s'; supported: text (default), json. Using text.",
+                _LOG_FORMAT_ENV, env_val)
+    return "text"

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -1,4 +1,6 @@
 ---
+# Logging: text by default. For JSON Lines output (aggregators), run with
+# --log-format json or set LOG_FORMAT=json. See README "Log Format".
 # if http/https not specified, defaults to https
 # if you put http here, it will try verify=false, not to check certs
 host: "https://bookstack.mydomain.org"

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -56,6 +56,14 @@ class TestJsonFormatterExcInfo:
         assert "exc_info" in out
         assert "ValueError: boom" in out["exc_info"]
 
+    def test_output_is_single_line_with_exc_info(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            rec = _record(exc_info=sys.exc_info())
+        line = JsonFormatter().format(rec)  # pylint: disable=used-before-assignment
+        assert "\n" not in line
+
     def test_exc_info_field_absent_when_no_exception(self):
         out = json.loads(JsonFormatter().format(_record()))
         assert "exc_info" not in out

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -5,7 +5,7 @@ import logging
 import re
 import sys
 
-from bookstack_file_exporter.common.logging import JsonFormatter
+from bookstack_file_exporter.common.logging import JsonFormatter, build_handler
 
 
 def _record(msg="hello %s", args=("world",), exc_info=None, **extra):
@@ -59,3 +59,22 @@ class TestJsonFormatterExcInfo:
     def test_exc_info_field_absent_when_no_exception(self):
         out = json.loads(JsonFormatter().format(_record()))
         assert "exc_info" not in out
+
+
+class TestBuildHandler:
+    def test_json_format_uses_jsonformatter(self):
+        handler = build_handler("json")
+        assert isinstance(handler.formatter, JsonFormatter)
+
+    def test_text_format_uses_plain_formatter(self):
+        handler = build_handler("text")
+        assert isinstance(handler.formatter, logging.Formatter)
+        assert not isinstance(handler.formatter, JsonFormatter)
+
+    def test_text_handler_renders_classic_line(self):
+        handler = build_handler("text")
+        rendered = handler.formatter.format(_record(msg="done", args=()))
+        assert rendered.endswith("[INFO] done")
+
+    def test_returns_stream_handler(self):
+        assert isinstance(build_handler("text"), logging.StreamHandler)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -1,0 +1,61 @@
+"""Tests for the JSON logging formatter and handler factory."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+import json
+import logging
+import re
+import sys
+
+from bookstack_file_exporter.common.logging import JsonFormatter
+
+
+def _record(msg="hello %s", args=("world",), exc_info=None, **extra):
+    rec = logging.LogRecord(
+        name="mod.sub", level=logging.INFO, pathname="p.py", lineno=10,
+        msg=msg, args=args, exc_info=exc_info,
+    )
+    for key, val in extra.items():
+        setattr(rec, key, val)
+    return rec
+
+
+class TestJsonFormatterCore:
+    def test_core_fields_present(self):
+        out = json.loads(JsonFormatter().format(_record()))
+        assert out["level"] == "INFO"
+        assert out["logger"] == "mod.sub"
+        assert out["message"] == "hello world"
+        assert "timestamp" in out
+
+    def test_timestamp_is_iso8601_utc(self):
+        out = json.loads(JsonFormatter().format(_record()))
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", out["timestamp"])
+
+    def test_output_is_single_line(self):
+        line = JsonFormatter().format(_record())
+        assert "\n" not in line
+
+
+class TestJsonFormatterExtras:
+    def test_extra_fields_merged(self):
+        out = json.loads(JsonFormatter().format(_record(node_count=314, remote=True)))
+        assert out["node_count"] == 314
+        assert out["remote"] is True
+
+    def test_non_serializable_extra_coerced_to_str(self):
+        out = json.loads(JsonFormatter().format(_record(obj=object())))
+        assert isinstance(out["obj"], str)
+
+
+class TestJsonFormatterExcInfo:
+    def test_exc_info_field_present_on_exception(self):
+        try:
+            raise ValueError("boom")
+        except ValueError:
+            rec = _record(exc_info=sys.exc_info())
+        out = json.loads(JsonFormatter().format(rec))
+        assert "exc_info" in out
+        assert "ValueError: boom" in out["exc_info"]
+
+    def test_exc_info_field_absent_when_no_exception(self):
+        out = json.loads(JsonFormatter().format(_record()))
+        assert "exc_info" not in out

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -26,9 +26,10 @@ class TestJsonFormatterCore:
         assert out["message"] == "hello world"
         assert "timestamp" in out
 
-    def test_timestamp_is_iso8601_utc(self):
+    def test_timestamp_is_iso8601_utc_with_millis(self):
         out = json.loads(JsonFormatter().format(_record()))
-        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", out["timestamp"])
+        assert re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z", out["timestamp"])
 
     def test_output_is_single_line(self):
         line = JsonFormatter().format(_record())
@@ -67,6 +68,17 @@ class TestJsonFormatterExcInfo:
     def test_exc_info_field_absent_when_no_exception(self):
         out = json.loads(JsonFormatter().format(_record()))
         assert "exc_info" not in out
+
+
+class TestJsonFormatterStackInfo:
+    def test_stack_info_field_present_when_set(self):
+        out = json.loads(JsonFormatter().format(
+            _record(stack_info="Stack (most recent call last):\n  frobnicate")))
+        assert "frobnicate" in out["stack_info"]
+
+    def test_stack_info_field_absent_when_unset(self):
+        out = json.loads(JsonFormatter().format(_record()))
+        assert "stack_info" not in out
 
 
 class TestBuildHandler:

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -52,7 +52,7 @@ class TestJsonFormatterExcInfo:
             raise ValueError("boom")
         except ValueError:
             rec = _record(exc_info=sys.exc_info())
-        out = json.loads(JsonFormatter().format(rec))
+        out = json.loads(JsonFormatter().format(rec))  # pylint: disable=used-before-assignment
         assert "exc_info" in out
         assert "ValueError: boom" in out["exc_info"]
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -6,31 +6,26 @@ from unittest.mock import patch
 from bookstack_file_exporter import run
 from bookstack_file_exporter.__main__ import main
 
+# Real argv so main() runs the real get_args -> get_log_level -> resolve_log_format
+# -> build_handler chain. Only the genuine boundaries are patched per test:
+# run.entrypoint (network + disk) and logging.basicConfig (global root logger).
+_ARGV = ("--log-format", "text")
+
 
 class TestMainReturnType:
     def test_main_returns_int(self):
         """main() must return an int so sys.exit() gets a proper code."""
         with patch.object(run, "entrypoint", return_value=0), \
-             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
-             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
-             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
-                   return_value="text"), \
-             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"):
-            result = main()
+            result = main(_ARGV)
         assert isinstance(result, int)
 
     def test_main_propagates_entrypoint_return_value(self):
         """main() must return exactly what entrypoint() returns."""
         sentinel = 42
         with patch.object(run, "entrypoint", return_value=sentinel), \
-             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
-             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
-             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
-                   return_value="text"), \
-             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"):
-            result = main()
+            result = main(_ARGV)
         assert result == sentinel
 
 
@@ -39,26 +34,16 @@ class TestSysExitWiring:
         """sys.exit(main()) must propagate entrypoint's int to the process exit code."""
         sentinel = 7
         with patch.object(run, "entrypoint", return_value=sentinel), \
-             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
-             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
-             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
-                   return_value="text"), \
-             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"), \
              patch("sys.exit") as mock_exit:
             # Simulate the guard block: sys.exit(main())
-            sys.exit(main())
+            sys.exit(main(_ARGV))
         mock_exit.assert_called_once_with(sentinel)
 
     def test_main_failure_code_reaches_sys_exit(self):
         """A failure code (1) from entrypoint must reach sys.exit unchanged."""
         with patch.object(run, "entrypoint", return_value=1), \
-             patch("bookstack_file_exporter.__main__.run_args.get_args"), \
-             patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
-             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
-                   return_value="text"), \
-             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"), \
              patch("sys.exit") as mock_exit:
-            sys.exit(main())
+            sys.exit(main(_ARGV))
         mock_exit.assert_called_once_with(1)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -13,6 +13,9 @@ class TestMainReturnType:
         with patch.object(run, "entrypoint", return_value=0), \
              patch("bookstack_file_exporter.__main__.run_args.get_args"), \
              patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
+                   return_value="text"), \
+             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"):
             result = main()
         assert isinstance(result, int)
@@ -23,6 +26,9 @@ class TestMainReturnType:
         with patch.object(run, "entrypoint", return_value=sentinel), \
              patch("bookstack_file_exporter.__main__.run_args.get_args"), \
              patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
+                   return_value="text"), \
+             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"):
             result = main()
         assert result == sentinel
@@ -35,6 +41,9 @@ class TestSysExitWiring:
         with patch.object(run, "entrypoint", return_value=sentinel), \
              patch("bookstack_file_exporter.__main__.run_args.get_args"), \
              patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
+                   return_value="text"), \
+             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"), \
              patch("sys.exit") as mock_exit:
             # Simulate the guard block: sys.exit(main())
@@ -46,6 +55,9 @@ class TestSysExitWiring:
         with patch.object(run, "entrypoint", return_value=1), \
              patch("bookstack_file_exporter.__main__.run_args.get_args"), \
              patch("bookstack_file_exporter.__main__.run_args.get_log_level", return_value=20), \
+             patch("bookstack_file_exporter.__main__.run_args.resolve_log_format",
+                   return_value="text"), \
+             patch("bookstack_file_exporter.__main__.bfe_logging.build_handler"), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig"), \
              patch("sys.exit") as mock_exit:
             sys.exit(main())

--- a/tests/unit/test_run_args.py
+++ b/tests/unit/test_run_args.py
@@ -1,0 +1,47 @@
+"""Tests for run_args log-format flag parsing and precedence resolution."""
+# pylint: disable=missing-class-docstring,missing-function-docstring
+import argparse
+import logging
+import sys
+
+from bookstack_file_exporter import run_args
+
+
+def _args(log_format=None):
+    return argparse.Namespace(log_format=log_format)
+
+
+class TestLogFormatArg:
+    def test_default_is_none(self, monkeypatch):
+        # --log-format absent -> None (so resolve_log_format can fall to env)
+        monkeypatch.setattr(sys, "argv", ["prog"])
+        assert run_args.get_args().log_format is None
+
+    def test_flag_parsed_and_lowercased(self, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["prog", "--log-format", "JSON"])
+        assert run_args.get_args().log_format == "json"
+
+
+class TestResolveLogFormat:
+    def test_cli_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("LOG_FORMAT", "text")
+        assert run_args.resolve_log_format(_args(log_format="json")) == "json"
+
+    def test_env_used_when_no_flag(self, monkeypatch):
+        monkeypatch.setenv("LOG_FORMAT", "json")
+        assert run_args.resolve_log_format(_args()) == "json"
+
+    def test_env_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("LOG_FORMAT", "JSON")
+        assert run_args.resolve_log_format(_args()) == "json"
+
+    def test_default_text_when_neither(self, monkeypatch):
+        monkeypatch.delenv("LOG_FORMAT", raising=False)
+        assert run_args.resolve_log_format(_args()) == "text"
+
+    def test_invalid_env_falls_back_to_text_with_warning(self, monkeypatch, caplog):
+        monkeypatch.setenv("LOG_FORMAT", "yaml")
+        with caplog.at_level(logging.WARNING):
+            assert run_args.resolve_log_format(_args()) == "text"
+        assert any("yaml" in r.message and "LOG_FORMAT" in r.message
+                   for r in caplog.records)

--- a/tests/unit/test_run_args.py
+++ b/tests/unit/test_run_args.py
@@ -2,7 +2,6 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import argparse
 import logging
-import sys
 
 from bookstack_file_exporter import run_args
 
@@ -12,14 +11,12 @@ def _args(log_format=None):
 
 
 class TestLogFormatArg:
-    def test_default_is_none(self, monkeypatch):
+    def test_default_is_none(self):
         # --log-format absent -> None (so resolve_log_format can fall to env)
-        monkeypatch.setattr(sys, "argv", ["prog"])
-        assert run_args.get_args().log_format is None
+        assert run_args.get_args([]).log_format is None
 
-    def test_flag_parsed_and_lowercased(self, monkeypatch):
-        monkeypatch.setattr(sys, "argv", ["prog", "--log-format", "JSON"])
-        assert run_args.get_args().log_format == "json"
+    def test_flag_parsed_and_lowercased(self):
+        assert run_args.get_args(["--log-format", "JSON"]).log_format == "json"
 
 
 class TestResolveLogFormat:


### PR DESCRIPTION
## Changes

Adds an opt-in JSON-structured logging mode. Text remains the default, so existing CLI output is unchanged.

- New `bookstack_file_exporter/common/logging.py` — `JsonFormatter(logging.Formatter)` (stdlib only, no new dependency) that emits one JSON object per log line (`timestamp` ISO-8601 UTC, `level`, `logger`, `message`, merged `extra={}` fields, `exc_info` when present), plus a `build_handler(log_format)` factory. This is the only formatter-aware file (swap seam if `python-json-logger` is ever adopted).
- `run_args.py` — new `--log-format {text,json}` flag (`default=None`) and `resolve_log_format()` precedence: CLI flag > `LOG_FORMAT` env var > `text` default. An invalid `LOG_FORMAT` value falls back to text with a warning (does not crash a container).
- `__main__.py` — `basicConfig` now selects the handler via `build_handler(resolve_log_format(args))`; level filtering still honored through `basicConfig(level=...)`.
- Docs: README gets a "Log Format" section + CLI/env entries; `examples/config.yml` notes the toggle.
- Bundled `chore:` — silenced the pre-existing intentional broad-except on the notification catch-all (`run.py:91`), matching the existing pattern at `run.py:61`. Lint now 10.00/10.

## Motivation

Structured logs are needed for log aggregators (Loki/ELK/CloudWatch). Default-off keeps current behavior byte-identical for existing users.

## Test Plan

- [ ] `uv run pytest` — 483 passing (new `tests/unit/test_logging.py`, `tests/unit/test_run_args.py`, updated `test_main.py`)
- [ ] `uv run pylint bookstack_file_exporter tests` — 10.00/10
- [ ] Default output unchanged: run without flag/env → classic `YYYY-MM-DD HH:MM:SS [INFO] ...` line
- [ ] `--log-format json` (or `LOG_FORMAT=json`) → one valid JSON object per line
- [ ] CLI overrides env; invalid `LOG_FORMAT` → text + one warning, no crash

## In-depth

- **No new runtime dependency.** `python-json-logger` (v4.x, maintained) was evaluated but skipped on YAGNI/bus-factor grounds; the `common/logging.py` seam keeps a later swap to a one-file change.
- Not exercised end-to-end (logging-only change, fully unit-covered).

---

### Post-review updates

- **Timestamps now millisecond-precision** (`2026-06-21T05:03:59.123Z`) so aggregators can order events within a second; **`stack_info` included** in JSON output when a log call passes `stack_info=True` (previously dropped).
- **`main()`/`get_args()` take an optional `argv` (default `None` → `sys.argv`)** — production path byte-identical. This let the `main()` tests drop internal-collaborator patches (now mock only the genuine boundaries `run.entrypoint` + `logging.basicConfig`) and let `test_run_args` drop `sys.argv` monkeypatching.
- Kept the stdlib `JsonFormatter` over `python-json-logger` (single-maintainer fork; swap-seam preserved in `common/logging.py`).
- Test count: 485 passing, pylint 10.00/10.
