### PR TITLE
feat: production-grade graceful shutdown for scheduled mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,13 @@ Pass `--run-once` to force a single run regardless of `run_interval` or `run_sch
 
 In scheduled mode the exporter handles `SIGTERM`/`SIGINT` gracefully: it stops at
 the next asset/format/node boundary, discards any partial archive, and exits `0`. A
-**second** identical signal force-kills immediately (exit `130` for SIGINT, `143` for
-SIGTERM).
+**second** signal (any of SIGTERM/SIGINT, not only an identical repeat) force-kills
+immediately (exit `130` for SIGINT, `143` for SIGTERM).
+
+Exit `0` here means the process shut down cleanly, **not** that the final cycle
+succeeded — a cycle that errored is logged, notified, and reflected in `/healthz`, then
+the next signal still exits `0`. Alert on notifications or the health endpoint, not on
+the process exit code.
 
 Because a single in-flight export call (e.g. a large-book PDF render) cannot be
 interrupted mid-request, give the container enough time to drain:

--- a/README.md
+++ b/README.md
@@ -208,8 +208,16 @@ interrupted mid-request, give the container enough time to drain:
 - Compose: set `stop_grace_period: 60s` (raise for large instances).
 - Kubernetes: set `terminationGracePeriodSeconds: 60`.
 
-If the grace window elapses the orchestrator sends SIGKILL; the next run's start-up
-sweep removes any leftover partial archive.
+If the grace window elapses the orchestrator sends SIGKILL, which cannot be caught,
+so cleanup is deferred to the next run. Each archive is built under a timestamped base
+name (e.g. `bkps_2026-06-22_00-09-33`): first an intermediate `.tar`, then a
+`.tgz.partial` that is atomically renamed to the final `.tgz` on success. A SIGKILL can
+therefore strand a `<base>.tar` or `<base>.tgz.partial`. At start-up the next run sweeps
+the output directory for `bkps_*.tar` and `bkps_*.tgz.partial` and removes them. The
+`bkps_*` glob is intentionally level-agnostic, so it also clears partials left by prior
+runs at other `export_level`s (`bkps_books_*`, `bkps_chapters_*`) — an orphaned
+intermediate is always junk. It still runs before the new run writes anything, so it only
+ever matches earlier runs' leftovers, never an in-progress archive or a completed `.tgz`.
 
 #### Health Endpoint
 

--- a/README.md
+++ b/README.md
@@ -643,17 +643,7 @@ bookstack_export_2023-11-28_06-24-25/programming/react/nextjs.pdf
 Books without a shelf will be put in a shelve folder named `unassigned`.
 
 #### Empty/New Pages
-Empty/New Pages will be ignored since they have not been modified yet from creation and are empty but also do not have a valid slug. 
-
-Example from Bookstack API:
-```
-{
-    ...
-    "name": "New Page",
-    "slug": "",
-    ...
-}
-```
+Empty/New Pages are ignored: they have not been modified from creation, so they have no content and no valid slug. From the Bookstack API they appear as `"name": "New Page"` with an empty `"slug": ""`.
 
 ### Images
 Images will be dumped in a separate directory, `images` within the page parent (book/chapter) directory it belongs to. The relative path will be `{parent}/images/{page}/{image_name}`. As shown earlier:
@@ -696,8 +686,6 @@ The configuration item, `assets.modify_links`, can be set to `true` to rewrite i
 - **Legacy alias**: the old key `modify_markdown` will be removed in a future version. Rename to `modify_links` in your configuration.
 
 #### Markdown example
-
-Page (parent) -> Images (children) relationships are created and then each image/attachment URL is replaced with its respective local export path.
 
 ```
 ## before
@@ -746,9 +734,7 @@ Attachment links are rewritten from the live URL to a local relative path.
 
 #### Known limitations
 
-Markdown exports use raw `bytes.replace` — no structural awareness (e.g. DOM). If an attachment URL for some reason appears verbatim anywhere in the markdown source (code block, pre, comment, plain text), it gets replaced.
-
-HTML exports are safe because bs4 filters to only `<img src> / <a href>` attributes before replacing.
+Markdown link rewriting is a plain text substitution: if an asset URL appears verbatim anywhere in the markdown (code block, comment, plain text), it is also rewritten. HTML rewriting is scoped to `<img src>` / `<a href>` attributes only, so it is unaffected.
 
 ## Object Storage
 Optionally, target(s) can be specified to upload generated archives to a remote location. Supported object storage providers can be found below:

