### PR TITLE
feat: opt-in /healthz health server for scheduled mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,60 @@ Two scheduling strategies are available for application mode (mutually exclusive
 
 Pass `--run-once` to force a single run regardless of `run_interval` or `run_schedule`.
 
+#### Health Endpoint
+
+In scheduled mode (`run_interval` or `run_schedule`), set `health_port` to expose an
+opt-in `GET /healthz` endpoint. No server is started unless `health_port` is set, and
+it is ignored in one-shot mode.
+
+```yaml
+health_port: 8080          # opt-in; no server unless set
+health_host: "0.0.0.0"     # optional bind address (default 0.0.0.0)
+```
+
+`GET /healthz` returns `200` with a JSON body while the daemon is alive:
+
+```json
+{
+  "status": "healthy",
+  "last_run": {
+    "status": "success",
+    "started_at": "2026-06-21T02:00:00Z",
+    "finished_at": "2026-06-21T02:03:11Z",
+    "duration_seconds": 191,
+    "archive_file": "bookstack_export_2026-06-21.tgz",
+    "error": null
+  },
+  "next_run": "2026-06-22T02:00:00Z",
+  "run_count": 5,
+  "failure_count": 0
+}
+```
+
+This is a **liveness** signal: it stays `200` even after a failed export cycle
+(the scheduled loop logs and continues), so probes do not flap on transient
+BookStack outages. Use `last_run.status` (`never` → `running` → `success` |
+`failed`) and `failure_count` for scrape-based alerting. Any path other than
+`/healthz` returns `404`.
+
+Kubernetes liveness probe:
+
+```yaml
+livenessProbe:
+  httpGet:
+    path: /healthz
+    port: 8080
+  initialDelaySeconds: 10
+  periodSeconds: 30
+```
+
+Docker healthcheck:
+
+```dockerfile
+HEALTHCHECK --interval=30s --timeout=5s \
+  CMD python -c "import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/healthz').status==200 else 1)"
+```
+
 #### Docker Compose
 When using `run_interval` or `run_schedule`, a docker compose set up could be used to run the exporter as an always running application. The exporter will wait for the next interval or scheduled time before subsequent runs.
 

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -122,6 +122,9 @@ class UserInput(BaseModel):
     keep_last: int | None = 0
     run_interval: int | None = 0
     run_schedule: str | None = None
+    # opt-in scheduled-mode health endpoint; no server unless health_port is set
+    health_port: int | None = None
+    health_host: str | None = "0.0.0.0"
     http_config: HttpConfig | None = HttpConfig()
     notifications: Notifications | None = None
     filters: Filters | None = None

--- a/bookstack_file_exporter/health/server.py
+++ b/bookstack_file_exporter/health/server.py
@@ -1,0 +1,43 @@
+"""Opt-in /healthz HTTP server (F4): stdlib ThreadingHTTPServer on a daemon
+thread. Liveness-only — returns 200 while the daemon is alive; the scrape
+signal lives in last_run.status. No new dependency."""
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from bookstack_file_exporter.health.status import RunStatus
+
+
+class HealthHandler(BaseHTTPRequestHandler):
+    """Serves GET /healthz as a JSON snapshot; any other path → 404.
+
+    The bound RunStatus is injected as a class attribute on a per-server
+    subclass (see start_health_server)."""
+    status: RunStatus = None  # set on the per-server subclass
+
+    # do_GET name is mandated by BaseHTTPRequestHandler
+    def do_GET(self):  # pylint: disable=invalid-name
+        """Serve GET /healthz as JSON; 404 for all other paths."""
+        if self.path == "/healthz":
+            body = json.dumps(self.status.snapshot()).encode("utf-8")
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return
+        self.send_response(404)
+        self.end_headers()
+
+    def log_message(self, *args):  # silence per-request stderr logging
+        pass
+
+
+def start_health_server(host: str, port: int, status: RunStatus) -> ThreadingHTTPServer:
+    """Start the health server on a daemon thread and return the server handle
+    so the caller can shut it down via server.shutdown()."""
+    handler_cls = type("BoundHealthHandler", (HealthHandler,), {"status": status})
+    server = ThreadingHTTPServer((host, port), handler_cls)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server

--- a/bookstack_file_exporter/health/status.py
+++ b/bookstack_file_exporter/health/status.py
@@ -1,0 +1,97 @@
+"""Lock-guarded mutable run status behind the /healthz JSON body (F4).
+
+Plain dataclass + threading.Lock (NOT pydantic): pydantic is for parse/validate,
+this is mutable shared state read by the health-server thread while the scheduled
+loop writes it. All timestamps are UTC; snapshot() emits ISO-8601 'Z' strings.
+"""
+import os
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from bookstack_file_exporter.notify.models import NotifyResult
+
+
+def _iso(value: datetime | None) -> str | None:
+    """Format a UTC datetime as ISO-8601 with a trailing Z, or None."""
+    if value is None:
+        return None
+    return value.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+@dataclass
+class RunStatus:  # pylint: disable=too-many-instance-attributes
+    """Thread-safe last-run/next-run status for the health endpoint."""
+    _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
+    _last_run_status: str = "never"   # never -> running -> success | failed
+    _started_at: datetime | None = None
+    _finished_at: datetime | None = None
+    _archive_file: str | None = None
+    _error: str | None = None
+    _next_run: datetime | None = None
+    _run_count: int = 0
+    _failure_count: int = 0
+
+    def mark_running(self) -> None:
+        """Transition to running state and record the start timestamp."""
+        with self._lock:
+            self._last_run_status = "running"
+            self._started_at = _now()
+            self._finished_at = None
+            self._archive_file = None
+            self._error = None
+
+    def mark_success(self, result: NotifyResult | None) -> None:
+        """Transition to success state, record finish time, and increment run count."""
+        with self._lock:
+            self._last_run_status = "success"
+            self._finished_at = _now()
+            self._error = None
+            self._archive_file = (
+                os.path.basename(result.local)
+                if result is not None and result.local
+                else None
+            )
+            self._run_count += 1
+
+    def mark_failed(self, err: Exception) -> None:
+        """Transition to failed state, record error message, and increment both counters."""
+        with self._lock:
+            self._last_run_status = "failed"
+            self._finished_at = _now()
+            self._archive_file = None
+            self._error = str(err)
+            self._run_count += 1
+            self._failure_count += 1
+
+    def set_next_run(self, next_run: datetime) -> None:
+        """Store the UTC datetime of the next scheduled run."""
+        with self._lock:
+            self._next_run = next_run
+
+    def _duration_seconds(self) -> int | None:
+        if self._started_at is None or self._finished_at is None:
+            return None
+        return int(round((self._finished_at - self._started_at).total_seconds()))
+
+    def snapshot(self) -> dict:
+        """Build the JSON-ready body under the lock. All keys always present."""
+        with self._lock:
+            return {
+                "status": "healthy",
+                "last_run": {
+                    "status": self._last_run_status,
+                    "started_at": _iso(self._started_at),
+                    "finished_at": _iso(self._finished_at),
+                    "duration_seconds": self._duration_seconds(),
+                    "archive_file": self._archive_file,
+                    "error": self._error,
+                },
+                "next_run": _iso(self._next_run),
+                "run_count": self._run_count,
+                "failure_count": self._failure_count,
+            }

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -2,7 +2,7 @@ import argparse
 import logging
 import signal
 import threading
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Callable
 
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
@@ -13,6 +13,8 @@ from bookstack_file_exporter.archiver.archiver import Archiver
 from bookstack_file_exporter.common.util import HttpHelper, seconds_until_next_cron
 from bookstack_file_exporter.notify.handler import NotifyHandler
 from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.health.status import RunStatus
+from bookstack_file_exporter.health.server import start_health_server
 
 log = logging.getLogger(__name__)
 
@@ -60,23 +62,42 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
 
+    status = None
+    server = None
+    if config.user_inputs.health_port:
+        status = RunStatus()
+        server = start_health_server(
+            config.user_inputs.health_host, config.user_inputs.health_port, status)
+        log.info("Health endpoint listening on %s:%s",
+                 config.user_inputs.health_host, config.user_inputs.health_port)
+
     while not stop.is_set():
+        if status:
+            status.mark_running()
         try:
-            run(config)
+            result = run(config)
+            if status:
+                status.mark_success(result)
         except Exception as err:  # pylint: disable=broad-except
             # log-and-continue: a failed cycle still waits the interval below
             # before retrying (no busy-loop), and the failure notification has
             # already fired inside run().
             log.error("Export failed: %s", err)
             log.debug("Traceback:", exc_info=True)
+            if status:
+                status.mark_failed(err)
 
         if stop.is_set():
             break
 
         wait_secs = next_wait()
+        if status:
+            status.set_next_run(datetime.now(timezone.utc) + timedelta(seconds=wait_secs))
         log.info("Waiting %s seconds for next run", wait_secs)
         stop.wait(wait_secs)
 
+    if server:
+        server.shutdown()
     log.info("Shutdown complete")
     return 0
 
@@ -88,6 +109,7 @@ def run(config: ConfigNode):
         if config.user_inputs.notifications:
             notif = NotifyHandler(config.user_inputs.notifications)
             notif.do_notify(result=result)
+        return result
     except Exception as run_err: # general catch all for notifications
         if not config.user_inputs.notifications:
             raise run_err

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -120,6 +120,16 @@ run_interval: 0
 # if a cycle overruns its scheduled tick, the missed tick is skipped (no catch-up)
 # example: "0 2 * * *" = 2am daily
 # run_schedule: "0 2 * * *"
+## optional - opt-in health endpoint for scheduled mode (run_interval or run_schedule)
+# when health_port is set, the daemon serves GET /healthz returning JSON:
+#   {"status","last_run":{...},"next_run","run_count","failure_count"}
+# liveness: returns 200 while the daemon is alive (a single failed cycle does NOT
+#   flip it off 200); the scrape signal is last_run.status (never/running/success/failed)
+# no server is started unless health_port is set; ignored in one-shot mode
+# health_port: 8080
+# optional bind address; defaults to 0.0.0.0 (container/k8s friendly).
+# set to 127.0.0.1 or a specific NIC on a bare-metal multi-homed host
+# health_host: "0.0.0.0"
 ## optional - if specified exporter will send notifications on failure
 # supported notification services are:
 # - apprise (https://github.com/caronc/apprise)

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -68,6 +68,8 @@ class TestRunStatusSnapshot:
         status.mark_running()
         status.mark_failed(RuntimeError("export boom"))
         snap = status.snapshot()
+        # liveness invariant: a failed cycle must NOT flip the top-level status
+        assert snap["status"] == "healthy"
         last = snap["last_run"]
         assert last["status"] == "failed"
         assert last["error"] == "export boom"

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -104,3 +104,67 @@ class TestRunStatusSnapshot:
         status.mark_running()
         status.mark_success(NotifyResult(local="/a/b.tgz"))
         json.dumps(status.snapshot())  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Health server: real HTTP surface (ephemeral port, real GET)
+# ---------------------------------------------------------------------------
+
+import http.client  # noqa: E402  (grouped with the server tests)
+import contextlib  # noqa: E402
+
+from bookstack_file_exporter.health.server import start_health_server  # noqa: E402
+
+
+@contextlib.contextmanager
+def _running_server(status):
+    server = start_health_server("127.0.0.1", 0, status)
+    try:
+        host, port = server.server_address
+        yield host, port
+    finally:
+        server.shutdown()
+
+
+def _get(host, port, path):
+    conn = http.client.HTTPConnection(host, port, timeout=5)
+    try:
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        return resp.status, resp.getheader("Content-Type"), resp.read()
+    finally:
+        conn.close()
+
+
+class TestHealthServer:
+    def test_healthz_returns_200_json_snapshot(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_success(NotifyResult(local="/bkps/export.tgz"))
+        with _running_server(status) as (host, port):
+            code, ctype, raw = _get(host, port, "/healthz")
+        assert code == 200
+        assert ctype == "application/json"
+        body = json.loads(raw)
+        assert body["status"] == "healthy"
+        assert body["last_run"]["status"] == "success"
+        assert body["last_run"]["archive_file"] == "export.tgz"
+
+    def test_unknown_path_returns_404(self):
+        with _running_server(RunStatus()) as (host, port):
+            code, _ctype, _raw = _get(host, port, "/nope")
+        assert code == 404
+
+    def test_snapshot_reflects_live_transitions(self):
+        status = RunStatus()
+        with _running_server(status) as (host, port):
+            code, _c, raw = _get(host, port, "/healthz")
+            assert json.loads(raw)["last_run"]["status"] == "never"
+            status.mark_running()
+            status.mark_failed(RuntimeError("boom"))
+            code, _c, raw = _get(host, port, "/healthz")
+        assert code == 200
+        body = json.loads(raw)
+        assert body["last_run"]["status"] == "failed"
+        assert body["last_run"]["error"] == "boom"
+        assert body["failure_count"] == 1

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -1,0 +1,106 @@
+# pylint: disable=missing-class-docstring,missing-function-docstring
+"""Tests for the opt-in /healthz health server (F4): RunStatus transitions
+and the real HTTP surface."""
+import json
+
+from bookstack_file_exporter.health.status import RunStatus
+from bookstack_file_exporter.notify.models import NotifyResult
+
+
+# ---------------------------------------------------------------------------
+# RunStatus: snapshot shape + transitions
+# ---------------------------------------------------------------------------
+
+class TestRunStatusSnapshot:
+    def test_initial_snapshot_all_keys_present_never(self):
+        snap = RunStatus().snapshot()
+        assert snap["status"] == "healthy"
+        assert snap["next_run"] is None
+        assert snap["run_count"] == 0
+        assert snap["failure_count"] == 0
+        last = snap["last_run"]
+        assert last == {
+            "status": "never",
+            "started_at": None,
+            "finished_at": None,
+            "duration_seconds": None,
+            "archive_file": None,
+            "error": None,
+        }
+
+    def test_mark_running_sets_running_and_started(self):
+        status = RunStatus()
+        status.mark_running()
+        last = status.snapshot()["last_run"]
+        assert last["status"] == "running"
+        assert last["started_at"] is not None
+        assert last["finished_at"] is None
+        assert last["duration_seconds"] is None
+
+    def test_mark_success_populates_archive_and_counts(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_success(NotifyResult(local="/bkps/bookstack_export_2026.tgz"))
+        snap = status.snapshot()
+        last = snap["last_run"]
+        assert last["status"] == "success"
+        assert last["finished_at"] is not None
+        assert last["duration_seconds"] is not None
+        assert last["archive_file"] == "bookstack_export_2026.tgz"
+        assert last["error"] is None
+        assert snap["run_count"] == 1
+        assert snap["failure_count"] == 0
+
+    def test_mark_success_none_result_archive_null(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_success(None)
+        assert status.snapshot()["last_run"]["archive_file"] is None
+
+    def test_mark_success_none_local_archive_null(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_success(NotifyResult(local=None))
+        assert status.snapshot()["last_run"]["archive_file"] is None
+
+    def test_mark_failed_sets_error_and_counts(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_failed(RuntimeError("export boom"))
+        snap = status.snapshot()
+        last = snap["last_run"]
+        assert last["status"] == "failed"
+        assert last["error"] == "export boom"
+        assert last["archive_file"] is None
+        assert snap["run_count"] == 1
+        assert snap["failure_count"] == 1
+
+    def test_set_next_run_reflected(self):
+        from datetime import datetime, timezone
+        status = RunStatus()
+        status.set_next_run(datetime(2026, 6, 22, 2, 0, 0, tzinfo=timezone.utc))
+        assert status.snapshot()["next_run"] == "2026-06-22T02:00:00Z"
+
+    def test_mark_running_clears_prior_error(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_failed(RuntimeError("boom"))
+        status.mark_running()
+        assert status.snapshot()["last_run"]["error"] is None
+
+    def test_counts_accumulate_across_cycles(self):
+        status = RunStatus()
+        for _ in range(2):
+            status.mark_running()
+            status.mark_success(None)
+        status.mark_running()
+        status.mark_failed(RuntimeError("x"))
+        snap = status.snapshot()
+        assert snap["run_count"] == 3
+        assert snap["failure_count"] == 1
+
+    def test_snapshot_is_json_serializable(self):
+        status = RunStatus()
+        status.mark_running()
+        status.mark_success(NotifyResult(local="/a/b.tgz"))
+        json.dumps(status.snapshot())  # must not raise

--- a/tests/unit/test_models_filters.py
+++ b/tests/unit/test_models_filters.py
@@ -189,3 +189,25 @@ class TestUserInputRunSchedule:
     def test_run_schedule_rejects_impossible_date(self):
         with pytest.raises(ValidationError):
             UserInput(**_base_user_input_kwargs(run_schedule="0 2 31 2 *"))
+
+
+# ---------------------------------------------------------------------------
+# UserInput: health server config (F4)
+# ---------------------------------------------------------------------------
+
+class TestUserInputHealthConfig:
+    def _base(self, **extra):
+        return UserInput(host="https://bs.example.org", formats=["markdown"], **extra)
+
+    def test_health_defaults(self):
+        cfg = self._base()
+        assert cfg.health_port is None
+        assert cfg.health_host == "0.0.0.0"
+
+    def test_health_port_accepted(self):
+        cfg = self._base(health_port=8080)
+        assert cfg.health_port == 8080
+
+    def test_health_host_override_accepted(self):
+        cfg = self._base(health_port=9000, health_host="127.0.0.1")
+        assert cfg.health_host == "127.0.0.1"

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -11,10 +11,15 @@ from bookstack_file_exporter import run
 from bookstack_file_exporter.notify.models import NotifyResult
 
 
-def _config(run_interval, run_once=False, run_schedule=None):
+def _config(run_interval, run_once=False, run_schedule=None, health_port=None):
     """Return a minimal fake args + config pair for entrypoint tests."""
     return SimpleNamespace(
-        user_inputs=SimpleNamespace(run_interval=run_interval, run_schedule=run_schedule)
+        user_inputs=SimpleNamespace(
+            run_interval=run_interval,
+            run_schedule=run_schedule,
+            health_port=health_port,
+            health_host="0.0.0.0",
+        )
     )
 
 
@@ -673,3 +678,75 @@ class TestExporterReturnValue:
         result_arg = call_kwargs.kwargs.get("result")
         assert isinstance(result_arg, NotifyResult)
         assert result_arg.local == "/local/export.tgz"
+
+
+# ---------------------------------------------------------------------------
+# Health server wiring in _run_scheduled (F4)
+# ---------------------------------------------------------------------------
+
+class TestScheduledHealthServer:
+    def test_no_health_port_does_not_start_server(self):
+        cfg = _config(run_interval=5, health_port=None)
+        stop_event = threading.Event()
+
+        def _run_side_effect(_config):
+            stop_event.set()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.start_health_server") as mock_start, \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        mock_start.assert_not_called()
+
+    def test_health_port_starts_and_shuts_down_server(self):
+        cfg = _config(run_interval=5, health_port=8080)
+        stop_event = threading.Event()
+        fake_server = MagicMock()
+
+        def _run_side_effect(_config):
+            stop_event.set()
+            return None
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.start_health_server",
+                   return_value=fake_server) as mock_start, \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        mock_start.assert_called_once()
+        assert mock_start.call_args.args[0] == "0.0.0.0"
+        assert mock_start.call_args.args[1] == 8080
+        fake_server.shutdown.assert_called_once()
+
+    def test_health_status_marks_cycle_outcome(self):
+        cfg = _config(run_interval=5, health_port=8080)
+        stop_event = threading.Event()
+        captured = {}
+
+        def _run_side_effect(_config):
+            stop_event.set()
+            return NotifyResult(local="/bkps/export.tgz")
+
+        def _fake_start(host, port, status):
+            captured["status"] = status
+            return MagicMock()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.start_health_server", side_effect=_fake_start), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        snap = captured["status"].snapshot()
+        assert snap["run_count"] == 1
+        assert snap["last_run"]["status"] == "success"
+        assert snap["last_run"]["archive_file"] == "export.tgz"


### PR DESCRIPTION
## Changes
Adds an opt-in `/healthz` HTTP health endpoint for scheduled (daemon) mode.

- New config fields on `UserInput`: `health_port` (int, default `null`) and `health_host` (str, default `0.0.0.0`). No server starts unless `health_port` is set; ignored in one-shot mode.
- New `bookstack_file_exporter/health/` package:
  - `status.py` — `RunStatus`, a lock-guarded mutable dataclass behind the JSON body (`mark_running` / `mark_success` / `mark_failed` / `set_next_run` / `snapshot`). UTC, ISO-8601 `Z` timestamps; `duration_seconds` derived in `snapshot`; `archive_file` guarded against both `result is None` and a falsy `result.local`.
  - `server.py` — `ThreadingHTTPServer` on a daemon thread (`start_health_server`); `GET /healthz` → `200` JSON, any other path → `404`; per-request logging silenced.
- `run.py`: `run()` now returns its `NotifyResult` on success (previously returned `None` implicitly, so `archive_file` could never populate). `_run_scheduled` starts the server when configured, marks each cycle, sets `next_run` reusing the single `next_wait()` value, and calls `server.shutdown()` on loop exit.
- Docs: README `Health Endpoint` section (config, JSON body, k8s `livenessProbe`, Docker `HEALTHCHECK`) and a commented block in `examples/config.yml`.

**Liveness, not readiness:** the top-level `status` stays `"healthy"` (HTTP `200`) while the daemon is alive, even after a failed export cycle (the loop logs and continues). The scrape signal is `last_run.status` (`never` → `running` → `success` | `failed`) plus `failure_count`.

**Stdlib only — no new dependency.** When `health_port` is unset, the scheduled loop is byte-identical to before (every added line is guarded; regression-locked by the existing `test_run.py` suite).

### Body shape
```json
{
  "status": "healthy",
  "last_run": {
    "status": "success",
    "started_at": "2026-06-21T02:00:00Z",
    "finished_at": "2026-06-21T02:03:11Z",
    "duration_seconds": 191,
    "archive_file": "bookstack_export_2026-06-21.tgz",
    "error": null
  },
  "next_run": "2026-06-22T02:00:00Z",
  "run_count": 5,
  "failure_count": 0
}
```

## Motivation
A scheduled container/pod had no way to be liveness-probed or scraped for last-run status. This closes that gap without adding a dependency or changing default behavior.

## Test plan / verification
- [x] `pytest tests/unit` — 513 passed
- [x] `pylint bookstack_file_exporter` — 10.00/10
- [x] `health/` package at 100% line coverage
- New tests cover: config field acceptance; `RunStatus` transitions (never → running → success/failed), counters, double null-guard on `archive_file`, JSON-serializability; the real HTTP surface (ephemeral port + live `http.client` GET → 200/JSON, unknown path → 404, live transitions); and `_run_scheduled` wiring (no server when unset, start + shutdown when set, per-cycle status marking).
- Not yet exercised against a live BookStack instance — end-to-end validation is deferred until the next lifecycle feature lands.

## In-depth
- **Liveness vs readiness:** chose liveness-only so transient BookStack outages don't flap the probe; readiness/`/metrics`/auth/TLS are explicitly out of scope (YAGNI for the single-container observability goal).
- **`health_host`:** defaults to `0.0.0.0` (k8s/compose friendly); the override exists for a bare-metal multi-homed host that wants `127.0.0.1` or a specific NIC. Known mild disclosure: `str(err)` in `last_run.error` can include the BookStack host URL on an unauthenticated endpoint — acceptable under the trusted pod/container-network model.
- **`run()` return change:** required so `last_run.archive_file` can be populated; the exception path is unchanged (re-raises the original error).
