### PR TITLE
feat: cron schedule (run_schedule) for daemon mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ What it does:
 - Can be run via [Python](#run-via-pip) or [Docker](#run-via-docker)
 - Can push archives to remote object storage like [Minio](https://min.io/)
 - Basic housekeeping option (`keep_last`) to keep a tidy archive destination
-- Can run in application mode (always running) using `run_interval` property. Used for basic scheduling of backups.
+- Can run in application mode (always running) using `run_interval` (interval-based) or `run_schedule` (cron-based) properties. Used for scheduling backups.
 
 Supported backup targets are:
 
@@ -122,7 +122,7 @@ Command line options:
 |`-c`, `--config-file`|True|Relative or Absolute path to a valid configuration file. This configuration file is checked against a schema for validation.|
 |`-v`, `--log-level` |False, default: info|Provide a valid log level: info, debug, warning, error.|
 |`--log-format` |False, default: text|Log output format. `text` (default) or `json` for JSON Lines. CLI overrides the `LOG_FORMAT` env var.|
-|`--run-once` |False|Force a single run and exit, ignoring `run_interval` in the config. Useful for a manual or CI-triggered run against a config that is otherwise set up for application (scheduled) mode.|
+|`--run-once` |False|Force a single run and exit, ignoring `run_interval` and `run_schedule` in the config. Useful for a manual or CI-triggered run against a config that is otherwise set up for application (scheduled) mode.|
 
 #### Environment Variables
 See [Valid Environment Variables](#valid-environment-variables) for more options.
@@ -184,13 +184,18 @@ docker run \
 #### Run Modes
 The exporter runs in one of two modes, selected automatically from your config:
 
-- **One-shot** (default): `run_interval` unset or `0` → runs once and exits. Returns exit code `0` on success, `1` on failure (clean error message; pass `-v debug` for the full traceback), and `130` on `Ctrl-C`. Pairs well with an external scheduler (Kubernetes `CronJob`, `cron`, `systemd` timer), which owns restart, backoff, and run history.
-- **Application / scheduled** (long-running): `run_interval` set → runs, sleeps `{run_interval}` seconds, repeats. For a single-container `docker compose` deployment with no external scheduler. A failed cycle is logged (and notifies, if configured) and waits for the next interval rather than crashing. Shuts down gracefully on `SIGTERM` (`docker stop`) and `SIGINT` (`Ctrl-C`), exiting `0`.
+- **One-shot** (default): `run_interval` unset or `0`, and `run_schedule` unset → runs once and exits. Returns exit code `0` on success, `1` on failure (clean error message; pass `-v debug` for the full traceback), and `130` on `Ctrl-C`. Pairs well with an external scheduler (Kubernetes `CronJob`, `cron`, `systemd` timer), which owns restart, backoff, and run history.
+- **Application / scheduled** (long-running): `run_interval` or `run_schedule` set → runs repeatedly, then waits for the next trigger. For a single-container `docker compose` deployment with no external scheduler. A failed cycle is logged (and notifies, if configured) and waits for the next trigger rather than crashing. Shuts down gracefully on `SIGTERM` (`docker stop`) and `SIGINT` (`Ctrl-C`), exiting `0`.
 
-Pass `--run-once` to force a single run regardless of `run_interval`.
+Two scheduling strategies are available for application mode (mutually exclusive — setting both is a config error):
+
+- **`run_interval`** (seconds): sleeps a fixed number of seconds between cycles. Simple but drifts over time — the effective period is `run_interval` + cycle runtime.
+- **`run_schedule`** (cron expression): fires at wall-clock times. Standard 5-field cron syntax (e.g. `"0 2 * * *"` = 2 am daily). croniter also accepts 6/7-field extended forms. Cron is evaluated in container-local time — set the `TZ` environment variable to control the timezone (default: `UTC`). Note: if a cycle runs past its scheduled tick, the missed tick is skipped (no catch-up). During a DST spring-forward, a scheduled time that falls inside the skipped hour will not fire that day.
+
+Pass `--run-once` to force a single run regardless of `run_interval` or `run_schedule`.
 
 #### Docker Compose
-When using the configuration option: `run_interval`, a docker compose set up could be used to run the exporter as an always running application. The exporter will sleep and wait until `{run_interval}` seconds has elapsed before subsequent runs.
+When using `run_interval` or `run_schedule`, a docker compose set up could be used to run the exporter as an always running application. The exporter will wait for the next interval or scheduled time before subsequent runs.
 
 An example is shown in `examples/docker-compose.yaml`
 
@@ -335,7 +340,8 @@ More descriptions can be found for each section below:
 | `http_config.backoff_factor` | `float` | `false` | Optional (default: `2.5`), set the backoff_factor for http request retries. Default backoff_factor `2.5` means we wait 5, 10, 20, and then 40 seconds (with default `http_config.retry_count: 5`) before our last retry. This should allow for per minute rate limits to be refreshed. |
 | `http_config.additional_headers` | `object` | `false` | Optional (default: `{}`), specify key/value pairs that will be added as additional headers to http requests. |
 | `keep_last` | `int` | `false` | Optional (default: `0`), if exporter can delete older archives. valid values are:<br>- set to `-1` if you want to delete all archives after each run (useful if you only want to upload to object storage)<br>- set to `1+` if you want to retain a certain number of archives<br>- `0` will result in no action done. |
-| `run_interval` | `int` | `false` | Optional (default: `0`). If specified, exporter will run as an application and pause for `{run_interval}` seconds before subsequent runs. Example: `86400` seconds = `24` hours or run once a day. Setting this property to `0` will invoke a single run and exit. Used for basic scheduling of backups. |
+| `run_interval` | `int` | `false` | Optional (default: `0`). If specified, exporter will run as an application and pause for `{run_interval}` seconds before subsequent runs. Example: `86400` seconds = `24` hours or run once a day. Setting this property to `0` will invoke a single run and exit. Mutually exclusive with `run_schedule`. |
+| `run_schedule` | `str` | `false` | Optional. Cron expression for wall-clock scheduling (e.g. `"0 2 * * *"` = 2 am daily). Standard 5-field cron; croniter also accepts 6/7-field extended forms. An invalid expression is rejected at config load. Evaluated in container-local time — set `TZ` env var to control timezone (default: `UTC`). If a cycle overruns its scheduled tick, the missed tick is skipped (no catch-up). Mutually exclusive with `run_interval`. |
 | `minio` | `object` | `false` | Optional [Minio](#minio-backups) configuration options. |
 | `notifications` | `object` | `false` | Optional [notification](#notifications) configuration options. |
 | `filters` | `object` | `false` | Optional per-resource-type regex filters (include/exclude lists). See [Filters](#filters) for details. |

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from datetime import datetime
 from http.cookiejar import DefaultCookiePolicy
 from typing import TypeVar
 from urllib.parse import urlparse, parse_qsl, urlencode, urlunparse
@@ -8,6 +9,7 @@ import urllib3
 import requests
 # pylint: disable=import-error
 from requests.adapters import HTTPAdapter, Retry
+from croniter import croniter
 from pydantic import TypeAdapter, ValidationError
 
 from bookstack_file_exporter.config_helper.models import HttpConfig
@@ -131,6 +133,18 @@ def check_var(env_key: str, default_val: str, required: bool = True) -> str:
             "- at least one should be set"
         )
     return default_val
+
+
+def seconds_until_next_cron(schedule: str, now: datetime) -> float:
+    """Seconds from `now` until the next time `schedule` (cron expr) fires.
+
+    Accepts standard 5-field cron; croniter also tolerates 6/7-field extended forms.
+
+    `now` is naive/container-local; the result is always strictly positive
+    (croniter returns the next future tick), so a cycle that overran its slot
+    waits for the next clock match rather than firing immediately.
+    """
+    return (croniter(schedule, now).get_next(datetime) - now).total_seconds()
 
 
 def resolve_env_json(env_key: str, target: type[T], default_val: T) -> T:

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -1,8 +1,9 @@
 import re
+from datetime import datetime
 from typing import Literal
 # pylint: disable=import-error
 from pydantic import BaseModel, Field, AliasChoices, ConfigDict, field_validator, model_validator
-from croniter import croniter
+from croniter import croniter, CroniterError
 
 # pylint: disable=too-few-public-methods
 class ObjectStorageConfig(BaseModel):
@@ -133,4 +134,9 @@ class UserInput(BaseModel):
                     "run_interval and run_schedule are mutually exclusive; set only one")
             if not croniter.is_valid(self.run_schedule):
                 raise ValueError(f"Invalid run_schedule cron expression: {self.run_schedule!r}")
+            try:
+                croniter(self.run_schedule, datetime(2000, 1, 1)).get_next(datetime)
+            except CroniterError as err:
+                raise ValueError(
+                    f"run_schedule cron expression never fires: {self.run_schedule!r}") from err
         return self

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -1,7 +1,8 @@
 import re
 from typing import Literal
 # pylint: disable=import-error
-from pydantic import BaseModel, Field, AliasChoices, ConfigDict, field_validator
+from pydantic import BaseModel, Field, AliasChoices, ConfigDict, field_validator, model_validator
+from croniter import croniter
 
 # pylint: disable=too-few-public-methods
 class ObjectStorageConfig(BaseModel):
@@ -119,6 +120,17 @@ class UserInput(BaseModel):
     minio: ObjectStorageConfig | None = None
     keep_last: int | None = 0
     run_interval: int | None = 0
+    run_schedule: str | None = None
     http_config: HttpConfig | None = HttpConfig()
     notifications: Notifications | None = None
     filters: Filters | None = None
+
+    @model_validator(mode="after")
+    def _check_schedule_config(self):
+        if self.run_schedule:
+            if self.run_interval:
+                raise ValueError(
+                    "run_interval and run_schedule are mutually exclusive; set only one")
+            if not croniter.is_valid(self.run_schedule):
+                raise ValueError(f"Invalid run_schedule cron expression: {self.run_schedule!r}")
+        return self

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -2,13 +2,15 @@ import argparse
 import logging
 import signal
 import threading
+from datetime import datetime
+from typing import Callable
 
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
 from bookstack_file_exporter.exporter.node import Node
 from bookstack_file_exporter.exporter.exporter import NodeExporter
 from bookstack_file_exporter.exporter.filter import NodeFilter
 from bookstack_file_exporter.archiver.archiver import Archiver
-from bookstack_file_exporter.common.util import HttpHelper
+from bookstack_file_exporter.common.util import HttpHelper, seconds_until_next_cron
 from bookstack_file_exporter.notify.handler import NotifyHandler
 from bookstack_file_exporter.notify.models import NotifyResult
 
@@ -24,9 +26,13 @@ def entrypoint(args: argparse.Namespace) -> int:
         log.debug("Traceback:", exc_info=True)
         return 1
 
-    if getattr(args, "run_once", False) or not config.user_inputs.run_interval:
+    inputs = config.user_inputs
+    if getattr(args, "run_once", False) or (not inputs.run_interval and not inputs.run_schedule):
         return _run_once(config)
-    return _run_scheduled(config)
+    if inputs.run_schedule:
+        return _run_scheduled(
+            config, lambda: seconds_until_next_cron(inputs.run_schedule, datetime.now()))
+    return _run_scheduled(config, lambda: inputs.run_interval)
 
 
 def _run_once(config: ConfigNode) -> int:
@@ -43,10 +49,9 @@ def _run_once(config: ConfigNode) -> int:
         return 1
 
 
-def _run_scheduled(config: ConfigNode) -> int:
-    """Run the export on a repeating interval until a stop signal is received."""
+def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
+    """Run the export on a repeating schedule until a stop signal is received."""
     stop = threading.Event()
-    interval = config.user_inputs.run_interval
 
     def _handle_signal(signum, _frame):
         log.info("Received signal %s, shutting down", signum)
@@ -68,8 +73,9 @@ def _run_scheduled(config: ConfigNode) -> int:
         if stop.is_set():
             break
 
-        log.info("Waiting %s seconds for next run", interval)
-        stop.wait(interval)
+        wait_secs = next_wait()
+        log.info("Waiting %s seconds for next run", wait_secs)
+        stop.wait(wait_secs)
 
     log.info("Shutdown complete")
     return 0

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -111,8 +111,15 @@ keep_last: 5
 ## optional - if specified exporter will run in a loop
 # it will run and then pause for {run_interval} seconds before running again
 # specify in seconds, example: 86400 seconds = 24 hours or run once a day
-# omit/commit out or set to 0 if you just want a single run and exit
+# omit/comment out or set to 0 if you just want a single run and exit
+# mutually exclusive with run_schedule below
 run_interval: 0
+## optional - cron schedule as an alternative to run_interval (mutually exclusive)
+# standard 5-field cron; fires at wall-clock times in container-local time (honors TZ env var)
+# default timezone is UTC; invalid expressions are rejected at config load
+# if a cycle overruns its scheduled tick, the missed tick is skipped (no catch-up)
+# example: "0 2 * * *" = 2am daily
+# run_schedule: "0 2 * * *"
 ## optional - if specified exporter will send notifications on failure
 # supported notification services are:
 # - apprise (https://github.com/caronc/apprise)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "minio>=7.2.20",
     "apprise>=1.10.0",
     "markdown-it-py>=4.2.0",
+    "croniter>=6.2.0",
 ]
 
 [project.urls]

--- a/tests/unit/test_models_filters.py
+++ b/tests/unit/test_models_filters.py
@@ -185,3 +185,7 @@ class TestUserInputRunSchedule:
         ui = UserInput(**_base_user_input_kwargs(run_interval=0, run_schedule="0 2 * * *"))
         assert ui.run_schedule == "0 2 * * *"
         assert ui.run_interval == 0
+
+    def test_run_schedule_rejects_impossible_date(self):
+        with pytest.raises(ValidationError):
+            UserInput(**_base_user_input_kwargs(run_schedule="0 2 31 2 *"))

--- a/tests/unit/test_models_filters.py
+++ b/tests/unit/test_models_filters.py
@@ -162,3 +162,26 @@ class TestUserInputFilters:
             UserInput(**_base_user_input_kwargs(
                 filters={"pages": {"include": ["[bad"]}}
             ))
+
+
+# ---------------------------------------------------------------------------
+# UserInput: run_schedule field and mutual-exclusion validator
+# ---------------------------------------------------------------------------
+
+class TestUserInputRunSchedule:
+    def test_run_schedule_accepts_valid_cron(self):
+        ui = UserInput(**_base_user_input_kwargs(run_schedule="0 2 * * *"))
+        assert ui.run_schedule == "0 2 * * *"
+
+    def test_run_schedule_rejects_invalid_cron(self):
+        with pytest.raises(ValidationError):
+            UserInput(**_base_user_input_kwargs(run_schedule="not a cron"))
+
+    def test_run_interval_and_schedule_mutually_exclusive(self):
+        with pytest.raises(ValidationError):
+            UserInput(**_base_user_input_kwargs(run_interval=3600, run_schedule="0 2 * * *"))
+
+    def test_run_interval_zero_with_schedule_ok(self):
+        ui = UserInput(**_base_user_input_kwargs(run_interval=0, run_schedule="0 2 * * *"))
+        assert ui.run_schedule == "0 2 * * *"
+        assert ui.run_interval == 0

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -11,9 +11,11 @@ from bookstack_file_exporter import run
 from bookstack_file_exporter.notify.models import NotifyResult
 
 
-def _config(run_interval, run_once=False):
+def _config(run_interval, run_once=False, run_schedule=None):
     """Return a minimal fake args + config pair for entrypoint tests."""
-    return SimpleNamespace(user_inputs=SimpleNamespace(run_interval=run_interval))
+    return SimpleNamespace(
+        user_inputs=SimpleNamespace(run_interval=run_interval, run_schedule=run_schedule)
+    )
 
 
 def _args(run_once=False):
@@ -262,6 +264,63 @@ def test_entrypoint_loops_when_interval_set():
 
     assert result == 0
     assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Branch selection: cron vs interval vs run-once
+# ---------------------------------------------------------------------------
+
+def test_entrypoint_uses_cron_when_schedule_set():
+    """run_schedule set + run_interval falsy → cron-based next_wait passed to _run_scheduled."""
+    cfg = _config(run_interval=0, run_schedule="0 2 * * *")
+    with patch.object(run, "ConfigNode", return_value=cfg), \
+         patch.object(run, "_run_scheduled", return_value=0) as mock_scheduled:
+        result = run.entrypoint(args=_args(run_once=False))
+    assert result == 0
+    mock_scheduled.assert_called_once()
+    # exercise the injected provider to prove the CRON branch (not interval) was wired:
+    # the cron lambda calls seconds_until_next_cron(now), always strictly positive.
+    next_wait = mock_scheduled.call_args.args[1]
+    assert next_wait() > 0
+
+
+def test_entrypoint_uses_interval_when_interval_set():
+    """run_interval set + run_schedule None → interval next_wait passed to _run_scheduled."""
+    cfg = _config(run_interval=60, run_schedule=None)
+    with patch.object(run, "ConfigNode", return_value=cfg), \
+         patch.object(run, "_run_scheduled", return_value=0) as mock_scheduled:
+        result = run.entrypoint(args=_args(run_once=False))
+    assert result == 0
+    mock_scheduled.assert_called_once()
+    # exercise the injected provider to prove the INTERVAL branch was wired:
+    # the interval lambda returns the configured run_interval verbatim.
+    next_wait = mock_scheduled.call_args.args[1]
+    assert next_wait() == 60
+
+
+def test_scheduled_loop_uses_injected_wait_provider():
+    """_run_scheduled calls stop.wait with the value returned by next_wait."""
+    cfg = _config(run_interval=0)
+    stop_event = threading.Event()
+    call_count = 0
+
+    def _run_side_effect(_config):
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("transient failure")
+
+    def _wait_side_effect(timeout=None):
+        stop_event.set()
+        return False
+
+    with patch.object(run, "run", side_effect=_run_side_effect), \
+         patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(stop_event, "wait", side_effect=_wait_side_effect) as mock_wait, \
+         patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+        result = run._run_scheduled(cfg, lambda: 5)
+
+    assert result == 0
+    mock_wait.assert_called_once_with(5)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_util_cron.py
+++ b/tests/unit/test_util_cron.py
@@ -1,0 +1,24 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring
+"""Unit tests for seconds_until_next_cron helper."""
+from datetime import datetime
+
+from bookstack_file_exporter.common.util import seconds_until_next_cron
+
+
+def test_seconds_until_next_basic():
+    """next fire of '0 2 * * *' from midnight is 2 hours later (same day)."""
+    now = datetime(2026, 1, 1, 0, 0, 0)
+    assert seconds_until_next_cron("0 2 * * *", now) == 2 * 3600
+
+
+def test_seconds_until_next_after_tick():
+    """A cycle that overran 02:00 waits for tomorrow's 02:00, not immediate fire."""
+    now = datetime(2026, 1, 1, 3, 0, 0)
+    assert seconds_until_next_cron("0 2 * * *", now) == 23 * 3600
+
+
+def test_seconds_until_next_nonnegative():
+    """Result is always strictly positive."""
+    now = datetime(2026, 6, 15, 12, 30, 0)
+    result = seconds_until_next_cron("*/5 * * * *", now)
+    assert result > 0

--- a/uv.lock
+++ b/uv.lock
@@ -106,6 +106,7 @@ source = { editable = "." }
 dependencies = [
     { name = "apprise" },
     { name = "beautifulsoup4" },
+    { name = "croniter" },
     { name = "markdown-it-py" },
     { name = "minio" },
     { name = "pydantic" },
@@ -125,6 +126,7 @@ dev = [
 requires-dist = [
     { name = "apprise", specifier = ">=1.10.0" },
     { name = "beautifulsoup4", specifier = ">=4.14.3" },
+    { name = "croniter", specifier = ">=6.2.0" },
     { name = "markdown-it-py", specifier = ">=4.2.0" },
     { name = "minio", specifier = ">=7.2.20" },
     { name = "pydantic", specifier = ">=2.13.4" },
@@ -431,6 +433,18 @@ wheels = [
 [package.optional-dependencies]
 toml = [
     { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
+name = "croniter"
+version = "6.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/5832661ed55107b8a09af3f0a2e71e0957226a59eb1dcf0a445cce6daf20/croniter-6.2.2.tar.gz", hash = "sha256:ba60832a5ec8e12e51b8691c3309a113d1cf6526bdf1a48150ce8ec7a532d0ab", size = 113762, upload-time = "2026-03-15T08:43:48.112Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d0/39/783980e78cb92c2d7bdb1fc7dbc86e94ccc6d58224d76a7f1f51b6c51e30/croniter-6.2.2-py3-none-any.whl", hash = "sha256:a5d17b1060974d36251ea4faf388233eca8acf0d09cbd92d35f4c4ac8f279960", size = 45422, upload-time = "2026-03-15T08:43:46.626Z" },
 ]
 
 [[package]]
@@ -774,6 +788,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -868,6 +894,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c2/58/1fb6de3503428196df78638f991ec8095274f1ee9723e272ee4d9ff0092b/responses-0.26.1.tar.gz", hash = "sha256:2eb3218553cc8f79b57d257bac23af5e1bf381f5b9390b1767816f0843e01dc2", size = 83088, upload-time = "2026-05-21T19:56:39.747Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/31/6a620b4427d546b9e7cca8b3b8c5f0559d9cef2bb9eedcda7f73c1473c19/responses-0.26.1-py3-none-any.whl", hash = "sha256:8aacc4586eb08fb2208ef64a9eb4258d9b0c6e6f4260845f2f018ab847495345", size = 35502, upload-time = "2026-05-21T19:56:38.046Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

Adds `run_schedule`, a cron-expression alternative to `run_interval` for the long-running daemon mode.

- New optional config field `run_schedule` (standard 5-field cron; croniter also tolerates 6/7-field extended forms). Mutually exclusive with a truthy `run_interval` — setting both is a config validation error.
- New pure helper `seconds_until_next_cron(schedule, now)` in `common/util.py` (functional core; returns strictly-positive seconds to the next fire).
- `_run_scheduled` refactored to take an injected `next_wait: Callable[[], float]` provider; `entrypoint` routes to cron when `run_schedule` is set, interval when `run_interval` is set, run-once otherwise. Interval-path behavior is unchanged (regression-locked).
- Cron is evaluated in **container-local time** via naive `datetime.now()` (honors the `TZ` env var; default UTC). Skip-on-overrun: the next fire is computed from cycle end, so a cycle that overran its tick waits for the next future clock match (no catch-up, no overlap).
- All unusable cron expressions are rejected at config load with a clean `ValueError`: malformed syntax **and** impossible calendar dates (e.g. `0 2 31 2 *`, which `croniter.is_valid()` accepts but `get_next` later raises on — would otherwise crash the daemon after its first cycle).
- New dependency: `croniter>=6.2.0` (MIT, maintained under pallets-eco).
- README Run Modes + `examples/config.yml` document the field, interval-vs-cron tradeoff, mutual exclusion, TZ/DST caveats, and skip-on-overrun.

## Motivation

`run_interval` drifts — the true period is `interval + cycle runtime`. Users wanting backups at a fixed wall-clock time (e.g. 2am nightly) in a single-container deployment with no external scheduler had no option. `run_schedule` fires on clock times instead.

## Test plan

- `uv run pytest` — 496 passed.
- `uv run pylint bookstack_file_exporter` — 10.00/10.
- Unit coverage: pure-fn cron math (incl. skip-on-overrun), validator (valid/invalid/impossible-date/mutual-exclusion incl. `run_interval=0` falsy edge), entrypoint routing (cron vs interval branches each exercise the injected provider), loop mechanics (injected wait reaches `stop.wait`). No test patches the module clock.
- SIGTERM/SIGINT graceful shutdown (F2) preserved.

## In-depth

- **Timezone:** chose container-local naive time over UTC-forced or config-selectable, matching traditional-cron intuition and the `TZ` env-var knob with zero extra config. DST spring-forward gap-hour caveat is documented, not coded around (acceptable for a backup tool).
- **Testability seam:** the `next_wait` callable + pure `seconds_until_next_cron` keep the loop free of clock mocks — each unit is tested at its own boundary.
- **Validation:** a fixed-reference `get_next` probe (not `datetime.now()`) keeps config validation deterministic while catching never-firing expressions.
- No runtime guard was added around `next_wait()` — load-time validation is the single correct fix; a runtime guard would be redundant defensive code.