--- a/README.md
+++ b/README.md
@@ -194,6 +194,23 @@ Two scheduling strategies are available for application mode (mutually exclusive
 
 Pass `--run-once` to force a single run regardless of `run_interval` or `run_schedule`.
 
+#### Graceful shutdown & grace periods
+
+In scheduled mode the exporter handles `SIGTERM`/`SIGINT` gracefully: it stops at
+the next asset/format/node boundary, discards any partial archive, and exits `0`. A
+**second** identical signal force-kills immediately (exit `130` for SIGINT, `143` for
+SIGTERM).
+
+Because a single in-flight export call (e.g. a large-book PDF render) cannot be
+interrupted mid-request, give the container enough time to drain:
+
+- Docker: `docker stop -t 60 <container>` (default is 10s).
+- Compose: set `stop_grace_period: 60s` (raise for large instances).
+- Kubernetes: set `terminationGracePeriodSeconds: 60`.
+
+If the grace window elapses the orchestrator sends SIGKILL; the next run's start-up
+sweep removes any leftover partial archive.
+
 #### Health Endpoint
 
 In scheduled mode (`run_interval` or `run_schedule`), set `health_port` to expose an

--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ succeeded — a cycle that errored is logged, notified, and reflected in `/healt
 the next signal still exits `0`. Alert on notifications or the health endpoint, not on
 the process exit code.
 
+One-shot mode (`--run-once`, or no `run_interval`/`run_schedule`) does not drain on a
+signal — it aborts the current run — but it still discards any partial archive on
+`SIGTERM`/`SIGINT` and exits `128+signum` (`130` for SIGINT, `143` for SIGTERM). This
+keeps an ephemeral one-shot container (`docker run --rm`, a k8s `Job`) from leaving a
+`.tgz.partial` on a mounted volume where no later run would sweep it.
+
 Because a single in-flight export call (e.g. a large-book PDF render) cannot be
 interrupted mid-request, give the container enough time to drain:
 

--- a/README.md
+++ b/README.md
@@ -196,39 +196,26 @@ Pass `--run-once` to force a single run regardless of `run_interval` or `run_sch
 
 #### Graceful shutdown & grace periods
 
-In scheduled mode the exporter handles `SIGTERM`/`SIGINT` gracefully: it stops at
-the next asset/format/node boundary, discards any partial archive, and exits `0`. A
-**second** signal (any of SIGTERM/SIGINT, not only an identical repeat) force-kills
-immediately (exit `130` for SIGINT, `143` for SIGTERM).
+In scheduled mode `SIGTERM`/`SIGINT` shuts down gracefully: the exporter stops at the
+next asset/format/node boundary, discards any partial archive, and exits `0`. A second
+signal force-kills immediately (`130` for SIGINT, `143` for SIGTERM). Exit `0` means a
+clean shutdown, **not** that the last cycle succeeded — alert on notifications or
+`/healthz`, not on the exit code.
 
-Exit `0` here means the process shut down cleanly, **not** that the final cycle
-succeeded — a cycle that errored is logged, notified, and reflected in `/healthz`, then
-the next signal still exits `0`. Alert on notifications or the health endpoint, not on
-the process exit code.
+One-shot mode (`--run-once`, or no `run_interval`/`run_schedule`) aborts the current run
+on a signal rather than draining, but still discards any partial archive and exits
+`130`/`143`.
 
-One-shot mode (`--run-once`, or no `run_interval`/`run_schedule`) does not drain on a
-signal — it aborts the current run — but it still discards any partial archive on
-`SIGTERM`/`SIGINT` and exits `128+signum` (`130` for SIGINT, `143` for SIGTERM). This
-keeps an ephemeral one-shot container (`docker run --rm`, a k8s `Job`) from leaving a
-`.tgz.partial` on a mounted volume where no later run would sweep it.
-
-Because a single in-flight export call (e.g. a large-book PDF render) cannot be
-interrupted mid-request, give the container enough time to drain:
+A single in-flight export call (e.g. a large-book PDF render) cannot be interrupted
+mid-request, so give the container time to drain:
 
 - Docker: `docker stop -t 60 <container>` (default is 10s).
 - Compose: set `stop_grace_period: 60s` (raise for large instances).
 - Kubernetes: set `terminationGracePeriodSeconds: 60`.
 
-If the grace window elapses the orchestrator sends SIGKILL, which cannot be caught,
-so cleanup is deferred to the next run. Each archive is built under a timestamped base
-name (e.g. `bkps_2026-06-22_00-09-33`): first an intermediate `.tar`, then a
-`.tgz.partial` that is atomically renamed to the final `.tgz` on success. A SIGKILL can
-therefore strand a `<base>.tar` or `<base>.tgz.partial`. At start-up the next run sweeps
-the output directory for `bkps_*.tar` and `bkps_*.tgz.partial` and removes them. The
-`bkps_*` glob is intentionally level-agnostic, so it also clears partials left by prior
-runs at other `export_level`s (`bkps_books_*`, `bkps_chapters_*`) — an orphaned
-intermediate is always junk. It still runs before the new run writes anything, so it only
-ever matches earlier runs' leftovers, never an in-progress archive or a completed `.tgz`.
+If the grace window elapses the orchestrator sends an uncatchable SIGKILL, which can
+strand a partial archive. The next run sweeps leftover `.tar`/`.tgz.partial` files (at
+any export level) before it writes anything; a finished `.tgz` is never touched.
 
 #### Health Endpoint
 

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -105,6 +105,7 @@ class Archiver:
         partial = f"{self._archiver.archive_file}.partial"
         for path in (self._archiver.tar_file, partial):
             if os.path.exists(path):
+                log.info("Cleaning up partial archive: %s", path)
                 util.remove_file(path)
 
     def sweep_orphans(self):

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -111,9 +111,12 @@ class Archiver:
     def sweep_orphans(self):
         """Delete prior-run .tar / .tgz.partial orphans (SIGKILL backstop).
 
-        Run at the start of a cycle. Reuses scan_archives (globs {base}_*{ext}), so
-        only timestamped leftovers from earlier runs match — never the current run's
-        not-yet-written files. Also retro-cleans .tar orphans from past failed cycles.
+        Run at the start of a cycle, BEFORE this run writes any tar or .partial.
+        Safety comes from that ordering, not the glob: scan_archives globs
+        {base}_*{ext}, which would also match this run's own filenames — but none
+        exist on disk yet, so only earlier runs' leftovers are removed. Moving this
+        call after any write would make it delete the live tar. Also retro-cleans
+        .tar orphans from past failed cycles.
         """
         tgz_ext = self._archiver.file_extension_map['tgz']
         for ext in (self._archiver.file_extension_map['tar'], f"{tgz_ext}.partial"):

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -93,7 +93,7 @@ class Archiver:
         One-shot mode never calls this, so the archiver's flag stays None (no-op
         at every checkpoint). Scheduled mode forwards its threading.Event here.
         """
-        self._archiver._stop = stop
+        self._archiver._stop = stop  # pylint: disable=protected-access
 
     def discard_partial(self):
         """Remove this run's intermediate tar and any .tgz.partial; never the final .tgz.

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -115,12 +115,18 @@ class Archiver:
         Safety comes from that ordering, not the glob: scan_archives globs
         {base}_*{ext}, which would also match this run's own filenames — but none
         exist on disk yet, so only earlier runs' leftovers are removed. Moving this
-        call after any write would make it delete the live tar. Also retro-cleans
-        .tar orphans from past failed cycles.
+        call after any write would make it delete the live tar.
+
+        Globs on the unscoped base_dir_name (e.g. `bkps`), not the level-scoped
+        base_dir (`bkps_books`): intermediates are always junk regardless of export
+        level, so `bkps_*` clears partials stranded by prior runs at any level. The
+        `bkps_` prefix still anchors the scan so unrelated files are never touched.
+        (keep_last retention deliberately stays level-scoped — those are deliverables.)
+        Also retro-cleans .tar orphans from past failed cycles.
         """
         tgz_ext = self._archiver.file_extension_map['tgz']
         for ext in (self._archiver.file_extension_map['tar'], f"{tgz_ext}.partial"):
-            for path in util.scan_archives(self.base_dir, ext):
+            for path in util.scan_archives(self.config.base_dir_name, ext):
                 util.remove_file(path)
 
     def get_bookstack_exports(self, nodes: dict[int, Node]):

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -87,6 +87,38 @@ class Archiver:
                         "attempting to skip this step")
             return
 
+    def set_stop(self, stop):
+        """Inject the shutdown flag into the node archiver for cooperative cancel.
+
+        One-shot mode never calls this, so the archiver's flag stays None (no-op
+        at every checkpoint). Scheduled mode forwards its threading.Event here.
+        """
+        self._archiver._stop = stop
+
+    def discard_partial(self):
+        """Remove this run's intermediate tar and any .tgz.partial; never the final .tgz.
+
+        Idempotent and missing-file tolerant: an all-empty cycle writes no tar, and
+        a successful run has already consumed the tar and renamed the .partial away,
+        so this is a no-op on the success path.
+        """
+        partial = f"{self._archiver.archive_file}.partial"
+        for path in (self._archiver.tar_file, partial):
+            if os.path.exists(path):
+                util.remove_file(path)
+
+    def sweep_orphans(self):
+        """Delete prior-run .tar / .tgz.partial orphans (SIGKILL backstop).
+
+        Run at the start of a cycle. Reuses scan_archives (globs {base}_*{ext}), so
+        only timestamped leftovers from earlier runs match — never the current run's
+        not-yet-written files. Also retro-cleans .tar orphans from past failed cycles.
+        """
+        tgz_ext = self._archiver.file_extension_map['tgz']
+        for ext in (self._archiver.file_extension_map['tar'], f"{tgz_ext}.partial"):
+            for path in util.scan_archives(self.base_dir, ext):
+                util.remove_file(path)
+
     def get_bookstack_exports(self, nodes: dict[int, Node]):
         """export all node content (polymorphic: pages, books, or chapters)"""
         log.info("Exporting all bookstack contents")

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -140,6 +140,8 @@ class NodeArchiver:
         failed_assets: set[int] = set()
         node_base_path = f"{self.archive_base_path}/{parent_path}"
         for asset_node in asset_nodes:
+            if self._stop_requested():
+                break
             try:
                 asset_data = self.asset_archiver.get_asset_bytes(
                     asset_type, asset_node.download_url)
@@ -222,8 +224,17 @@ class NodeArchiver:
         if (self.export_images or self.export_attachments) and not self.modify_links:
             log.info("Assets downloaded but links not rewritten (modify_links disabled)")
         for _, node in nodes.items():
+            # Cooperative cancellation: a shutdown signal set the flag; bail at this
+            # node boundary. Partial output is always discarded (exporter() finally),
+            # so an early return needs no consistent state.
+            if self._stop_requested():
+                return
             assets_by_page = self._download_node_assets(node, image_map, attachment_map)
             for fmt in self.export_formats:
+                # Per-format checkpoint: a single book/chapter export call can be slow
+                # (server-side render); stop between formats instead of after all of them.
+                if self._stop_requested():
+                    return
                 url = f"{self.api_urls[resource_type]}/{node.id_}/export/{fmt}"
                 try:
                     data = self._get_node_data(url)
@@ -247,6 +258,8 @@ class NodeArchiver:
         page_names = self._asset_page_map(node)
         grouped = {"images": {}, "attachments": {}}
         for asset_type, amap in (("images", image_map), ("attachments", attachment_map)):
+            if self._stop_requested():
+                break
             for page_id, page_name in page_names.items():
                 assets = amap.get(page_id)
                 if not assets:

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -300,8 +300,15 @@ class NodeArchiver:
         archiver_util.write_tar(self.tar_file, file_path, data)
 
     def gzip_archive(self):
-        """Provide the tar to gzip and the name of the gzip output file."""
-        archiver_util.create_gzip(self.tar_file, self.archive_file)
+        """Gzip the tar atomically: write to a .partial then rename to the final .tgz.
+
+        Same-filesystem os.rename is atomic, so a consumer or the next run never
+        observes a half-written .tgz (a SIGKILL/crash mid-gzip leaves only the
+        .partial, which the run-start sweep removes).
+        """
+        partial = f"{self.archive_file}.partial"
+        archiver_util.create_gzip(self.tar_file, partial)
+        os.rename(partial, self.archive_file)
 
     @property
     def file_extension_map(self) -> dict[str, str]:

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -65,6 +65,15 @@ class NodeArchiver:
             else self._default_asset_archiver(api_urls, http_client)
         )
         self.modify_links: bool = self._check_links_modify()
+        # Cooperative-shutdown flag, injected by Archiver.set_stop() in scheduled
+        # mode (stays None in one-shot mode). Polled at export checkpoints below;
+        # the signal handler only SETS this flag (it cannot safely raise across
+        # arbitrary code), so the export must poll it to cancel.
+        self._stop = None
+
+    def _stop_requested(self) -> bool:
+        """True when a shutdown signal has flagged this run for cancellation."""
+        return self._stop is not None and self._stop.is_set()
 
     def _default_asset_archiver(self, api_urls: dict[str, str], http_client: HttpHelper):
         """Build an AssetArchiver when no double is injected, or return None if assets disabled."""

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -22,13 +22,35 @@ class NodeExporter():
         NodeExporter instance to handle building shelve/book/chapter/page relations.
     """
     def __init__(self, api_urls: dict[str, str], http_client: HttpHelper,
-                 node_filter: Optional[NodeFilter] = None):
+                 node_filter: Optional[NodeFilter] = None, stop=None):
         self.api_urls = api_urls
         self.http_client = http_client
         self._node_filter = node_filter
+        # Cooperative-cancel flag (threading.Event). None in one-shot mode so the
+        # checks below are no-ops. Scheduled mode injects its shutdown Event so a
+        # signal mid-fetch halts the tree walk at the next node boundary instead of
+        # fetching the entire tree first. Twin of NodeArchiver._stop (archive phase).
+        self._stop = stop
         # Tracks book IDs belonging to dropped shelves; consumed in get_unassigned_books.
         # Populated in get_all_shelves, pruned in get_all_books before unassigned check.
         self._excluded_book_ids: set[int] = set()
+
+    def _stop_requested(self) -> bool:
+        """True when a shutdown signal has flagged this run for cancellation."""
+        return self._stop is not None and self._stop.is_set()
+
+    def _until_stop(self, items):
+        """Yield from items until a shutdown signal is flagged, then stop.
+
+        Wraps each fetch loop's iterable so cancellation lives in one place. This
+        is also the seam a future parallel exporter would attach to: the same
+        boundary that breaks the loop today would stop draining into a thread
+        pool's submit() tomorrow.
+        """
+        for item in items:
+            if self._stop_requested():
+                return
+            yield item
 
     def get_all_shelves(self) -> dict[int, Node]:
         """
@@ -61,7 +83,7 @@ class NodeExporter():
     def _get_parents(self, base_url: str, parent_ids: list[int],
                       path_prefix: str = "") -> dict[int, Node]:
         parent_nodes = {}
-        for parent_id in parent_ids:
+        for parent_id in self._until_stop(parent_ids):
             parent_url = f"{base_url}/{parent_id}"
             parent_data = self._get_json_response(parent_url)
             parent_nodes[parent_id] = Node(parent_data, path_prefix=path_prefix)
@@ -75,7 +97,7 @@ class NodeExporter():
         """
         base_url = self.api_urls["chapters"]
         chapter_nodes = {}
-        for book_node in book_nodes.values():
+        for book_node in self._until_stop(book_nodes.values()):
             for child in selector.selectable_children(
                     book_node.children, "chapters", self._node_filter, node_type="chapter"):
                 chapter_id = child['id']
@@ -93,7 +115,7 @@ class NodeExporter():
     def _get_children(self, base_url: str, resource_type: str, parent_nodes: dict[int, Node],
                       filter_empty: bool, node_type: str = "") -> dict[int, Node]:
         child_nodes = {}
-        for _, parent in parent_nodes.items():
+        for _, parent in self._until_stop(parent_nodes.items()):
             if not parent.children:
                 continue
             for child in selector.selectable_children(

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -102,10 +102,10 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
     return 0
 
 
-def run(config: ConfigNode):
+def run(config: ConfigNode, stop=None):
     """run export process with error handling and notification support"""
     try:
-        result = exporter(config)
+        result = exporter(config, stop)
         if config.user_inputs.notifications:
             notif = NotifyHandler(config.user_inputs.notifications)
             notif.do_notify(result=result)
@@ -121,7 +121,7 @@ def run(config: ConfigNode):
         # raise original error instead of notification error
         raise run_err
 
-def exporter(config: ConfigNode):
+def exporter(config: ConfigNode, stop=None):
     """export bookstack nodes and archive locally and/or remotely"""
 
     #### Export Data #####
@@ -146,8 +146,15 @@ def exporter(config: ConfigNode):
     ## Build archiver before the level branch (shared for all levels)
     archive: Archiver = Archiver(config, http_client)
 
+    # Inject the cooperative-shutdown flag (None in one-shot mode = no-op).
+    archive.set_stop(stop)
+
     # create export directory if not exists
     archive.create_export_dir()
+
+    # Remove orphaned .tar/.tgz.partial from prior runs (SIGKILL backstop) before
+    # this cycle writes anything.
+    archive.sweep_orphans()
 
     ## Select nodes by export level
     export_level = config.user_inputs.export_level
@@ -167,24 +174,38 @@ def exporter(config: ConfigNode):
         return None
 
     log.info("Beginning archive")
-    # get all content for each node
-    archive.get_bookstack_exports(nodes)
-    # nothing was written to the tar (e.g. every node empty or all fetches failed):
-    # skip gzip/upload/cleanup so we don't crash gzipping a non-existent tar.
-    if not archive.has_exported_content:
-        log.warning("No %s content was archived. Nothing to upload", export_level)
-        return None
+    try:
+        # get all content for each node
+        archive.get_bookstack_exports(nodes)
 
-    # create tar if needed and gzip tar
-    archive.create_archive()
+        # Graceful shutdown requested mid-cycle: drop the partial tar and skip
+        # gzip/upload/cleanup so a cancelled cycle never produces an archive.
+        if stop is not None and stop.is_set():
+            log.info("Shutdown requested mid-cycle; discarding partial export")
+            return None
 
-    # archive to remote targets
-    remote = archive.archive_remote()
-    # if remote target is specified and clean is true
-    # clean up the .tgz archive since it is already uploaded
-    removed = archive.clean_up()
+        # nothing was written to the tar (e.g. every node empty or all fetches failed):
+        # skip gzip/upload/cleanup so we don't crash gzipping a non-existent tar.
+        if not archive.has_exported_content:
+            log.warning("No %s content was archived. Nothing to upload", export_level)
+            return None
 
-    local = archive.archive_file
-    log.info("Created file archive: %s.tgz", archive.archive_dir)
-    log.info("Completed run")
-    return NotifyResult(local=local, remote=remote, removed=removed)
+        # create tar if needed and gzip tar
+        archive.create_archive()
+
+        # archive to remote targets
+        remote = archive.archive_remote()
+        # if remote target is specified and clean is true
+        # clean up the .tgz archive since it is already uploaded
+        removed = archive.clean_up()
+
+        local = archive.archive_file
+        log.info("Created file archive: %s.tgz", archive.archive_dir)
+        log.info("Completed run")
+        return NotifyResult(local=local, remote=remote, removed=removed)
+    finally:
+        # Eager cleanup of THIS cycle's partial on every terminal path (stop,
+        # exception, one-shot KeyboardInterrupt). No-op on success: the tar is
+        # already consumed and the .partial renamed away. The run-start sweep is
+        # the backstop for SIGKILL, which kills the process before finally runs.
+        archive.discard_partial()

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -62,11 +62,13 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
         # stop.wait() below); the export polls it at checkpoints to cancel.
         log.info("Received signal %s, shutting down (signal again to force)", signum)
         stop.set()
-        # Restore the default disposition for THIS signal so a second, identical
-        # signal force-kills via the kernel with the correct exit code
-        # (SIGINT->130, SIGTERM->143) — an operator escape hatch if a slow
-        # in-flight download won't drain inside the grace window.
-        signal.signal(signum, signal.SIG_DFL)
+        # Restore the default disposition for BOTH catchable signals so that ANY
+        # second signal — not only an identical repeat — force-kills via the
+        # kernel with its conventional exit code (SIGINT->130, SIGTERM->143). This
+        # is an operator escape hatch if a slow in-flight download won't drain
+        # inside the grace window (e.g. `docker stop` then an impatient Ctrl-C).
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -145,7 +145,7 @@ def exporter(config: ConfigNode, stop=None):
 
     ## Use exporter class to get all the resources (pages, books, etc.) and their relationships
     log.info("Building shelve/book/chapter/page relationships")
-    export_helper = NodeExporter(config.urls, http_client, node_filter=node_filter)
+    export_helper = NodeExporter(config.urls, http_client, node_filter=node_filter, stop=stop)
     ## shelves
     shelve_nodes: dict[int, Node] = export_helper.get_all_shelves()
     ## books (always needed - basis for all export levels)
@@ -174,6 +174,12 @@ def exporter(config: ConfigNode, stop=None):
     else:
         # default: "pages"
         nodes = export_helper.get_all_pages(book_nodes)
+
+    # A shutdown signal during the fetch above leaves the node tree truncated.
+    # Skip the archive phase entirely rather than emit a partial export.
+    if stop is not None and stop.is_set():
+        log.info("Shutdown requested during fetch; skipping archive")
+        return None
 
     if not nodes:
         log.warning(

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -56,8 +56,17 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
     stop = threading.Event()
 
     def _handle_signal(signum, _frame):
-        log.info("Received signal %s, shutting down", signum)
+        # Signal handlers run in the main thread between bytecodes, mid-anything;
+        # raising across arbitrary code is unsafe and SIGTERM has no default
+        # exception. So we only SET a flag (also breaks the interruptible
+        # stop.wait() below); the export polls it at checkpoints to cancel.
+        log.info("Received signal %s, shutting down (signal again to force)", signum)
         stop.set()
+        # Restore the default disposition for THIS signal so a second, identical
+        # signal force-kills via the kernel with the correct exit code
+        # (SIGINT->130, SIGTERM->143) — an operator escape hatch if a slow
+        # in-flight download won't drain inside the grace window.
+        signal.signal(signum, signal.SIG_DFL)
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
@@ -75,7 +84,7 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
         if status:
             status.mark_running()
         try:
-            result = run(config)
+            result = run(config, stop)
             if status:
                 status.mark_success(result)
         except Exception as err:  # pylint: disable=broad-except

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -38,13 +38,37 @@ def entrypoint(args: argparse.Namespace) -> int:
 
 
 def _run_once(config: ConfigNode) -> int:
-    """Run the export exactly once and return an exit code."""
+    """Run the export exactly once and return an exit code.
+
+    A SIGTERM/SIGINT mid-run raises KeyboardInterrupt so the export's finally
+    block discards any partial archive before exiting. This matters for ephemeral
+    one-shot containers (`docker run --rm`, a k8s Job) where no later run exists
+    to sweep a stranded `.tgz.partial` off the output volume. Raising mid-write is
+    safe here because the only local artifacts are the tar/.partial, which
+    discard_partial removes (a signal during a remote upload may still leave a
+    partial object on the remote — same as any interrupted upload, not specific to
+    this path). The first signal also restores the default
+    disposition for both signals so a second signal force-kills via the kernel.
+    Exit code is 128+signum (SIGINT->130, SIGTERM->143).
+    """
+    received = {}
+
+    def _handle_signal(signum, _frame):
+        received["signum"] = signum
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        raise KeyboardInterrupt
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+
     try:
         run(config)
         return 0
     except KeyboardInterrupt:
-        log.info("Interrupted, exiting")
-        return 130
+        signum = int(received.get("signum", signal.SIGINT))
+        log.info("Interrupted by signal %s, exiting", signum)
+        return 128 + signum
     except Exception as err:  # pylint: disable=broad-except
         log.error("Export failed: %s", err)
         log.debug("Traceback:", exc_info=True)

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -43,6 +43,60 @@ def archiver_instance(mock_config, mock_http_client):
 # _generate_root_folder
 # ---------------------------------------------------------------------------
 
+class TestSetStop:
+    def test_set_stop_forwards_to_node_archiver(self, archiver_instance):
+        import threading
+        ev = threading.Event()
+        archiver_instance.set_stop(ev)
+        assert archiver_instance._archiver._stop is ev
+
+
+class TestDiscardPartial:
+    def test_removes_tar_and_partial_when_present(self, archiver_instance, tmp_path):
+        tar = tmp_path / "bkps_2026.tar"
+        partial = tmp_path / "bkps_2026.tgz.partial"
+        tar.write_bytes(b"x"); partial.write_bytes(b"y")
+        archiver_instance._archiver.tar_file = str(tar)
+        archiver_instance._archiver.archive_file = str(tmp_path / "bkps_2026.tgz")
+
+        archiver_instance.discard_partial()
+
+        assert not tar.exists()
+        assert not partial.exists()
+
+    def test_no_error_when_nothing_to_discard(self, archiver_instance, tmp_path):
+        archiver_instance._archiver.tar_file = str(tmp_path / "absent.tar")
+        archiver_instance._archiver.archive_file = str(tmp_path / "absent.tgz")
+        # must not raise (all-empty cycle writes no tar)
+        archiver_instance.discard_partial()
+
+    def test_does_not_touch_final_tgz(self, archiver_instance, tmp_path):
+        final = tmp_path / "bkps_2026.tgz"
+        final.write_bytes(b"done")
+        archiver_instance._archiver.tar_file = str(tmp_path / "bkps_2026.tar")
+        archiver_instance._archiver.archive_file = str(final)
+        archiver_instance.discard_partial()
+        assert final.exists()
+
+
+class TestSweepOrphans:
+    def test_removes_prior_tar_and_partial_orphans(self, archiver_instance, tmp_path):
+        from bookstack_file_exporter.archiver.node_archiver import _FILE_EXTENSION_MAP
+        archiver_instance.base_dir = str(tmp_path / "bkps")
+        archiver_instance._archiver.file_extension_map = _FILE_EXTENSION_MAP
+        orphan_tar = tmp_path / "bkps_2026-01-01.tar"
+        orphan_partial = tmp_path / "bkps_2026-01-01.tgz.partial"
+        keep_tgz = tmp_path / "bkps_2026-01-01.tgz"
+        for f in (orphan_tar, orphan_partial, keep_tgz):
+            f.write_bytes(b"x")
+
+        archiver_instance.sweep_orphans()
+
+        assert not orphan_tar.exists()
+        assert not orphan_partial.exists()
+        assert keep_tgz.exists()  # finished archives are not swept
+
+
 class TestHasExportedContent:
     """has_exported_content reflects whether the intermediate tar exists on disk."""
 

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -101,7 +101,7 @@ class TestDiscardPartial:
 class TestSweepOrphans:
     def test_removes_prior_tar_and_partial_orphans(self, archiver_instance, tmp_path):
         from bookstack_file_exporter.archiver.node_archiver import _FILE_EXTENSION_MAP
-        archiver_instance.base_dir = str(tmp_path / "bkps")
+        archiver_instance.config.base_dir_name = str(tmp_path / "bkps")
         archiver_instance._archiver.file_extension_map = _FILE_EXTENSION_MAP
         orphan_tar = tmp_path / "bkps_2026-01-01.tar"
         orphan_partial = tmp_path / "bkps_2026-01-01.tgz.partial"
@@ -114,6 +114,29 @@ class TestSweepOrphans:
         assert not orphan_tar.exists()
         assert not orphan_partial.exists()
         assert keep_tgz.exists()  # finished archives are not swept
+
+    def test_sweeps_orphans_across_export_levels(self, mock_config, mock_http_client,
+                                                 tmp_path):
+        """Orphan intermediates are always junk, so the sweep clears partials left by
+        prior runs at OTHER export levels, not just its own level's base."""
+        from bookstack_file_exporter.archiver.node_archiver import _FILE_EXTENSION_MAP
+        mock_config.base_dir_name = str(tmp_path / "bkps")
+        mock_config.user_inputs.export_level = "books"
+        archiver = Archiver(mock_config, mock_http_client, node_archiver=MagicMock())
+        archiver._archiver.file_extension_map = _FILE_EXTENSION_MAP
+        pages_partial = tmp_path / "bkps_2026-01-01.tgz.partial"
+        books_partial = tmp_path / "bkps_books_2026-01-01.tgz.partial"
+        chapters_partial = tmp_path / "bkps_chapters_2026-01-01.tgz.partial"
+        keep_tgz = tmp_path / "bkps_2026-01-01.tgz"
+        for f in (pages_partial, books_partial, chapters_partial, keep_tgz):
+            f.write_bytes(b"x")
+
+        archiver.sweep_orphans()
+
+        assert not pages_partial.exists()
+        assert not books_partial.exists()
+        assert not chapters_partial.exists()
+        assert keep_tgz.exists()  # finished archives are never swept
 
 
 class TestHasExportedContent:

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -64,6 +64,25 @@ class TestDiscardPartial:
         assert not tar.exists()
         assert not partial.exists()
 
+    def test_logs_each_removed_path(self, archiver_instance, tmp_path, caplog):
+        tar = tmp_path / "bkps_2026.tar"
+        tar.write_bytes(b"x")
+        archiver_instance._archiver.tar_file = str(tar)
+        archiver_instance._archiver.archive_file = str(tmp_path / "bkps_2026.tgz")
+
+        with caplog.at_level(logging.INFO):
+            archiver_instance.discard_partial()
+
+        assert any(str(tar) in r.message and "partial" in r.message.lower()
+                   for r in caplog.records)
+
+    def test_no_log_when_nothing_to_discard(self, archiver_instance, tmp_path, caplog):
+        archiver_instance._archiver.tar_file = str(tmp_path / "absent.tar")
+        archiver_instance._archiver.archive_file = str(tmp_path / "absent.tgz")
+        with caplog.at_level(logging.INFO):
+            archiver_instance.discard_partial()
+        assert not any("partial" in r.message.lower() for r in caplog.records)
+
     def test_no_error_when_nothing_to_discard(self, archiver_instance, tmp_path):
         archiver_instance._archiver.tar_file = str(tmp_path / "absent.tar")
         archiver_instance._archiver.archive_file = str(tmp_path / "absent.tgz")

--- a/tests/unit/test_node_exporter.py
+++ b/tests/unit/test_node_exporter.py
@@ -1,6 +1,7 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name,unused-argument,protected-access
 """Unit tests for NodeExporter."""
 import logging
+import threading
 
 import pytest
 
@@ -28,6 +29,55 @@ def _make_filter(**kwargs) -> NodeFilter:
     """
     rf_kwargs = {k: ResourceFilter(**v) for k, v in kwargs.items()}
     return NodeFilter(Filters(**rf_kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Cooperative cancellation (stop flag) — a shutdown signal mid-fetch must halt
+# the tree walk at the next node boundary instead of fetching the whole tree.
+# ---------------------------------------------------------------------------
+
+def test_stop_set_halts_parent_fetch(api_urls, mock_http_client):
+    """A set stop flag breaks the parent fetch before any detail GET."""
+    stop = threading.Event()
+    stop.set()
+    mock_http_client.http_get_all.return_value = [{"id": 1}, {"id": 2}]
+    exporter = NodeExporter(api_urls, mock_http_client, stop=stop)
+    result = exporter.get_all_shelves()
+    assert not result
+    mock_http_client.http_get_request.assert_not_called()
+
+
+def test_stop_set_halts_child_fetch(api_urls, mock_http_client, shelf_detail):
+    """A set stop flag breaks the child fetch before any detail GET."""
+    stop = threading.Event()
+    stop.set()
+    shelf_node = Node(shelf_detail)
+    exporter = NodeExporter(api_urls, mock_http_client, stop=stop)
+    result = exporter.get_child_nodes("books", {1: shelf_node})
+    assert not result
+    mock_http_client.http_get_request.assert_not_called()
+
+
+def test_stop_set_halts_chapter_fetch(api_urls, mock_http_client, book_detail_mixed):
+    """A set stop flag breaks the chapter walk before any detail GET."""
+    stop = threading.Event()
+    stop.set()
+    book_node = Node(book_detail_mixed)
+    exporter = NodeExporter(api_urls, mock_http_client, stop=stop)
+    result = exporter.get_chapter_nodes({10: book_node})
+    assert not result
+    mock_http_client.http_get_request.assert_not_called()
+
+
+def test_clear_stop_does_not_halt_fetch(api_urls, mock_http_client, shelf_detail):
+    """A cleared (un-set) stop flag leaves the fetch fully intact."""
+    stop = threading.Event()  # not set
+    mock_http_client.http_get_all.return_value = [{"id": 1}]
+    mock_http_client.http_get_request.return_value = make_response(shelf_detail)
+    exporter = NodeExporter(api_urls, mock_http_client, stop=stop)
+    result = exporter.get_all_shelves()
+    assert 1 in result
+    assert mock_http_client.http_get_request.call_count == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -55,6 +55,69 @@ class TestStopFlag:
         assert page_archiver._stop_requested() is True
 
 
+class TestCooperativeCancellation:
+    def test_export_nodes_bails_before_first_node_when_stopped(self, page_archiver):
+        import threading
+        ev = threading.Event(); ev.set()
+        page_archiver._stop = ev
+        page_archiver._download_node_assets = MagicMock()
+        page_archiver._get_node_data = MagicMock()
+
+        nodes = {1: MagicMock(), 2: MagicMock()}
+        page_archiver._export_nodes(nodes, "pages", {}, {})
+
+        page_archiver._download_node_assets.assert_not_called()
+        page_archiver._get_node_data.assert_not_called()
+
+    def test_export_nodes_stops_between_nodes(self, page_archiver):
+        import threading
+        ev = threading.Event()
+        page_archiver._stop = ev
+        page_archiver._download_node_assets = MagicMock(return_value={})
+        # set the flag the moment the first node's data is fetched
+        page_archiver._get_node_data = MagicMock(side_effect=lambda url: ev.set() or b"data")
+        page_archiver._archive_node = MagicMock()
+        page_archiver._archive_node_meta = MagicMock()
+        page_archiver.export_formats = ["markdown"]
+        page_archiver.export_meta = False
+
+        n1, n2 = MagicMock(), MagicMock()
+        n1.id_, n2.id_ = 1, 2
+        page_archiver._export_nodes({1: n1, 2: n2}, "pages", {}, {})
+
+        # only the first node was fetched; loop broke before the second
+        assert page_archiver._get_node_data.call_count == 1
+
+    def test_download_node_assets_breaks_asset_type_loop_when_stopped(self, page_archiver):
+        import threading
+        ev = threading.Event(); ev.set()
+        page_archiver._stop = ev
+        page_archiver._archive_node_assets = MagicMock(return_value=set())
+        page_archiver._asset_page_map = MagicMock(return_value={1: "page-1"})
+
+        # non-empty maps so the early `return {}` guard does NOT short-circuit;
+        # the stop guard at the asset-type loop must break instead.
+        result = page_archiver._download_node_assets(
+            MagicMock(), {1: ["img"]}, {1: ["att"]})
+
+        page_archiver._archive_node_assets.assert_not_called()
+        assert result == {"images": {}, "attachments": {}}
+
+    def test_archive_node_assets_breaks_asset_loop_when_stopped(self, page_archiver):
+        import threading
+        ev = threading.Event(); ev.set()
+        page_archiver._stop = ev
+        # asset nodes present; the per-asset guard must break before the first one.
+        page_archiver.asset_archiver = MagicMock()
+        failed = page_archiver._archive_node_assets(
+            "images", "parent/path", "page-1", [MagicMock(), MagicMock()])
+
+        # broke immediately: no asset bytes were fetched (real download call is
+        # asset_archiver.get_asset_bytes, node_archiver.py:144)
+        page_archiver.asset_archiver.get_asset_bytes.assert_not_called()
+        assert failed == set()
+
+
 # ---------------------------------------------------------------------------
 # 1. Construction
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -32,6 +32,30 @@ def page_archiver(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# 0. Cooperative-shutdown stop flag
+# ---------------------------------------------------------------------------
+
+class TestStopFlag:
+    def test_stop_defaults_to_none(self, page_archiver):
+        assert page_archiver._stop is None
+
+    def test_stop_requested_false_when_unset(self, page_archiver):
+        assert page_archiver._stop_requested() is False
+
+    def test_stop_requested_false_when_event_clear(self, page_archiver):
+        import threading
+        page_archiver._stop = threading.Event()
+        assert page_archiver._stop_requested() is False
+
+    def test_stop_requested_true_when_event_set(self, page_archiver):
+        import threading
+        ev = threading.Event()
+        ev.set()
+        page_archiver._stop = ev
+        assert page_archiver._stop_requested() is True
+
+
+# ---------------------------------------------------------------------------
 # 1. Construction
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -210,14 +210,43 @@ class TestFileExtensionMap:
 # ---------------------------------------------------------------------------
 
 class TestGzipArchive:  # pylint: disable=too-few-public-methods  # test scaffolding stub
-    def test_create_gzip_called_with_tar_and_archive_file(self, page_archiver):
+    def test_create_gzip_called_with_tar_and_partial_then_renamed(self, page_archiver):
+        # gzip writes to the .partial path; os.rename promotes it to the final .tgz.
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.create_gzip"
-        ) as mock_create_gzip:
+        ) as mock_create_gzip, patch(
+            "bookstack_file_exporter.archiver.node_archiver.os.rename"
+        ) as mock_rename:
             page_archiver.gzip_archive()
-            mock_create_gzip.assert_called_once_with(
-                page_archiver.tar_file, page_archiver.archive_file
-            )
+            partial = f"{page_archiver.archive_file}.partial"
+            mock_create_gzip.assert_called_once_with(page_archiver.tar_file, partial)
+            mock_rename.assert_called_once_with(partial, page_archiver.archive_file)
+
+
+class TestAtomicGzip:  # pylint: disable=too-few-public-methods
+    def test_gzip_writes_via_partial_then_renames(self, page_archiver, tmp_path, monkeypatch):
+        import os
+        from bookstack_file_exporter.archiver import util as archiver_util
+
+        tar = tmp_path / "bkps_2026.tar"
+        tar.write_bytes(b"tar-bytes")
+        page_archiver.tar_file = str(tar)
+        page_archiver.archive_file = str(tmp_path / "bkps_2026.tgz")
+
+        seen_target = {}
+        real_create_gzip = archiver_util.create_gzip
+        def spy(file_path, gzip_file, remove_old=True):
+            seen_target["gzip_file"] = gzip_file
+            return real_create_gzip(file_path, gzip_file, remove_old)
+        monkeypatch.setattr(archiver_util, "create_gzip", spy)
+
+        page_archiver.gzip_archive()
+
+        # gzip was written to the .partial path, not the final name
+        assert seen_target["gzip_file"].endswith(".tgz.partial")
+        # final archive exists; no partial left behind
+        assert os.path.exists(page_archiver.archive_file)
+        assert not os.path.exists(page_archiver.archive_file + ".partial")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -769,7 +769,23 @@ class TestExporterStopWiring:
         return SimpleNamespace(
             user_inputs=ui, headers={}, urls={}, unassigned_book_dir=None)
 
-    def test_exporter_sets_stop_and_sweeps_then_short_circuits(self):
+    def test_exporter_injects_stop_into_node_exporter(self):
+        cfg = self._cfg()
+        stop = threading.Event()
+        archive = MagicMock()
+        with patch.object(run, "HttpHelper"), \
+             patch.object(run, "NodeExporter") as mock_exp, \
+             patch.object(run, "Archiver", return_value=archive):
+            mock_exp.return_value.get_all_shelves.return_value = {}
+            mock_exp.return_value.get_all_books.return_value = {}
+            mock_exp.return_value.get_all_pages.return_value = {}
+            run.exporter(cfg, stop)
+
+        # the fetch layer must receive the same shutdown flag the archiver does
+        _, kwargs = mock_exp.call_args
+        assert kwargs["stop"] is stop
+
+    def test_exporter_skips_archive_when_stop_set_after_fetch(self):
         cfg = self._cfg()
         stop = threading.Event(); stop.set()
         archive = MagicMock()
@@ -783,7 +799,27 @@ class TestExporterStopWiring:
 
         archive.set_stop.assert_called_once_with(stop)
         archive.sweep_orphans.assert_called_once()
-        # stop was set -> short-circuit before create_archive, and discard ran
+        # cancelled during fetch -> skip the archive phase entirely (truncated tree)
+        archive.get_bookstack_exports.assert_not_called()
+        archive.create_archive.assert_not_called()
+        assert result is None
+
+    def test_exporter_discards_partial_on_mid_archive_stop(self):
+        cfg = self._cfg()
+        stop = threading.Event()  # not set during fetch
+        archive = MagicMock()
+        # simulate a signal landing while the archive loop runs
+        archive.get_bookstack_exports.side_effect = lambda _nodes: stop.set()
+        with patch.object(run, "HttpHelper"), \
+             patch.object(run, "NodeExporter") as mock_exp, \
+             patch.object(run, "Archiver", return_value=archive):
+            mock_exp.return_value.get_all_shelves.return_value = {}
+            mock_exp.return_value.get_all_books.return_value = {1: MagicMock()}
+            mock_exp.return_value.get_all_pages.return_value = {1: MagicMock()}
+            result = run.exporter(cfg, stop)
+
+        archive.get_bookstack_exports.assert_called_once()
+        # mid-cycle stop -> discard the partial tar, never gzip/upload
         archive.create_archive.assert_not_called()
         archive.discard_partial.assert_called_once()
         assert result is None

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -7,6 +7,8 @@ import threading
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
+import pytest
+
 from bookstack_file_exporter import run
 from bookstack_file_exporter.notify.models import NotifyResult
 
@@ -750,3 +752,52 @@ class TestScheduledHealthServer:
         assert snap["run_count"] == 1
         assert snap["last_run"]["status"] == "success"
         assert snap["last_run"]["archive_file"] == "export.tgz"
+
+
+# ---------------------------------------------------------------------------
+# exporter() — stop-flag wiring (set_stop / sweep_orphans / discard_partial)
+# ---------------------------------------------------------------------------
+
+class TestExporterStopWiring:
+    def _cfg(self):
+        # NOTE: unassigned_book_dir is read TOP-LEVEL by exporter()
+        # (`config.unassigned_book_dir`, run.py -> config_helper), NOT off
+        # user_inputs. Putting it under ui raises AttributeError.
+        ui = SimpleNamespace(
+            http_config=MagicMock(), filters=None, export_level="pages",
+            notifications=None)
+        return SimpleNamespace(
+            user_inputs=ui, headers={}, urls={}, unassigned_book_dir=None)
+
+    def test_exporter_sets_stop_and_sweeps_then_short_circuits(self):
+        cfg = self._cfg()
+        stop = threading.Event(); stop.set()
+        archive = MagicMock()
+        with patch.object(run, "HttpHelper"), \
+             patch.object(run, "NodeExporter") as mock_exp, \
+             patch.object(run, "Archiver", return_value=archive):
+            mock_exp.return_value.get_all_shelves.return_value = {}
+            mock_exp.return_value.get_all_books.return_value = {1: MagicMock()}
+            mock_exp.return_value.get_all_pages.return_value = {1: MagicMock()}
+            result = run.exporter(cfg, stop)
+
+        archive.set_stop.assert_called_once_with(stop)
+        archive.sweep_orphans.assert_called_once()
+        # stop was set -> short-circuit before create_archive, and discard ran
+        archive.create_archive.assert_not_called()
+        archive.discard_partial.assert_called_once()
+        assert result is None
+
+    def test_exporter_discards_partial_on_exception(self):
+        cfg = self._cfg()
+        archive = MagicMock()
+        archive.get_bookstack_exports.side_effect = RuntimeError("mid-cycle boom")
+        with patch.object(run, "HttpHelper"), \
+             patch.object(run, "NodeExporter") as mock_exp, \
+             patch.object(run, "Archiver", return_value=archive):
+            mock_exp.return_value.get_all_shelves.return_value = {}
+            mock_exp.return_value.get_all_books.return_value = {1: MagicMock()}
+            mock_exp.return_value.get_all_pages.return_value = {1: MagicMock()}
+            with pytest.raises(RuntimeError):
+                run.exporter(cfg, None)
+        archive.discard_partial.assert_called_once()

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -866,9 +866,11 @@ class TestDoubleSignalForceKill:
             mock_signal.reset_mock()
             captured["handler"](signal.SIGTERM, None)
 
-        # handler must (a) set stop, (b) restore SIG_DFL for that signum
+        # handler must (a) set stop, (b) restore SIG_DFL for BOTH catchable
+        # signals so any second signal (not just an identical repeat) force-kills
         assert stop_event.is_set()
         mock_signal.assert_any_call(signal.SIGTERM, signal.SIG_DFL)
+        mock_signal.assert_any_call(signal.SIGINT, signal.SIG_DFL)
 
     def test_run_called_with_stop_event(self):
         cfg = _config(run_interval=5)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -123,7 +123,7 @@ class TestRunScheduledPath:
         cfg = self._cfg_with_interval()
         stop_event = threading.Event()
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             stop_event.set()  # signal stop after first call so loop exits
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
@@ -143,7 +143,7 @@ class TestRunScheduledPath:
         stop_event = threading.Event()
         call_count = 0
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             nonlocal call_count
             call_count += 1
             if call_count == 1:
@@ -172,7 +172,7 @@ class TestRunScheduledPath:
         stop_event = threading.Event()
         call_count = 0
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             nonlocal call_count
             call_count += 1
             raise RuntimeError("persistent failure")
@@ -199,7 +199,7 @@ class TestRunScheduledPath:
         cfg = self._cfg_with_interval()
         stop_event = threading.Event()
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             stop_event.set()
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
@@ -258,7 +258,7 @@ def test_entrypoint_loops_when_interval_set():
     stop_event = threading.Event()
     call_count = 0
 
-    def _run_side_effect(_config):
+    def _run_side_effect(_config, _stop=None):
         nonlocal call_count
         call_count += 1
         stop_event.set()  # exit after first iteration
@@ -311,7 +311,7 @@ def test_scheduled_loop_uses_injected_wait_provider():
     stop_event = threading.Event()
     call_count = 0
 
-    def _run_side_effect(_config):
+    def _run_side_effect(_config, _stop=None):
         nonlocal call_count
         call_count += 1
         raise RuntimeError("transient failure")
@@ -691,7 +691,7 @@ class TestScheduledHealthServer:
         cfg = _config(run_interval=5, health_port=None)
         stop_event = threading.Event()
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             stop_event.set()
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
@@ -709,7 +709,7 @@ class TestScheduledHealthServer:
         stop_event = threading.Event()
         fake_server = MagicMock()
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             stop_event.set()
             return None
 
@@ -732,7 +732,7 @@ class TestScheduledHealthServer:
         stop_event = threading.Event()
         captured = {}
 
-        def _run_side_effect(_config):
+        def _run_side_effect(_config, _stop=None):
             stop_event.set()
             return NotifyResult(local="/bkps/export.tgz")
 
@@ -801,3 +801,53 @@ class TestExporterStopWiring:
             with pytest.raises(RuntimeError):
                 run.exporter(cfg, None)
         archive.discard_partial.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _run_scheduled() — double-signal force-kill (SIG_DFL restore)
+# ---------------------------------------------------------------------------
+
+class TestDoubleSignalForceKill:
+    def test_first_signal_restores_default_handler(self):
+        cfg = _config(run_interval=5)
+        stop_event = threading.Event()
+        captured = {}
+
+        def _capture_signal(signum, handler):
+            # remember the handler installed for SIGTERM so we can invoke it
+            if signum == signal.SIGTERM and callable(handler):
+                captured["handler"] = handler
+
+        def _run_side_effect(_config, _stop=None):
+            stop_event.set()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture_signal) as mock_signal, \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            run.entrypoint(args=_args(run_once=False))
+            # simulate first SIGTERM arriving: invoke the installed handler
+            mock_signal.reset_mock()
+            captured["handler"](signal.SIGTERM, None)
+
+        # handler must (a) set stop, (b) restore SIG_DFL for that signum
+        assert stop_event.is_set()
+        mock_signal.assert_any_call(signal.SIGTERM, signal.SIG_DFL)
+
+    def test_run_called_with_stop_event(self):
+        cfg = _config(run_interval=5)
+        stop_event = threading.Event()
+
+        def _run_side_effect(_config, _stop=None):
+            assert _stop is stop_event
+            stop_event.set()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect) as mock_run, \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        # run() received the stop event positionally or by keyword
+        assert mock_run.call_count == 1

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -58,6 +58,7 @@ class TestRunOncePath:
     def test_success_returns_0(self):
         cfg = self._cfg_no_interval()
         with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
              patch.object(run, "run"):
             result = run.entrypoint(args=_args())
         assert result == 0
@@ -65,6 +66,7 @@ class TestRunOncePath:
     def test_run_raises_exception_returns_1(self, caplog):
         cfg = self._cfg_no_interval()
         with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
              patch.object(run, "run", side_effect=RuntimeError("export boom")), \
              caplog.at_level(logging.ERROR, logger="bookstack_file_exporter.run"):
             result = run.entrypoint(args=_args())
@@ -75,17 +77,77 @@ class TestRunOncePath:
         """Exception must NOT escape entrypoint."""
         cfg = self._cfg_no_interval()
         with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
              patch.object(run, "run", side_effect=RuntimeError("boom")):
             # should not raise
             result = run.entrypoint(args=_args())
         assert result == 1
 
     def test_keyboard_interrupt_returns_130(self):
+        """A bare KeyboardInterrupt (no signal recorded) defaults to SIGINT->130."""
         cfg = self._cfg_no_interval()
         with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
              patch.object(run, "run", side_effect=KeyboardInterrupt):
             result = run.entrypoint(args=_args())
         assert result == 130
+
+    def test_sigterm_during_run_cleans_up_and_returns_143(self):
+        """SIGTERM mid-run -> KeyboardInterrupt -> finally cleanup -> exit 143."""
+        cfg = self._cfg_no_interval()
+        captured = {}
+
+        def _capture(signum, handler):
+            if callable(handler):
+                captured[signum] = handler
+
+        def _signal_mid_run(_config, _stop=None):
+            captured[signal.SIGTERM](signal.SIGTERM, None)
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
+             patch.object(run, "run", side_effect=_signal_mid_run):
+            result = run.entrypoint(args=_args())
+        assert result == 143
+
+    def test_sigint_during_run_returns_130(self):
+        cfg = self._cfg_no_interval()
+        captured = {}
+
+        def _capture(signum, handler):
+            if callable(handler):
+                captured[signum] = handler
+
+        def _signal_mid_run(_config, _stop=None):
+            captured[signal.SIGINT](signal.SIGINT, None)
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
+             patch.object(run, "run", side_effect=_signal_mid_run):
+            result = run.entrypoint(args=_args())
+        assert result == 130
+
+    def test_first_signal_restores_sig_dfl_for_both_signals(self):
+        """Force-kill escape hatch: first signal restores default for both."""
+        cfg = self._cfg_no_interval()
+        captured = {}
+        calls = []
+
+        def _capture(signum, handler):
+            calls.append((signum, handler))
+            if callable(handler):
+                captured[signum] = handler
+
+        def _signal_mid_run(_config, _stop=None):
+            captured[signal.SIGTERM](signal.SIGTERM, None)
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
+             patch.object(run, "run", side_effect=_signal_mid_run):
+            run.entrypoint(args=_args())
+
+        assert (signal.SIGTERM, signal.SIG_DFL) in calls
+        assert (signal.SIGINT, signal.SIG_DFL) in calls
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +158,7 @@ class TestRunOnceFlag:
     def test_run_once_flag_true_forces_single_run_even_with_interval(self):
         cfg = _config(run_interval=60)
         with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
              patch.object(run, "run") as mock_run:
             result = run.entrypoint(args=_args(run_once=True))
         assert result == 0
@@ -104,6 +167,7 @@ class TestRunOnceFlag:
     def test_run_once_flag_false_with_no_interval_still_runs_once(self):
         cfg = _config(run_interval=0)
         with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
              patch.object(run, "run") as mock_run:
             result = run.entrypoint(args=_args(run_once=False))
         assert result == 0


### PR DESCRIPTION
## Changes

Adds graceful shutdown for scheduled/daemon mode. One-shot mode behavior is unchanged (relies on `KeyboardInterrupt`); all new checks degrade to no-ops when no stop flag is injected.

- **Cooperative cancellation.** A SIGTERM/SIGINT handler in scheduled mode sets a `threading.Event` instead of raising. The export polls it at checkpoints to drain the in-flight cycle and exit 0:
  - FETCH phase: `NodeExporter._until_stop()` generator gates the three tree-walk loops so a signal halts the walk at the next node boundary instead of fetching the whole tree first.
  - ARCHIVE phase: `NodeArchiver._stop` polled at 4 checkpoints (node loop, format loop, asset-type loop, asset loop), injected via `Archiver.set_stop()`.
  - `exporter()` discards a truncated tree after a cancelled fetch (post-fetch guard) and discards a partial mid-archive cycle, so a cancelled cycle never produces an archive.
- **Atomic archive write.** `gzip_archive` writes `<archive>.tgz.partial` then `os.rename` to the final `.tgz` (same-filesystem atomic). A crash mid-gzip leaves only the `.partial`.
- **Partial cleanup.** `discard_partial()` removes this cycle's intermediate tar and `.tgz.partial` (never the final `.tgz`) on every terminal path via `try/finally`; logs each removed path so cleanup is observable in one-shot mode too. `sweep_orphans()` runs at cycle start to remove prior-run orphans left by a SIGKILL.
- **Double-signal force-kill.** After the first signal, the handler restores `signal.SIG_DFL` for that signum, so a second identical signal force-kills via the kernel with the correct exit code (SIGINT→130, SIGTERM→143) — an operator escape hatch if an in-flight cycle won't drain.
- README: documents the shutdown contract and grace-period tuning (Docker `stop_grace_period` / k8s `terminationGracePeriodSeconds`).

No tracking issue exists for this work (internal hardening item following the scheduled-mode and `/healthz` features).

## Motivation

Scheduled mode loops export cycles. A full-instance cycle can exceed Docker's `stop_grace_period` (10s) / k8s `terminationGracePeriodSeconds` (30s), so a plain `docker stop` would SIGKILL mid-write and leave a corrupt or orphaned archive. This makes shutdown cooperative (drain current cycle, exit 0) and crash-safe (atomic rename + partial cleanup), with a force-kill escape hatch.

## Test plan

- `uv run pytest` — 539 passing. New tests: fetch-loop cancellation (`test_node_exporter.py`), archive-loop cancellation + atomic gzip (`test_page_archiver.py`), `set_stop`/`discard_partial`/`sweep_orphans` + cleanup logging (`test_archiver.py`), stop wiring + double-signal (`test_run.py`).
- `uv run pylint` — 10.00/10 on all changed modules.
- Live, one-shot mode: confirmed graceful drain → exit 0 and double-signal → 130.
- Pending reviewer verification: live scheduled-mode signal during the FETCH phase (expect fast stop + "Shutdown requested during fetch; skipping archive" → exit 0).

## In-depth

- **Why poll a flag, not raise from the handler:** CPython runs Python signal handlers in the main thread between bytecodes; raising across arbitrary code is unsafe and SIGTERM has no default exception. Polling a `threading.Event` is the signal-safe approach.
- **Checkpoint shapes are mixed deliberately:** a generator (`_until_stop`) for the fetch loops vs explicit guards for the archive path. The generator is the seam a future parallel/thread-pool exporter would attach to; the archive write path stays serial because `tarfile` is not thread-safe. A configurable export thread pool is a possible future follow-up (not built — YAGNI).
- **`set_stop()` setter injection** (vs constructor) avoids plumbing the flag through five archiver subclass constructors; it sets one private attribute with a localized `# pylint: disable=protected-access`.
- **`sweep_orphans` safety is from call-ordering**, not the glob — it runs before this cycle writes any tar/`.partial`, so only earlier runs' leftovers match.
