### PR TITLE
feat!: S3 upload support via object_storage list (v3.0.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ object_storage:
 | `secret_key` | `str` | `false` | Inline secret key credential. |
 | `access_key_env` | `str` | `false` | Name of an environment variable to read for the access key. Use with `secret_key_env` to keep credentials out of the config file, or to give two targets of the same type distinct credentials. |
 | `secret_key_env` | `str` | `false` | Name of an environment variable to read for the secret key. Must be paired with `access_key_env`. |
+| `name` | `str` | `false` | Optional human-readable label for this target, used in logs and notifications. If two entries share the same `type` and `bucket` (e.g. same bucket reached via different credentials), each **must** set a distinct `name` — the exporter rejects the config if two entries would produce the same derived `type/bucket` label and no `name` is set to disambiguate. |
 
 #### Credential resolution (per entry, first match wins)
 

--- a/README.md
+++ b/README.md
@@ -831,8 +831,10 @@ object_storage:
 4. `type: s3` only — `~/.aws/credentials` (by `AWS_PROFILE`) → EC2/ECS/EKS IAM role
    (IMDS). Role-based deploys need no secrets in config or env.
 
-Setting only one half of a credential pair (key without secret, or `*_env` without its
-partner) is a config error.
+Setting only one half of an *in-config* credential pair (`access_key` without `secret_key`,
+or `*_env` without its partner) is a config error. A partially-set *ambient* env pair
+(e.g. `MINIO_ACCESS_KEY` set but `MINIO_SECRET_KEY` unset) is **ignored, not an error** —
+resolution falls through to the next source.
 
 ## Migrating from v2
 

--- a/README.md
+++ b/README.md
@@ -875,6 +875,25 @@ or `*_env` without its partner) is a config error. A partially-set *standard env
 (e.g. `MINIO_ACCESS_KEY` set but `MINIO_SECRET_KEY` unset) is **ignored, not an error** —
 resolution falls through to the next source.
 
+#### Multi-target upload behavior
+
+Every configured `object_storage` target is attempted, even if an earlier one fails. The run
+outcome is one of:
+
+| Outcome | When | Exit code | Notification |
+|---|---|---|---|
+| Success | all targets uploaded | `0` | "Success" (`on_success`) |
+| Partial | some targets failed, **or** all failed but a local copy is kept (`keep_last >= 0`) | `3` | "Partial" (`on_failure`) |
+| Failure | the export itself failed, **or** all uploads failed with no local copy kept (`keep_last < 0`) | `1` | "Failed" (`on_failure`) |
+
+A *partial* run means at least one durable copy of the backup survived (a remote target, or the
+local `.tgz` when `keep_last >= 0`). It is reported via the `on_failure` notification so it is
+not silently treated as a clean success. When `keep_last < 0` (local archive deleted) AND every
+upload fails, the run is a hard failure — the local archive is preserved so the run can be retried.
+
+In scheduled mode the `/healthz` endpoint reports `last_run.status` as `degraded` for a partial
+run (distinct from `success` and `failed`).
+
 ## Migrating from v2
 
 v3.0.0 removes the single `minio:` block. Move your settings into an `object_storage:`

--- a/README.md
+++ b/README.md
@@ -764,7 +764,7 @@ Optionally, one or more upload targets can be specified to push generated archiv
 ### Object Storage Upload (MinIO / S3)
 
 Configure one or more upload targets under `object_storage:`. Each entry has a `type`
-(`minio` or `s3`).
+(`minio` or `s3`). Any S3-compatible store — Wasabi, Cloudflare R2, Backblaze B2, Ceph, DigitalOcean Spaces — also works under `type: s3` (or `type: minio`) by setting an explicit `host`.
 
 ```yaml
 object_storage:

--- a/README.md
+++ b/README.md
@@ -796,7 +796,7 @@ object_storage:
     secret_key: wJalr...
 
   # AWS S3 with no creds in config -> AWS default chain
-  #   (AWS_* env -> ~/.aws/credentials -> EC2/ECS/EKS IAM role via IMDS)
+  #   (AWS_* env -> EC2/ECS/EKS IAM role via IMDS)
   - type: s3
     bucket: role-backups
     region: us-east-1
@@ -829,8 +829,8 @@ object_storage:
    Ambient env vars override inline config keys, consistent with the BookStack token
    and standard precedence.
 3. `access_key` + `secret_key` — inline values (config-file fallback).
-4. `type: s3` only — `~/.aws/credentials` (by `AWS_PROFILE`) → EC2/ECS/EKS IAM role
-   (IMDS). Role-based deploys need no secrets in config or env.
+4. `type: s3` only — EC2/ECS IAM role via IMDS. No secrets required in config, env,
+   or files: the instance role supplies them at runtime (the cloud-native k8s/EC2 path).
 
 Setting only one half of an *in-config* credential pair (`access_key` without `secret_key`,
 or `*_env` without its partner) is a config error. A partially-set *ambient* env pair

--- a/README.md
+++ b/README.md
@@ -891,6 +891,10 @@ local `.tgz` when `keep_last >= 0`). It is reported via the `on_failure` notific
 not silently treated as a clean success. When `keep_last < 0` (local archive deleted) AND every
 upload fails, the run is a hard failure — the local archive is preserved so the run can be retried.
 
+A target that uploads successfully but whose retention cleanup (pruning old objects per `keep_last`)
+fails also yields a **Partial** run — the backup is safely stored, but the failed cleanup is surfaced
+(exit 3 / `on_failure` / `degraded` health) so unbounded object growth is noticed.
+
 In scheduled mode the `/healthz` endpoint reports `last_run.status` as `degraded` for a partial
 run (distinct from `success` and `failed`).
 

--- a/README.md
+++ b/README.md
@@ -795,8 +795,7 @@ object_storage:
     access_key: AKIA...
     secret_key: wJalr...
 
-  # AWS S3 with no creds in config -> AWS default chain
-  #   (AWS_* env -> EC2/ECS/EKS IAM role via IMDS)
+  # AWS S3 with no creds in config -> standard AWS_* env, else EC2/ECS IAM role via IMDS
   - type: s3
     bucket: role-backups
     region: us-east-1
@@ -822,18 +821,55 @@ object_storage:
 
 #### Credential resolution (per entry, first match wins)
 
-1. `access_key_env` + `secret_key_env` — read those named env vars. The only way to give
-   two targets of the same type distinct, out-of-file credentials.
-2. Ambient env vars — `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` for minio;
-   `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` for s3.
-   Ambient env vars override inline config keys, consistent with the BookStack token
-   and standard precedence.
-3. `access_key` + `secret_key` — inline values (config-file fallback).
-4. `type: s3` only — EC2/ECS IAM role via IMDS. No secrets required in config, env,
-   or files: the instance role supplies them at runtime (the cloud-native k8s/EC2 path).
+Each entry resolves credentials through an ordered chain; the first source that supplies a
+full key pair wins.
+
+1. **Per-entry named env vars** — `access_key_env` + `secret_key_env` give the *names* of the
+   env vars to read. The only way to give two same-type targets *distinct* credentials kept
+   out of the config file (the standard env vars in tier 2 are global, so they cannot).
+   ```yaml
+   - type: minio
+     host: minio2.local:9000
+     bucket: backups2
+     access_key_env: MINIO2_ACCESS_KEY   # the value is the env var NAME, not the secret
+     secret_key_env: MINIO2_SECRET_KEY
+   ```
+   ```bash
+   export MINIO2_ACCESS_KEY=AKIA... MINIO2_SECRET_KEY=wJalr...
+   ```
+2. **Standard env vars** — the fixed, SDK-recognized names, picked up automatically. These are
+   global: every entry of that type shares them.
+   - minio: `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`
+   - s3: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` (optional)
+
+   They override inline keys (tier 3), consistent with the BookStack token and 12-factor
+   precedence.
+   ```yaml
+   - type: minio
+     host: minio.local:9000
+     bucket: backups        # no creds in the YAML
+   ```
+   ```bash
+   export MINIO_ACCESS_KEY=AKIA... MINIO_SECRET_KEY=wJalr...
+   ```
+3. **Inline keys** — `access_key` + `secret_key` in the entry itself.
+   ```yaml
+   - type: s3
+     bucket: aws-backups
+     region: us-east-1
+     access_key: AKIA...
+     secret_key: wJalr...
+   ```
+4. **IAM role via IMDS** (`type: s3` only) — no secrets anywhere; the EC2/ECS instance role
+   supplies short-lived credentials at runtime (the cloud-native k8s/EC2 path).
+   ```yaml
+   - type: s3
+     bucket: role-backups
+     region: us-east-1      # no creds in the YAML, no env vars
+   ```
 
 Setting only one half of an *in-config* credential pair (`access_key` without `secret_key`,
-or `*_env` without its partner) is a config error. A partially-set *ambient* env pair
+or `*_env` without its partner) is a config error. A partially-set *standard env var* pair
 (e.g. `MINIO_ACCESS_KEY` set but `MINIO_SECRET_KEY` unset) is **ignored, not an error** —
 resolution falls through to the next source.
 

--- a/README.md
+++ b/README.md
@@ -823,12 +823,13 @@ object_storage:
 
 1. `access_key_env` + `secret_key_env` — read those named env vars. The only way to give
    two targets of the same type distinct, out-of-file credentials.
-2. `access_key` + `secret_key` — inline values.
-3. `type: s3` with none of the above — AWS default chain: `AWS_ACCESS_KEY_ID` /
-   `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` → `~/.aws/credentials` (by `AWS_PROFILE`)
-   → EC2/ECS/EKS IAM role (IMDS). Role-based deploys need no secrets in config or env.
-4. `type: minio` with none of the above — fixed `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`
-   env vars (the v2 single-MinIO behavior).
+2. Ambient env vars — `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` for minio;
+   `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` for s3.
+   Ambient env vars override inline config keys, consistent with the BookStack token
+   and standard precedence.
+3. `access_key` + `secret_key` — inline values (config-file fallback).
+4. `type: s3` only — `~/.aws/credentials` (by `AWS_PROFILE`) → EC2/ECS/EKS IAM role
+   (IMDS). Role-based deploys need no secrets in config or env.
 
 Setting only one half of a credential pair (key without secret, or `*_env` without its
 partner) is a config error.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Table of Contents
     - [Attachments](#attachments)
     - [Modify Links](#modify-links)
   - [Object Storage](#object-storage)
-    - [Minio Backups](#minio-backups)
+    - [Object Storage Upload (MinIO / S3)](#object-storage-upload-minio--s3)
   - [Notifications](#notifications)
     - [apprise](#apprise)
   - [Potential Breaking Upgrades](#potential-breaking-upgrades)
@@ -48,7 +48,7 @@ What it does:
 - The exporter can also [Modify Links](#modify-links) to replace image and/or attachment links with local exported paths for a more portable backup
 - YAML configuration file for repeatable and easy runs
 - Can be run via [Python](#run-via-pip) or [Docker](#run-via-docker)
-- Can push archives to remote object storage like [Minio](https://min.io/)
+- Can push archives to remote object storage like [MinIO](https://min.io/) or [AWS S3](https://aws.amazon.com/s3/)
 - Basic housekeeping option (`keep_last`) to keep a tidy archive destination
 - Can run in application mode (always running) using `run_interval` (interval-based) or `run_schedule` (cron-based) properties. Used for scheduling backups.
 
@@ -56,7 +56,7 @@ Supported backup targets are:
 
 1. local
 2. minio
-3. s3 (Not Yet Implemented)
+3. s3
 
 Supported backup formats are based on Bookstack API and shown [here](https://demo.bookstackapp.com/api/docs#pages-exportHtml) and below:
 
@@ -335,8 +335,7 @@ _Ensure [Authentication](#authentication-and-permissions) has been set up before
 
 A full example is also shown below. Optionally, look at `examples/` folder of the github repo for more examples with long descriptions.
 
-For object storage configuration, find more information in their respective sections
-- [Minio](#minio-backups)
+For object storage configuration, find more information in the [Object Storage Upload](#object-storage-upload-minio--s3) section.
 
 **Schema and values are checked so ensure proper settings are provided. As mentioned, credentials can be specified as environment variables instead if preferred.**
 
@@ -362,14 +361,14 @@ http_config:
   retry_count: 5
   additional_headers:
     User-Agent: "test-agent"
-minio:
-  host: "minio.yourdomain.com"
-  access_key: ""
-  secret_key: ""
-  region: "us-east-1"
-  bucket: "mybucket"
-  path: "bookstack/file_backups"
-  keep_last: 5
+object_storage:
+  - type: minio
+    host: "minio.yourdomain.com"
+    region: "us-east-1"
+    bucket: "mybucket"
+    path: "bookstack/file_backups"
+    secure: false
+    keep_last: 5
 output_path: "bkps/"
 assets:
   export_images: true
@@ -429,7 +428,7 @@ More descriptions can be found for each section below:
 | `run_schedule` | `str` | `false` | Optional. Cron expression for wall-clock scheduling (e.g. `"0 2 * * *"` = 2 am daily). Standard 5-field cron; croniter also accepts 6/7-field extended forms. An invalid expression is rejected at config load. Evaluated in container-local time — set `TZ` env var to control timezone (default: `UTC`). If a cycle overruns its scheduled tick, the missed tick is skipped (no catch-up). Mutually exclusive with `run_interval`. |
 | `health_port` | `int` | `false` | Optional (default: unset). Scheduled mode only (`run_interval` or `run_schedule`). When set, the daemon serves an opt-in `GET /healthz` endpoint on this port. No server is started unless set; ignored in one-shot mode. See [Health Endpoint](#health-endpoint). |
 | `health_host` | `str` | `false` | Optional (default: `0.0.0.0`). Bind address for the `health_port` server. Set to `127.0.0.1` or a specific NIC to restrict exposure on a multi-homed host. Only used when `health_port` is set. |
-| `minio` | `object` | `false` | Optional [Minio](#minio-backups) configuration options. |
+| `object_storage` | `list` | `false` | Optional list of object storage upload targets. See [Object Storage Upload](#object-storage-upload-minio--s3) for details. |
 | `notifications` | `object` | `false` | Optional [notification](#notifications) configuration options. |
 | `filters` | `object` | `false` | Optional per-resource-type regex filters (include/exclude lists). See [Filters](#filters) for details. |
 | `filters.exclude_unassigned_books` | `bool` | `false` | Optional (default: `false`). When `true`, drop all books that are not on any shelf, independent of the `books` patterns. See [Filters](#filters) for details. |
@@ -443,9 +442,10 @@ General
 - `BOOKSTACK_TOKEN_ID`
 - `BOOKSTACK_TOKEN_SECRET`
 
-[Minio Credentials](#authentication-1)
-- `MINIO_ACCESS_KEY`
-- `MINIO_SECRET_KEY`
+[Object Storage Credentials](#object-storage-upload-minio--s3)
+- `MINIO_ACCESS_KEY` — default MinIO access key (single-target MinIO, backward-compatible with v2)
+- `MINIO_SECRET_KEY` — default MinIO secret key
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN` — AWS default chain for S3 targets
 
 ## Export Level
 
@@ -759,40 +759,107 @@ Attachment links are rewritten from the live URL to a local relative path.
 Markdown link rewriting is a plain text substitution: if an asset URL appears verbatim anywhere in the markdown (code block, comment, plain text), it is also rewritten. HTML rewriting is scoped to `<img src>` / `<a href>` attributes only, so it is unaffected.
 
 ## Object Storage
-Optionally, target(s) can be specified to upload generated archives to a remote location. Supported object storage providers can be found below:
-- [Minio](#minio-backups)
+Optionally, one or more upload targets can be specified to push generated archives to remote object storage. Optionally, look at `examples/config.yml` in the github repo for a commented-out example.
 
-### Minio Backups
-Optionally, look at `examples/config.yml` in the github repo, which includes a commented-out `minio:` block to enable object storage upload. 
+### Object Storage Upload (MinIO / S3)
 
-#### Authentication
-Credentials can be specified directly in the `minio` configuration section or as environment variables. If specified in config and env, env variable will take precedence.
+Configure one or more upload targets under `object_storage:`. Each entry has a `type`
+(`minio` or `s3`).
 
-Environment variables:
-- `MINIO_ACCESS_KEY`
-- `MINIO_SECRET_KEY`
-
-#### Example
 ```yaml
-minio:
-    host: "minio.yourdomain.com"
-    region: "us-east-1"
-    bucket: "mybucket"
-    access_key: ""
-    secret_key: ""
-    path: "bookstack/file_backups"
+object_storage:
+  # MinIO, creds from fixed MINIO_ACCESS_KEY / MINIO_SECRET_KEY env vars (default)
+  - type: minio
+    host: minio.local:9000        # required for minio (host:port)
+    bucket: backups
+    region: us-east-1             # optional for minio
+    secure: false                 # local minio is often non-TLS
+    path: exports                 # optional object key prefix
     keep_last: 5
+
+  # Second MinIO with DISTINCT creds kept out of the file -> per-entry env NAMES
+  - type: minio
+    host: minio2.local:9000
+    bucket: backups2
+    secure: false
+    access_key_env: MINIO2_ACCESS_KEY   # names of env vars to read
+    secret_key_env: MINIO2_SECRET_KEY
+
+  # AWS S3 with inline creds
+  - type: s3
+    bucket: aws-backups
+    region: us-east-1             # required for s3
+    # host optional; defaults to s3.<region>.amazonaws.com
+    # secure defaults to true for s3
+    keep_last: 10
+    access_key: AKIA...
+    secret_key: wJalr...
+
+  # AWS S3 with no creds in config -> AWS default chain
+  #   (AWS_* env -> ~/.aws/credentials -> EC2/ECS/EKS IAM role via IMDS)
+  - type: s3
+    bucket: role-backups
+    region: us-east-1
+    keep_last: 10
 ```
-#### Configuration
+
+#### Entry fields
+
 | Item | Type | Required | Description |
 | ---- | ---- | -------- | ----------- |
-| `host` | `str` | `true` | Hostname for minio. A host/ip + port combination is also allowed, example: `minio.yourdomain.com:8443` |
-| `region` | `str` | `true` | This is required since minio api appears to require it. Set to the region your bucket resides in, if unsure, try `us-east-1` |
+| `type` | `str` | `true` | `minio` or `s3` |
+| `host` | `str` | required for `minio` | Hostname (and optional port) for the MinIO instance, e.g. `minio.yourdomain.com:9000`. For `s3`, defaults to `s3.<region>.amazonaws.com` if omitted. |
 | `bucket` | `str` | `true` | Bucket to upload to |
-| `access_key` | `str` | `false` if specified through env var instead, otherwise `true` | Access key for the minio instance |
-| `secret_key` | `str` | `false` if specified through env var, otherwise `true` | Secret key for the minio instance |
-| `path` | `str` | `false` | Optional, path of the backup to use. Will use root bucket path if not set. `<bucket_name>:/<path>/bookstack-<timestamp>.tgz` |
-| `keep_last` | `int` | `false` | Optional (default: `0`), if exporter can delete older archives in minio.<br>- set to `1+` if you want to retain a certain number of archives<br>-  `0` will result in no action done |
+| `region` | `str` | required for `s3`, optional for `minio` | AWS region or MinIO region. If unsure for MinIO, try `us-east-1`. |
+| `secure` | `bool` | `false` | Optional (default: `true`). Set `false` for plain-HTTP local MinIO. |
+| `path` | `str` | `false` | Optional object key prefix. Will use root bucket path if not set. |
+| `keep_last` | `int` | `false` | Optional (default: `0`). Number of archives to retain in this target.<br>- set to `1+` to retain a certain number of archives<br>- `0` will result in no action done |
+| `access_key` | `str` | `false` | Inline access key credential. |
+| `secret_key` | `str` | `false` | Inline secret key credential. |
+| `access_key_env` | `str` | `false` | Name of an environment variable to read for the access key. Use with `secret_key_env` to keep credentials out of the config file, or to give two targets of the same type distinct credentials. |
+| `secret_key_env` | `str` | `false` | Name of an environment variable to read for the secret key. Must be paired with `access_key_env`. |
+
+#### Credential resolution (per entry, first match wins)
+
+1. `access_key_env` + `secret_key_env` — read those named env vars. The only way to give
+   two targets of the same type distinct, out-of-file credentials.
+2. `access_key` + `secret_key` — inline values.
+3. `type: s3` with none of the above — AWS default chain: `AWS_ACCESS_KEY_ID` /
+   `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` → `~/.aws/credentials` (by `AWS_PROFILE`)
+   → EC2/ECS/EKS IAM role (IMDS). Role-based deploys need no secrets in config or env.
+4. `type: minio` with none of the above — fixed `MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY`
+   env vars (the v2 single-MinIO behavior).
+
+Setting only one half of a credential pair (key without secret, or `*_env` without its
+partner) is a config error.
+
+## Migrating from v2
+
+v3.0.0 removes the single `minio:` block. Move your settings into an `object_storage:`
+list entry with `type: minio`:
+
+```yaml
+# v2 (removed)
+minio:
+  host: minio.local:9000
+  bucket: backups
+  region: us-east-1
+  path: exports
+  keep_last: 5
+
+# v3
+object_storage:
+  - type: minio
+    host: minio.local:9000
+    bucket: backups
+    region: us-east-1          # now optional for minio
+    path: exports
+    keep_last: 5
+    secure: false              # NEW: set false for non-TLS local minio
+```
+
+`MINIO_ACCESS_KEY` / `MINIO_SECRET_KEY` env vars work unchanged for a single MinIO entry.
+Note `secure` now defaults to `true`; set `secure: false` for plain-HTTP local MinIO.
 
 ## Notifications
 It is possible to send notifications when an export run succeeds or fails. Currently, the only supported notification service is [apprise](https://github.com/caronc/apprise). Apprise is a general purpose notification service and has a variety of integrations and includes generic HTTP POST.
@@ -848,6 +915,7 @@ Below are versions that have major changes to the way configuration or exporter 
 | ------------- | -------------- | ----------- |
 | `< 1.4.X` | `1.5.0` | `assets.verify_ssl` has been moved to `http_config.verify_ssl` and the default value has been updated to `false`. `additional_headers` has been moved to `http_config.additional_headers` |
 | `1.6.X` | `vX.X.X` | `assets.modify_markdown` is deprecated — HTML image and attachment link rewrites are now supported, so the markdown-specific name no longer fits. Use `assets.modify_links` instead. The legacy `modify_markdown` key still works but will be removed in a future release. |
+| `< 3.0.0` | `3.0.0` | The top-level `minio:` config block is removed. Replace it with an `object_storage:` list entry with `type: minio`. See [Migrating from v2](#migrating-from-v2) for the exact mapping. |
 
 ## Running Tests
 

--- a/README.md
+++ b/README.md
@@ -795,7 +795,7 @@ object_storage:
     access_key: AKIA...
     secret_key: wJalr...
 
-  # AWS S3 with no creds in config -> standard AWS_* env, else EC2/ECS IAM role via IMDS
+  # AWS S3 with no creds in config -> standard AWS_* env, else IAM role (EC2/ECS/EKS, auto-detected)
   - type: s3
     bucket: role-backups
     region: us-east-1
@@ -817,7 +817,7 @@ object_storage:
 | `secret_key` | `str` | `false` | Inline secret key credential. |
 | `access_key_env` | `str` | `false` | Name of an environment variable to read for the access key. Use with `secret_key_env` to keep credentials out of the config file, or to give two targets of the same type distinct credentials. |
 | `secret_key_env` | `str` | `false` | Name of an environment variable to read for the secret key. Must be paired with `access_key_env`. |
-| `name` | `str` | `false` | Optional human-readable label for this target, used in logs and notifications. If two entries share the same `type` and `bucket` (e.g. same bucket reached via different credentials), each **must** set a distinct `name` — the exporter rejects the config if two entries would produce the same derived `type/bucket` label and no `name` is set to disambiguate. |
+| `name` | `str` | `false` | Optional human-readable label for this target (intended for logs and notifications). If two entries share the same `type` and `bucket` (e.g. same bucket reached via different credentials), each **must** set a distinct `name` — the exporter rejects the config if two entries would produce the same derived `type/bucket` label and no `name` is set to disambiguate. |
 
 #### Credential resolution (per entry, first match wins)
 
@@ -860,8 +860,10 @@ full key pair wins.
      access_key: AKIA...
      secret_key: wJalr...
    ```
-4. **IAM role via IMDS** (`type: s3` only) — no secrets anywhere; the EC2/ECS instance role
-   supplies short-lived credentials at runtime (the cloud-native k8s/EC2 path).
+4. **IAM role** (`type: s3` only) — no secrets anywhere; the instance/pod role supplies
+   short-lived credentials at runtime. Auto-detected by minio-py's `IamAwsProvider`: EC2
+   (IMDS), ECS (container credentials), and EKS (IRSA web-identity / Pod Identity) — the
+   cloud-native k8s/EC2 path.
    ```yaml
    - type: s3
      bucket: role-backups

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -12,6 +12,7 @@ from bookstack_file_exporter.archiver.node_archiver import (
 )
 from bookstack_file_exporter.archiver.s3_archiver import S3CompatibleArchiver
 from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
+from bookstack_file_exporter.notify.models import ExportStatus, UploadOutcome
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
 from bookstack_file_exporter.common import util as common_util
 from bookstack_file_exporter.common.util import HttpHelper
@@ -19,6 +20,11 @@ from bookstack_file_exporter.common.util import HttpHelper
 log = logging.getLogger(__name__)
 
 _DATE_STR_FORMAT = "%Y-%m-%d_%H-%M-%S"
+
+
+class AggregateUploadError(Exception):
+    """All upload targets failed AND no durable local copy survives (keep_last < 0)."""
+
 
 # pylint: disable=too-many-instance-attributes
 class Archiver:
@@ -150,24 +156,45 @@ class Archiver:
         self._archiver.gzip_archive()
 
     # send to remote systems
-    def archive_remote(self) -> list[str]:
-        """Upload the archive to each configured target; return remote dest strings.
+    def archive_remote(self) -> list[UploadOutcome]:
+        """Upload to every configured target, attempting all even if some fail.
 
-        Both 'minio' and 's3' share S3CompatibleArchiver (identical S3 API surface).
-        Type is constrained to minio|s3 by the config model, so no runtime type guard.
+        Returns one UploadOutcome per target (dest on success, error on failure). Never
+        raises on a per-target upload error — aggregate status is decided by
+        resolve_remote_status. Both 'minio' and 's3' share S3CompatibleArchiver.
         """
-        if not self.config.object_storage_config:
-            return []
-        dests: list[str] = []
-        for entry in self.config.object_storage_config:
-            dests.append(self._upload(entry))
-        return dests
+        outcomes: list[UploadOutcome] = []
+        for entry in self.config.object_storage_config or []:
+            outcomes.append(self._upload(entry))
+        return outcomes
 
-    def _upload(self, provider_config: StorageProviderConfig) -> str:
-        archiver = self._s3_archiver_cls(provider_config)
-        dest = archiver.upload_backup(self._archiver.archive_file)
-        archiver.clean_up(self._archiver.file_extension_map['tgz'])
-        return dest
+    def _upload(self, provider_config: StorageProviderConfig) -> UploadOutcome:
+        label = provider_config.config.label
+        try:
+            archiver = self._s3_archiver_cls(provider_config)
+            dest = archiver.upload_backup(self._archiver.archive_file)
+            archiver.clean_up(self._archiver.file_extension_map['tgz'])
+            return UploadOutcome(label=label, dest=dest, error=None)
+        except Exception as err:  # pylint: disable=broad-except
+            # attempt-all: record and continue so other targets still run
+            log.error("Upload to target '%s' failed: %s", label, err)
+            return UploadOutcome(label=label, dest=None, error=str(err))
+
+    def resolve_remote_status(self, outcomes: list[UploadOutcome]) -> ExportStatus:
+        """Derive run status from upload outcomes. Raise AggregateUploadError only when
+        NO durable copy survives: every upload failed AND keep_last<0 deletes the local."""
+        if not outcomes:
+            return ExportStatus.SUCCESS
+        n_ok = sum(1 for o in outcomes if o.dest is not None)
+        if n_ok == len(outcomes):
+            return ExportStatus.SUCCESS
+        if n_ok == 0 and self.config.user_inputs.keep_last is not None \
+                and self.config.user_inputs.keep_last < 0:
+            failed = ", ".join(o.label for o in outcomes)
+            raise AggregateUploadError(
+                f"all upload targets failed and no local copy is kept "
+                f"(keep_last<0): {failed}")
+        return ExportStatus.PARTIAL
 
     def clean_up(self) -> list[str]:
         """remove archive after sending to remote target; return files deleted"""

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -10,7 +10,7 @@ from bookstack_file_exporter.archiver.node_archiver import (
     ChapterArchiver,
     PageArchiver,
 )
-from bookstack_file_exporter.archiver.minio_archiver import S3CompatibleArchiver
+from bookstack_file_exporter.archiver.s3_archiver import S3CompatibleArchiver
 from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
 from bookstack_file_exporter.common import util as common_util

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -10,7 +10,7 @@ from bookstack_file_exporter.archiver.node_archiver import (
     ChapterArchiver,
     PageArchiver,
 )
-from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
+from bookstack_file_exporter.archiver.minio_archiver import S3CompatibleArchiver
 from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
 from bookstack_file_exporter.config_helper.config_helper import ConfigNode
 from bookstack_file_exporter.common import util as common_util
@@ -35,7 +35,7 @@ class Archiver:
         for use for handling bookstack exports and remote uploads.
     """
     def __init__(self, config: ConfigNode, http_client: HttpHelper,
-                 node_archiver=None, minio_archiver_cls=MinioArchiver):
+                 node_archiver=None, s3_archiver_cls=S3CompatibleArchiver):
         self.config = config
         # for convenience
         self.base_dir = self._level_base_dir(config.base_dir_name,
@@ -44,7 +44,7 @@ class Archiver:
         self._archiver: NodeArchiver = (
             node_archiver if node_archiver is not None else self._build_archiver(http_client)
         )
-        self._minio_archiver_cls = minio_archiver_cls
+        self._s3_archiver_cls = s3_archiver_cls
 
     def _build_archiver(self, http_client: HttpHelper) -> NodeArchiver:
         """Return the appropriate archiver based on the configured export level."""
@@ -151,30 +151,26 @@ class Archiver:
 
     # send to remote systems
     def archive_remote(self) -> list[str]:
-        """for each target, do their respective tasks; return list of remote dest strings"""
+        """Upload the archive to each configured target; return remote dest strings.
+
+        Both 'minio' and 's3' share S3CompatibleArchiver (identical S3 API surface);
+        the type is validated for a clear error on unknown backends.
+        """
         if not self.config.object_storage_config:
             return []
-        handlers = {
-            "minio": self._archive_minio,
-            "s3": self._archive_s3,
-        }
+        supported = {"minio", "s3"}
         dests: list[str] = []
-        for key, value in self.config.object_storage_config.items():
-            handler = handlers.get(key)
-            if handler is None:
-                raise ValueError(f"unsupported remote storage type: {key}")
-            dests.append(handler(value))
+        for entry in self.config.object_storage_config:
+            if entry.type not in supported:
+                raise ValueError(f"unsupported remote storage type: {entry.type}")
+            dests.append(self._upload(entry))
         return dests
 
-    def _archive_minio(self, obj_config: StorageProviderConfig) -> str:
-        minio_archiver = self._minio_archiver_cls(obj_config.access_key,
-                                                  obj_config.secret_key, obj_config.config)
-        dest = minio_archiver.upload_backup(self._archiver.archive_file)
-        minio_archiver.clean_up(self._archiver.file_extension_map['tgz'])
+    def _upload(self, provider_config: StorageProviderConfig) -> str:
+        archiver = self._s3_archiver_cls(provider_config)
+        dest = archiver.upload_backup(self._archiver.archive_file)
+        archiver.clean_up(self._archiver.file_extension_map['tgz'])
         return dest
-
-    def _archive_s3(self, obj_config: StorageProviderConfig):
-        raise NotImplementedError("S3 remote storage is not yet implemented")
 
     def clean_up(self) -> list[str]:
         """remove archive after sending to remote target; return files deleted"""

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -173,20 +173,29 @@ class Archiver:
         try:
             archiver = self._s3_archiver_cls(provider_config)
             dest = archiver.upload_backup(self._archiver.archive_file)
-            archiver.clean_up(self._archiver.file_extension_map['tgz'])
-            return UploadOutcome(label=label, dest=dest, error=None)
         except Exception as err:  # pylint: disable=broad-except
             # attempt-all: record and continue so other targets still run
             log.error("Upload to target '%s' failed: %s", label, err)
             return UploadOutcome(label=label, dest=None, error=str(err))
+        # Upload landed. A retention-prune failure is housekeeping, not a backup failure:
+        # keep dest (never flip to failed) but flag a warning so the run is degraded.
+        try:
+            archiver.clean_up(self._archiver.file_extension_map['tgz'])
+        except Exception as err:  # pylint: disable=broad-except
+            log.error("Remote retention cleanup for target '%s' failed (upload OK): %s",
+                      label, err)
+            return UploadOutcome(label=label, dest=dest, error=None, warning=str(err))
+        return UploadOutcome(label=label, dest=dest, error=None)
 
     def resolve_remote_status(self, outcomes: list[UploadOutcome]) -> ExportStatus:
         """Derive run status from upload outcomes. Raise AggregateUploadError only when
-        NO durable copy survives: every upload failed AND keep_last<0 deletes the local."""
+        NO durable copy survives: every upload failed AND keep_last<0 deletes the local.
+        A target that uploaded but whose retention cleanup failed (warning) downgrades
+        SUCCESS to PARTIAL."""
         if not outcomes:
             return ExportStatus.SUCCESS
         n_ok = sum(1 for o in outcomes if o.dest is not None)
-        if n_ok == len(outcomes):
+        if n_ok == len(outcomes) and not any(o.warning for o in outcomes):
             return ExportStatus.SUCCESS
         if n_ok == 0 and self.config.user_inputs.keep_last is not None \
                 and self.config.user_inputs.keep_last < 0:

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -153,16 +153,13 @@ class Archiver:
     def archive_remote(self) -> list[str]:
         """Upload the archive to each configured target; return remote dest strings.
 
-        Both 'minio' and 's3' share S3CompatibleArchiver (identical S3 API surface);
-        the type is validated for a clear error on unknown backends.
+        Both 'minio' and 's3' share S3CompatibleArchiver (identical S3 API surface).
+        Type is constrained to minio|s3 by the config model, so no runtime type guard.
         """
         if not self.config.object_storage_config:
             return []
-        supported = {"minio", "s3"}
         dests: list[str] = []
         for entry in self.config.object_storage_config:
-            if entry.type not in supported:
-                raise ValueError(f"unsupported remote storage type: {entry.type}")
             dests.append(self._upload(entry))
         return dests
 

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -159,7 +159,8 @@ class Archiver:
     def archive_remote(self) -> list[UploadOutcome]:
         """Upload to every configured target, attempting all even if some fail.
 
-        Returns one UploadOutcome per target (dest on success, error on failure). Never
+        Returns one UploadOutcome per target (dest on success, error on upload
+        failure, or dest+warning when the upload landed but retention cleanup failed). Never
         raises on a per-target upload error — aggregate status is decided by
         resolve_remote_status. Both 'minio' and 's3' share S3CompatibleArchiver.
         """

--- a/bookstack_file_exporter/archiver/minio_archiver.py
+++ b/bookstack_file_exporter/archiver/minio_archiver.py
@@ -13,30 +13,26 @@ from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
 
 log = logging.getLogger(__name__)
 
-class MinioArchiver:
-    """
-    MinioArchiver handles uploads, lifecycle, and validations for minio archives.
-    
+class S3CompatibleArchiver:
+    """Handles uploads, retention, and bucket validation for any S3-compatible target
+    (MinIO or AWS S3). Both types share this class — the upload/cleanup API surface
+    (fput_object, list_objects, remove_object, bucket_exists) is identical.
+
     Args:
-        :config: <StorageProviderConfig> = minio configuration
-
-        :bucket: <str> = upload bucket
-        
-        :path: <str> (optional) = specify bucket path for upload
-
-    Returns:
-        MinioArchiver instance for archival use
+        :provider_config: <StorageProviderConfig> = resolved endpoint, secure flag,
+            credential Provider, and the raw entry (bucket/path/region/keep_last).
     """
-    def __init__(self, access_key: str, secret_key: str, config: StorageProviderConfig):
+    def __init__(self, provider_config: StorageProviderConfig):
+        cfg = provider_config.config
         self._client = Minio(
-            config.host,
-            access_key=access_key,
-            secret_key=secret_key,
-            region=config.region
+            provider_config.endpoint,
+            credentials=provider_config.credentials,
+            secure=provider_config.secure,
+            region=cfg.region,
         )
-        self.bucket = config.bucket
-        self.path = self._generate_path(config.path)
-        self.keep_last = config.keep_last
+        self.bucket = cfg.bucket
+        self.path = self._generate_path(cfg.path)
+        self.keep_last = cfg.keep_last
         self._validate_bucket()
 
     def _validate_bucket(self):

--- a/bookstack_file_exporter/archiver/s3_archiver.py
+++ b/bookstack_file_exporter/archiver/s3_archiver.py
@@ -69,9 +69,10 @@ class S3CompatibleArchiver:
 
     def _scan_objects(self, file_extension: str) -> list[MinioObject]:
         filter_str = "bookstack_export_"
-        # prefix should end in '/' for object listing
+        # prefix should end in '/' for object listing; empty path -> root listing
+        # (a "/" prefix matches nothing, so empty-path retention would silently no-op)
         # ref: https://min.io/docs/minio/linux/developers/python/API.html#list_objects
-        path_prefix = self.path + "/"
+        path_prefix = f"{self.path}/" if self.path else ""
         # get all objects in archive path/directory
         full_list: list[MinioObject] = self._client.list_objects(self.bucket, prefix=path_prefix)
         # validate and filter out non managed objects

--- a/bookstack_file_exporter/archiver/s3_archiver.py
+++ b/bookstack_file_exporter/archiver/s3_archiver.py
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 class S3CompatibleArchiver:
     """Handles uploads, retention, and bucket validation for any S3-compatible target
-    (MinIO or AWS S3). Both types share this class — the upload/cleanup API surface
+    (AWS S3, MinIO, or any other S3-compatible store). Both types share this class — the upload/cleanup API surface
     (fput_object, list_objects, remove_object, bucket_exists) is identical.
 
     Args:
@@ -43,7 +43,7 @@ class S3CompatibleArchiver:
         return path_name.rstrip('/') if path_name else ""
 
     def upload_backup(self, local_file_path: str) -> str:
-        """upload archive file to minio bucket; return 'bucket/object_path' dest string"""
+        """upload archive file to object storage bucket; return 'bucket/object_path' dest string"""
         # this will be the name of the object to upload
         # only get the file name not path
         # we are going to use path provided by user for object storage
@@ -68,7 +68,7 @@ class S3CompatibleArchiver:
 
     def _scan_objects(self, file_extension: str) -> list[MinioObject]:
         filter_str = "bookstack_export_"
-        # prefix should end in '/' for minio
+        # prefix should end in '/' for object listing
         # ref: https://min.io/docs/minio/linux/developers/python/API.html#list_objects
         path_prefix = self.path + "/"
         # get all objects in archive path/directory
@@ -81,17 +81,17 @@ class S3CompatibleArchiver:
     def _get_stale_objects(self, file_extension: str) -> list[MinioObject]:
         minio_objects = self._scan_objects(file_extension)
         if not minio_objects:
-            log.debug("No minio objects found to clean up")
+            log.debug("No objects found to clean up")
             return []
         if self.keep_last < 0:
             # we want to keep one copy at least
             # last copy that remains if local is deleted
-            log.debug("Minio 'keep_last' set to negative number, ignoring")
+            log.debug("'keep_last' set to negative number, ignoring")
             return []
         to_delete = []
         if len(minio_objects) > self.keep_last:
-            log.debug("Number of minio objects is greater than 'keep_last'")
-            log.debug("Running clean up of minio objects")
+            log.debug("Number of objects is greater than 'keep_last'")
+            log.debug("Running clean up of objects")
             to_delete = self._filter_objects(minio_objects)
         return to_delete
 
@@ -101,7 +101,7 @@ class S3CompatibleArchiver:
             key=lambda d: d.last_modified,
             keep_last=self.keep_last,
         )
-        log.debug("%d minio objects will be cleaned up", len(objects_to_clean))
+        log.debug("%d objects will be cleaned up", len(objects_to_clean))
         return objects_to_clean
 
     def _delete_objects(self, minio_objects: list[MinioObject]):

--- a/bookstack_file_exporter/archiver/s3_archiver.py
+++ b/bookstack_file_exporter/archiver/s3_archiver.py
@@ -15,8 +15,9 @@ log = logging.getLogger(__name__)
 
 class S3CompatibleArchiver:
     """Handles uploads, retention, and bucket validation for any S3-compatible target
-    (AWS S3, MinIO, or any other S3-compatible store). Both types share this class — the upload/cleanup API surface
-    (fput_object, list_objects, remove_object, bucket_exists) is identical.
+    (AWS S3, MinIO, or any other S3-compatible store). Both types share this class — the
+    upload/cleanup API surface (fput_object, list_objects, remove_object, bucket_exists)
+    is identical.
 
     Args:
         :provider_config: <StorageProviderConfig> = resolved endpoint, secure flag,

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -69,9 +69,10 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
 
     1. per-entry env NAMES (access_key_env/secret_key_env) -> StaticProvider. Only scheme
        that supports two same-type targets with distinct out-of-file creds.
-    2. inline access_key/secret_key -> StaticProvider.
-    3. type s3, nothing set -> AWS default chain (env -> ~/.aws -> IAM role via IMDS).
-    4. type minio, nothing set -> EnvMinioProvider (fixed MINIO_ACCESS_KEY/MINIO_SECRET_KEY).
+    2. ambient env (MINIO_ACCESS_KEY/MINIO_SECRET_KEY for minio; AWS_ACCESS_KEY_ID/
+       AWS_SECRET_ACCESS_KEY for s3) — checked before inline config-file keys.
+    3. inline access_key/secret_key (config-file fallback).
+    4. type s3 only: ~/.aws/credentials (by AWS_PROFILE) then IAM role via IMDS.
     """
     if entry.access_key_env and entry.secret_key_env:
         access = os.environ.get(entry.access_key_env)
@@ -81,14 +82,21 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
                 f"credential env vars {entry.access_key_env}/{entry.secret_key_env} "
                 "are referenced but not set or empty")
         return StaticProvider(access, secret)
-    if entry.access_key and entry.secret_key:
-        return StaticProvider(entry.access_key, entry.secret_key)
+
+    # inline keys, when present, sit BELOW ambient env (env > config file)
+    inline = (StaticProvider(entry.access_key, entry.secret_key)
+              if entry.access_key and entry.secret_key else None)
+
     if entry.type == "s3":
-        return ChainedProvider([
-            EnvAWSProvider(),
-            AWSConfigProvider(),
-            IamAwsProvider(),
-        ])
+        if inline:
+            return ChainedProvider(
+                [EnvAWSProvider(), inline, AWSConfigProvider(), IamAwsProvider()])
+        return ChainedProvider(
+            [EnvAWSProvider(), AWSConfigProvider(), IamAwsProvider()])
+
+    # minio
+    if inline:
+        return ChainedProvider([EnvMinioProvider(), inline])
     return EnvMinioProvider()
 
 

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -56,6 +56,11 @@ def _dig(raw: dict, path: tuple):
     return current
 
 
+def _present(value) -> bool:
+    """A replacement key counts as present only if found AND non-empty/non-falsy."""
+    return value is not _MISSING and bool(value)
+
+
 def check_legacy_keys(raw: dict) -> None:
     """Warn on deprecated keys; fail fast on removed keys that would silently change
     behavior. Operates on the raw dict BEFORE pydantic (which ignores unknown keys)."""
@@ -65,7 +70,9 @@ def check_legacy_keys(raw: dict) -> None:
         legacy_name = ".".join(path)
         replacement_name = ".".join(replacement_path)
         if policy == "fail_if_no_replacement":
-            if _dig(raw, replacement_path) is _MISSING:
+            # an empty/falsy replacement (e.g. object_storage: []) is not a real
+            # migration -> it would silently drop backups, so treat it as absent.
+            if not _present(_dig(raw, replacement_path)):
                 raise ValueError(
                     f"'{legacy_name}' was removed in v3.0.0; migrate to "
                     f"'{replacement_name}'. See the 'Migrating from v2' section in the "

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -33,63 +33,9 @@ def load_yaml_config(path: str) -> dict:
     return data
 
 
-_MISSING = object()
-
-# Each entry: (path, replacement_path, policy)
-#   path/replacement_path: tuple locating the key in the raw config dict (supports nesting)
-#   policy: "warn"                  -> legacy key still honored (aliased); nudge to rename
-#           "fail_if_no_replacement" -> key removed; error UNLESS the replacement is also
-#                                       present (a stale leftover is only a warning)
-_LEGACY_KEYS = [
-    (("assets", "modify_markdown"), ("assets", "modify_links"), "warn"),
-    (("minio",), ("object_storage",), "fail_if_no_replacement"),
-]
-
-
-def _dig(raw: dict, path: tuple):
-    """Return the value at a nested key path, or _MISSING if any segment is absent."""
-    current = raw
-    for key in path:
-        if not isinstance(current, dict) or key not in current:
-            return _MISSING
-        current = current[key]
-    return current
-
-
-def _present(value) -> bool:
-    """A replacement key counts as present only if found AND non-empty/non-falsy."""
-    return value is not _MISSING and bool(value)
-
-
-def check_legacy_keys(raw: dict) -> None:
-    """Warn on deprecated keys; fail fast on removed keys that would silently change
-    behavior. Operates on the raw dict BEFORE pydantic (which ignores unknown keys)."""
-    for path, replacement_path, policy in _LEGACY_KEYS:
-        if _dig(raw, path) is _MISSING:
-            continue
-        legacy_name = ".".join(path)
-        replacement_name = ".".join(replacement_path)
-        if policy == "fail_if_no_replacement":
-            # an empty/falsy replacement (e.g. object_storage: []) is not a real
-            # migration -> it would silently drop backups, so treat it as absent.
-            if not _present(_dig(raw, replacement_path)):
-                raise ValueError(
-                    f"'{legacy_name}' was removed in v3.0.0; migrate to "
-                    f"'{replacement_name}'. See the 'Migrating from v2' section in the "
-                    "README.")
-            log.warning(
-                "DEPRECATED: '%s' was removed in v3.0.0 and is ignored; '%s' is in use. "
-                "Remove the stale '%s' block.", legacy_name, replacement_name, legacy_name)
-        else:  # "warn"
-            log.warning(
-                "DEPRECATED: '%s' IS DEPRECATED, USE '%s' INSTEAD. "
-                "THE LEGACY KEY WILL BE REMOVED IN A FUTURE VERSION.",
-                legacy_name, replacement_name)
-
-
 def build_user_input(raw: dict) -> models.UserInput:
-    """Legacy/removed-key guard + pydantic validation. Returns models.UserInput."""
-    check_legacy_keys(raw)
+    """Pydantic validation. Deprecated/removed-key handling lives in the models
+    (Assets/UserInput before-validators). Returns models.UserInput."""
     try:
         return models.UserInput(**raw)
     except Exception:

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -64,6 +64,17 @@ _BOOKSTACK_TOKEN_FIELD ='BOOKSTACK_TOKEN_ID'
 _BOOKSTACK_TOKEN_SECRET_FIELD='BOOKSTACK_TOKEN_SECRET'
 
 
+def _s3_provider_chain(entry: models.BaseStorageConfig) -> list[Provider]:
+    """Provider list for an s3 entry: env > [inline] > IAM role (EC2/ECS/EKS). No ~/.aws
+    file tier. Returned as a list so the composition is testable without reaching into
+    minio-py's private ChainedProvider internals."""
+    chain: list[Provider] = [EnvAWSProvider()]
+    if entry.access_key and entry.secret_key:
+        chain.append(StaticProvider(entry.access_key, entry.secret_key))
+    chain.append(IamAwsProvider())
+    return chain
+
+
 def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
     """Resolve one entry's credentials to a minio-py Provider (first match wins):
 
@@ -89,11 +100,7 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
               if entry.access_key and entry.secret_key else None)
 
     if entry.type == "s3":
-        # env > inline > IAM role (IamAwsProvider auto-detects EC2/ECS/EKS). No ~/.aws
-        # file tier and no static creds required: a role can supply them at runtime.
-        if inline:
-            return ChainedProvider([EnvAWSProvider(), inline, IamAwsProvider()])
-        return ChainedProvider([EnvAWSProvider(), IamAwsProvider()])
+        return ChainedProvider(_s3_provider_chain(entry))
 
     # minio: env > inline (no file tier; minio has no IMDS equivalent)
     if inline:

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -69,7 +69,7 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
 
     1. per-entry env NAMES (access_key_env/secret_key_env) -> StaticProvider. Only scheme
        that supports two same-type targets with distinct out-of-file creds.
-    2. ambient env (MINIO_ACCESS_KEY/MINIO_SECRET_KEY for minio; AWS_ACCESS_KEY_ID/
+    2. standard env vars (MINIO_ACCESS_KEY/MINIO_SECRET_KEY for minio; AWS_ACCESS_KEY_ID/
        AWS_SECRET_ACCESS_KEY for s3) — checked before inline config-file keys.
     3. inline access_key/secret_key (config-file fallback).
     4. type s3 only — IMDS / EC2-ECS IAM role (no secrets in config/env/files).
@@ -83,7 +83,7 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
                 "are referenced but not set or empty")
         return StaticProvider(access, secret)
 
-    # inline keys, when present, sit BELOW ambient env (env > config file)
+    # inline keys, when present, sit BELOW the standard env vars (env > config file)
     inline = (StaticProvider(entry.access_key, entry.secret_key)
               if entry.access_key and entry.secret_key else None)
 

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -6,7 +6,14 @@ import yaml
 
 from bookstack_file_exporter.common.util import check_var
 from bookstack_file_exporter.config_helper import models
-from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
+from bookstack_file_exporter.config_helper.remote import (
+    StorageProviderConfig,
+    aws_endpoint_from_region,
+)
+from minio.credentials import (
+    Provider, StaticProvider, ChainedProvider,
+    EnvAWSProvider, AWSConfigProvider, IamAwsProvider, EnvMinioProvider,
+)
 
 log = logging.getLogger(__name__)
 
@@ -78,8 +85,44 @@ _BASE_DIR_NAME = "bookstack_export"
 
 _BOOKSTACK_TOKEN_FIELD ='BOOKSTACK_TOKEN_ID'
 _BOOKSTACK_TOKEN_SECRET_FIELD='BOOKSTACK_TOKEN_SECRET'
-_MINIO_ACCESS_KEY_FIELD='MINIO_ACCESS_KEY'
-_MINIO_SECRET_KEY_FIELD='MINIO_SECRET_KEY'
+
+
+def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
+    """Resolve one entry's credentials to a minio-py Provider (first match wins):
+
+    1. per-entry env NAMES (access_key_env/secret_key_env) -> StaticProvider. Only scheme
+       that supports two same-type targets with distinct out-of-file creds.
+    2. inline access_key/secret_key -> StaticProvider.
+    3. type s3, nothing set -> AWS default chain (env -> ~/.aws -> IAM role via IMDS).
+    4. type minio, nothing set -> EnvMinioProvider (fixed MINIO_ACCESS_KEY/MINIO_SECRET_KEY).
+    """
+    if entry.access_key_env and entry.secret_key_env:
+        access = os.environ.get(entry.access_key_env)
+        secret = os.environ.get(entry.secret_key_env)
+        if not access or not secret:
+            raise ValueError(
+                f"credential env vars {entry.access_key_env}/{entry.secret_key_env} "
+                "are referenced but not set or empty")
+        return StaticProvider(access, secret)
+    if entry.access_key and entry.secret_key:
+        return StaticProvider(entry.access_key, entry.secret_key)
+    if entry.type == "s3":
+        return ChainedProvider([
+            EnvAWSProvider(),
+            AWSConfigProvider(),
+            IamAwsProvider(),
+        ])
+    return EnvMinioProvider()
+
+
+def _resolve_endpoint(entry: models.BaseStorageConfig) -> str:
+    """Connection host for an entry: explicit host wins; else s3 defaults from region."""
+    if entry.host:
+        return entry.host
+    if entry.type == "s3" and entry.region:
+        return aws_endpoint_from_region(entry.region)
+    return ""
+
 
 # pylint: disable=too-many-instance-attributes
 ## Normalize config from cli or from config file
@@ -121,22 +164,22 @@ class ConfigNode:
         token_secret = check_var(_BOOKSTACK_TOKEN_SECRET_FIELD, token_secret)
         return token_id, token_secret
 
-    def _generate_remote_config(self) -> dict[str, StorageProviderConfig]:
-        object_config = {}
-        # check for optional minio credentials if configuration is set in yaml configuration file
-        if self.user_inputs.minio:
-            minio_access_key = check_var(_MINIO_ACCESS_KEY_FIELD,
-                                               self.user_inputs.minio.access_key)
-            minio_secret_key = check_var(_MINIO_SECRET_KEY_FIELD,
-                                               self.user_inputs.minio.secret_key)
-
-            object_config["minio"] = StorageProviderConfig(minio_access_key,
-                                     minio_secret_key, self.user_inputs.minio)
-        for platform, config in object_config.items():
-            if not config.is_valid(platform):
-                error_str = "provided " + platform + " configuration is invalid"
-                raise ValueError(error_str)
-        return object_config
+    def _generate_remote_config(self) -> list[StorageProviderConfig]:
+        configs: list[StorageProviderConfig] = []
+        if not self.user_inputs.object_storage:
+            return configs
+        for entry in self.user_inputs.object_storage:
+            provider_config = StorageProviderConfig(
+                storage_type=entry.type,
+                endpoint=_resolve_endpoint(entry),
+                secure=entry.secure,
+                credentials=_resolve_credentials(entry),
+                config=entry,
+            )
+            if not provider_config.is_valid(entry.type):
+                raise ValueError(f"provided {entry.type} configuration is invalid")
+            configs.append(provider_config)
+        return configs
 
     def _generate_headers(self) -> dict[str, str]:
         headers = {}
@@ -196,6 +239,6 @@ class ConfigNode:
         return self._base_dir_name
 
     @property
-    def object_storage_config(self) -> dict[str, StorageProviderConfig]:
-        """return remote storage configuration"""
+    def object_storage_config(self) -> list[StorageProviderConfig]:
+        """return list of resolved remote storage targets"""
         return self._object_storage_config

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -3,16 +3,16 @@ import argparse
 import logging
 # pylint: disable=import-error
 import yaml
+from minio.credentials import (
+    Provider, StaticProvider, ChainedProvider,
+    EnvAWSProvider, AWSConfigProvider, IamAwsProvider, EnvMinioProvider,
+)
 
 from bookstack_file_exporter.common.util import check_var
 from bookstack_file_exporter.config_helper import models
 from bookstack_file_exporter.config_helper.remote import (
     StorageProviderConfig,
     aws_endpoint_from_region,
-)
-from minio.credentials import (
-    Provider, StaticProvider, ChainedProvider,
-    EnvAWSProvider, AWSConfigProvider, IamAwsProvider, EnvMinioProvider,
 )
 
 log = logging.getLogger(__name__)

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -159,9 +159,7 @@ class ConfigNode:
 
     def _generate_remote_config(self) -> list[StorageProviderConfig]:
         configs: list[StorageProviderConfig] = []
-        if not self.user_inputs.object_storage:
-            return configs
-        for entry in self.user_inputs.object_storage:
+        for entry in self.user_inputs.object_storage or []:
             provider_config = StorageProviderConfig(
                 storage_type=entry.type,
                 endpoint=_resolve_endpoint(entry),

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -33,32 +33,56 @@ def load_yaml_config(path: str) -> dict:
     return data
 
 
-def check_legacy_modify_markdown(raw: dict) -> None:
-    """Emit deprecation warnings if legacy 'assets.modify_markdown' key is present."""
-    assets_raw = raw.get("assets", {}) or {}
-    if not isinstance(assets_raw, dict):
-        # Non-dict value (e.g. assets: true) — let pydantic produce the clear error.
-        return
-    has_legacy = "modify_markdown" in assets_raw
-    has_new = "modify_links" in assets_raw
-    if not has_legacy:
-        return
-    log.warning(
-        "DEPRECATED: 'assets.modify_markdown' IS DEPRECATED, "
-        "USE 'assets.modify_links' INSTEAD. "
-        "THE LEGACY KEY WILL BE REMOVED IN A FUTURE VERSION."
-    )
-    if has_new and assets_raw["modify_links"] != assets_raw["modify_markdown"]:
-        log.warning(
-            "Both 'assets.modify_links' and 'assets.modify_markdown' "
-            "are set with different values. 'assets.modify_links' wins; "
-            "the legacy 'assets.modify_markdown' value is ignored."
-        )
+_MISSING = object()
+
+# Each entry: (path, replacement_path, policy)
+#   path/replacement_path: tuple locating the key in the raw config dict (supports nesting)
+#   policy: "warn"                  -> legacy key still honored (aliased); nudge to rename
+#           "fail_if_no_replacement" -> key removed; error UNLESS the replacement is also
+#                                       present (a stale leftover is only a warning)
+_LEGACY_KEYS = [
+    (("assets", "modify_markdown"), ("assets", "modify_links"), "warn"),
+    (("minio",), ("object_storage",), "fail_if_no_replacement"),
+]
+
+
+def _dig(raw: dict, path: tuple):
+    """Return the value at a nested key path, or _MISSING if any segment is absent."""
+    current = raw
+    for key in path:
+        if not isinstance(current, dict) or key not in current:
+            return _MISSING
+        current = current[key]
+    return current
+
+
+def check_legacy_keys(raw: dict) -> None:
+    """Warn on deprecated keys; fail fast on removed keys that would silently change
+    behavior. Operates on the raw dict BEFORE pydantic (which ignores unknown keys)."""
+    for path, replacement_path, policy in _LEGACY_KEYS:
+        if _dig(raw, path) is _MISSING:
+            continue
+        legacy_name = ".".join(path)
+        replacement_name = ".".join(replacement_path)
+        if policy == "fail_if_no_replacement":
+            if _dig(raw, replacement_path) is _MISSING:
+                raise ValueError(
+                    f"'{legacy_name}' was removed in v3.0.0; migrate to "
+                    f"'{replacement_name}'. See the 'Migrating from v2' section in the "
+                    "README.")
+            log.warning(
+                "DEPRECATED: '%s' was removed in v3.0.0 and is ignored; '%s' is in use. "
+                "Remove the stale '%s' block.", legacy_name, replacement_name, legacy_name)
+        else:  # "warn"
+            log.warning(
+                "DEPRECATED: '%s' IS DEPRECATED, USE '%s' INSTEAD. "
+                "THE LEGACY KEY WILL BE REMOVED IN A FUTURE VERSION.",
+                legacy_name, replacement_name)
 
 
 def build_user_input(raw: dict) -> models.UserInput:
-    """Legacy-key deprecation check + pydantic validation. Returns models.UserInput."""
-    check_legacy_modify_markdown(raw)
+    """Legacy/removed-key guard + pydantic validation. Returns models.UserInput."""
+    check_legacy_keys(raw)
     try:
         return models.UserInput(**raw)
     except Exception:

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -5,7 +5,7 @@ import logging
 import yaml
 from minio.credentials import (
     Provider, StaticProvider, ChainedProvider,
-    EnvAWSProvider, AWSConfigProvider, IamAwsProvider, EnvMinioProvider,
+    EnvAWSProvider, IamAwsProvider, EnvMinioProvider,
 )
 
 from bookstack_file_exporter.common.util import check_var
@@ -72,7 +72,7 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
     2. ambient env (MINIO_ACCESS_KEY/MINIO_SECRET_KEY for minio; AWS_ACCESS_KEY_ID/
        AWS_SECRET_ACCESS_KEY for s3) — checked before inline config-file keys.
     3. inline access_key/secret_key (config-file fallback).
-    4. type s3 only: ~/.aws/credentials (by AWS_PROFILE) then IAM role via IMDS.
+    4. type s3 only — IMDS / EC2-ECS IAM role (no secrets in config/env/files).
     """
     if entry.access_key_env and entry.secret_key_env:
         access = os.environ.get(entry.access_key_env)
@@ -88,13 +88,13 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
               if entry.access_key and entry.secret_key else None)
 
     if entry.type == "s3":
+        # env > inline > IMDS (EC2/ECS IAM role). No ~/.aws file tier and no static
+        # creds required: a role can supply them at runtime.
         if inline:
-            return ChainedProvider(
-                [EnvAWSProvider(), inline, AWSConfigProvider(), IamAwsProvider()])
-        return ChainedProvider(
-            [EnvAWSProvider(), AWSConfigProvider(), IamAwsProvider()])
+            return ChainedProvider([EnvAWSProvider(), inline, IamAwsProvider()])
+        return ChainedProvider([EnvAWSProvider(), IamAwsProvider()])
 
-    # minio
+    # minio: env > inline (no file tier; minio has no IMDS equivalent)
     if inline:
         return ChainedProvider([EnvMinioProvider(), inline])
     return EnvMinioProvider()

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -161,7 +161,7 @@ class ConfigNode:
                 credentials=_resolve_credentials(entry),
                 config=entry,
             )
-            if not provider_config.is_valid(entry.type):
+            if not provider_config.is_valid():
                 raise ValueError(f"provided {entry.type} configuration is invalid")
             configs.append(provider_config)
         return configs

--- a/bookstack_file_exporter/config_helper/config_helper.py
+++ b/bookstack_file_exporter/config_helper/config_helper.py
@@ -72,7 +72,8 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
     2. standard env vars (MINIO_ACCESS_KEY/MINIO_SECRET_KEY for minio; AWS_ACCESS_KEY_ID/
        AWS_SECRET_ACCESS_KEY for s3) — checked before inline config-file keys.
     3. inline access_key/secret_key (config-file fallback).
-    4. type s3 only — IMDS / EC2-ECS IAM role (no secrets in config/env/files).
+    4. type s3 only — IAM role auto-detected by IamAwsProvider (EC2 IMDS / ECS / EKS
+       IRSA / Pod Identity); no secrets in config/env/files.
     """
     if entry.access_key_env and entry.secret_key_env:
         access = os.environ.get(entry.access_key_env)
@@ -88,8 +89,8 @@ def _resolve_credentials(entry: models.BaseStorageConfig) -> Provider:
               if entry.access_key and entry.secret_key else None)
 
     if entry.type == "s3":
-        # env > inline > IMDS (EC2/ECS IAM role). No ~/.aws file tier and no static
-        # creds required: a role can supply them at runtime.
+        # env > inline > IAM role (IamAwsProvider auto-detects EC2/ECS/EKS). No ~/.aws
+        # file tier and no static creds required: a role can supply them at runtime.
         if inline:
             return ChainedProvider([EnvAWSProvider(), inline, IamAwsProvider()])
         return ChainedProvider([EnvAWSProvider(), IamAwsProvider()])

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -1,9 +1,12 @@
+import logging
 import re
 from datetime import datetime
 from typing import Literal
 # pylint: disable=import-error
 from pydantic import BaseModel, Field, AliasChoices, ConfigDict, field_validator, model_validator
 from croniter import croniter, CroniterError
+
+log = logging.getLogger(__name__)
 
 # pylint: disable=too-few-public-methods
 class BaseStorageConfig(BaseModel):
@@ -56,6 +59,17 @@ class Assets(BaseModel):
         validation_alias=AliasChoices("modify_links", "modify_markdown"),
     )
     export_meta: bool | None = False
+
+    @model_validator(mode="before")
+    @classmethod
+    def _warn_deprecated_keys(cls, raw):
+        """Nudge on the deprecated 'modify_markdown' key. The value is still honored
+        via the validation_alias above; this only logs a rename reminder."""
+        if isinstance(raw, dict) and "modify_markdown" in raw:
+            log.warning(
+                "DEPRECATED: 'assets.modify_markdown' is deprecated, use "
+                "'assets.modify_links' instead. It will be removed in a future version.")
+        return raw
 
 class HttpConfig(BaseModel):
     """YAML schema for user provided http settings"""
@@ -155,6 +169,24 @@ class UserInput(BaseModel):
     http_config: HttpConfig | None = HttpConfig()
     notifications: Notifications | None = None
     filters: Filters | None = None
+
+    @model_validator(mode="before")
+    @classmethod
+    def _reject_removed_keys(cls, raw):
+        """Fail fast on removed v2 keys that pydantic would otherwise silently drop
+        (extra='ignore'). A leftover 'minio:' with no 'object_storage:' yields zero
+        upload targets -> silent backup loss, unacceptable for a backup tool. A 'minio:'
+        next to a real 'object_storage:' is a harmless stale leftover -> warn only.
+        An empty 'object_storage: []' is NOT a real replacement -> still fails."""
+        if isinstance(raw, dict) and "minio" in raw:
+            if not raw.get("object_storage"):
+                raise ValueError(
+                    "'minio' was removed in v3.0.0; migrate to 'object_storage'. "
+                    "See the 'Migrating from v2' section in the README.")
+            log.warning(
+                "DEPRECATED: 'minio' was removed in v3.0.0 and is ignored; "
+                "'object_storage' is in use. Remove the stale 'minio' block.")
+        return raw
 
     @model_validator(mode="after")
     def _check_schedule_config(self):

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -27,6 +27,13 @@ class BaseStorageConfig(BaseModel):
     secret_key: str | None = ""
     access_key_env: str | None = None
     secret_key_env: str | None = None
+    name: str | None = None
+
+    @property
+    def label(self) -> str:
+        """Identity for logs/notifications. Excludes creds (secrets) and host/region by
+        design, so a bare type/bucket collision forces the user to set a distinct name."""
+        return self.name or f"{self.type}/{self.bucket}"
 
     @model_validator(mode="after")
     def _check_cred_pairs(self):
@@ -182,6 +189,22 @@ class UserInput(BaseModel):
                 "'minio' was removed in v3.0.0; migrate to 'object_storage'. "
                 "See the 'Migrating from v2' section in the README.")
         return raw
+
+    @model_validator(mode="after")
+    def _check_unique_object_storage_labels(self):
+        """Enforce distinct labels across all object_storage entries."""
+        if not self.object_storage:
+            return self
+        seen: set[str] = set()
+        # pylint: disable-next=not-an-iterable
+        for entry in self.object_storage:
+            lbl = entry.label
+            if lbl in seen:
+                raise ValueError(
+                    f"Duplicate object_storage label {lbl!r}. "
+                    "Two entries share the same type/bucket; set a distinct 'name' on each.")
+            seen.add(lbl)
+        return self
 
     @model_validator(mode="after")
     def _check_schedule_config(self):

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -173,19 +173,14 @@ class UserInput(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def _reject_removed_keys(cls, raw):
-        """Fail fast on removed v2 keys that pydantic would otherwise silently drop
-        (extra='ignore'). A leftover 'minio:' with no 'object_storage:' yields zero
-        upload targets -> silent backup loss, unacceptable for a backup tool. A 'minio:'
-        next to a real 'object_storage:' is a harmless stale leftover -> warn only.
-        An empty 'object_storage: []' is NOT a real replacement -> still fails."""
+        """Hard-fail on removed v2 keys that pydantic would otherwise silently drop
+        (extra='ignore'). 'minio:' was REMOVED in v3 (not deprecated -- it no longer
+        does anything), so ANY presence is an error: a backup tool must never run on a
+        stale config that silently produces no uploads. v3.0.0 is the expected break."""
         if isinstance(raw, dict) and "minio" in raw:
-            if not raw.get("object_storage"):
-                raise ValueError(
-                    "'minio' was removed in v3.0.0; migrate to 'object_storage'. "
-                    "See the 'Migrating from v2' section in the README.")
-            log.warning(
-                "DEPRECATED: 'minio' was removed in v3.0.0 and is ignored; "
-                "'object_storage' is in use. Remove the stale 'minio' block.")
+            raise ValueError(
+                "'minio' was removed in v3.0.0; migrate to 'object_storage'. "
+                "See the 'Migrating from v2' section in the README.")
         return raw
 
     @model_validator(mode="after")

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -6,15 +6,35 @@ from pydantic import BaseModel, Field, AliasChoices, ConfigDict, field_validator
 from croniter import croniter, CroniterError
 
 # pylint: disable=too-few-public-methods
-class ObjectStorageConfig(BaseModel):
-    """YAML schema for minio configuration"""
+class BaseStorageConfig(BaseModel):
+    """YAML schema for one object_storage entry (minio or s3).
+
+    Permissive model: per-type required-ness (minio->host, s3->region) is checked at
+    runtime in remote.py is_valid(); only the always-true cred-pair invariant is enforced
+    here. Separate per-type models are deferred until fields genuinely diverge (YAGNI).
+    """
+    type: Literal["minio", "s3"]
     host: str | None = ""
+    bucket: str
+    region: str | None = None
+    path: str | None = ""
+    secure: bool = True
+    keep_last: int | None = 0
     access_key: str | None = ""
     secret_key: str | None = ""
-    bucket: str
-    path: str | None = ""
-    region: str
-    keep_last: int | None = 0
+    access_key_env: str | None = None
+    secret_key_env: str | None = None
+
+    @model_validator(mode="after")
+    def _check_cred_pairs(self):
+        """A half cred pair is always a mistake, regardless of the fallback chain."""
+        if bool(self.access_key) != bool(self.secret_key):
+            raise ValueError(
+                "access_key and secret_key must be set together (or both omitted)")
+        if bool(self.access_key_env) != bool(self.secret_key_env):
+            raise ValueError(
+                "access_key_env and secret_key_env must be set together (or both omitted)")
+        return self
 
 # pylint: disable=too-few-public-methods
 class BookstackAccess(BaseModel):
@@ -118,7 +138,7 @@ class UserInput(BaseModel):
     # (html/pdf embed assets server-side and are not rewritten at these levels).
     export_level: Literal["pages", "books", "chapters"] = "pages"
     assets: Assets | None = Assets()
-    minio: ObjectStorageConfig | None = None
+    object_storage: list[BaseStorageConfig] | None = None
     keep_last: int | None = 0
     # Opt-in node-level parallel fetch. Default 1 = today's exact serial behavior.
     # ge=1 because ThreadPoolExecutor(max_workers=0) raises ValueError — reject

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -31,8 +31,9 @@ class BaseStorageConfig(BaseModel):
 
     @property
     def label(self) -> str:
-        """Identity for logs/notifications. Excludes creds (secrets) and host/region by
-        design, so a bare type/bucket collision forces the user to set a distinct name."""
+        """Target identity, intended for logs/notifications (consumed today only by the
+        uniqueness check below; wired into output in a later task). Excludes creds (secrets)
+        and host/region by design, so a bare type/bucket collision forces a distinct name."""
         return self.name or f"{self.type}/{self.bucket}"
 
     @model_validator(mode="after")

--- a/bookstack_file_exporter/config_helper/remote.py
+++ b/bookstack_file_exporter/config_helper/remote.py
@@ -14,6 +14,7 @@ def aws_endpoint_from_region(region: str) -> str:
 
 
 ## convenience class — holds one resolved object storage target (minio or s3)
+# pylint: disable=too-few-public-methods
 class StorageProviderConfig:
     """Resolved configuration for a single object storage target.
 
@@ -29,6 +30,7 @@ class StorageProviderConfig:
         config <BaseStorageConfig> = the raw parsed entry (bucket/path/region/keep_last)
     """
 
+    # pylint: disable=too-many-arguments,too-many-positional-arguments
     def __init__(self, storage_type: str, endpoint: str, secure: bool,
                  credentials: Provider, config: BaseStorageConfig):
         self.type = storage_type

--- a/bookstack_file_exporter/config_helper/remote.py
+++ b/bookstack_file_exporter/config_helper/remote.py
@@ -1,54 +1,61 @@
 import logging
 
-from bookstack_file_exporter.config_helper.models import ObjectStorageConfig
+# pylint: disable=import-error
+from minio.credentials import Provider
+
+from bookstack_file_exporter.config_helper.models import BaseStorageConfig
 
 log = logging.getLogger(__name__)
 
-## convenience class
-## able to work for minio, s3, etc.
+
+def aws_endpoint_from_region(region: str) -> str:
+    """Default AWS S3 endpoint host for a region (used when no host is given)."""
+    return f"s3.{region}.amazonaws.com"
+
+
+## convenience class — holds one resolved object storage target (minio or s3)
 class StorageProviderConfig:
-    """
-    Convenience class to hold object storage provider configuration
-    
+    """Resolved configuration for a single object storage target.
+
+    Carries a minio-py credential Provider (not raw key strings) plus the resolved
+    endpoint host and TLS flag, so the archiver can construct a Minio() client directly.
+
     Args:
-        access_key <str> = required token id
-
-        secret_key <str> = required secret token
-
-        config <ObjectStorageConfig> = required configuration options
-
-    Returns:
-        StorageProviderConfig instance for holding configuration
+        storage_type <str> = 'minio' | 's3'; drives validation + dispatch
+        endpoint <str> = host:port the client connects to (resolved; for s3 may be
+            defaulted from region)
+        secure <bool> = TLS on/off
+        credentials <Provider> = minio-py credential provider
+        config <BaseStorageConfig> = the raw parsed entry (bucket/path/region/keep_last)
     """
 
-    def __init__(self, access_key: str, secret_key: str, config: ObjectStorageConfig):
+    def __init__(self, storage_type: str, endpoint: str, secure: bool,
+                 credentials: Provider, config: BaseStorageConfig):
+        self.type = storage_type
+        self.endpoint = endpoint
+        self.secure = secure
+        self.credentials = credentials
         self.config = config
-        self._access_key = access_key
-        self._secret_key = secret_key
-        self._valid_checker = {'minio': self._is_minio_valid}
-
-    @property
-    def access_key(self) -> str:
-        """return access key for use"""
-        return self._access_key
-
-    @property
-    def secret_key(self) -> str:
-        """return secret key for use"""
-        return self._secret_key
+        self._valid_checker = {
+            "minio": self._is_minio_valid,
+            "s3": self._is_s3_valid,
+        }
 
     def is_valid(self, storage_type: str) -> bool:
-        """check if object storage config is valid"""
+        """check if object storage config is valid for the given type"""
         return self._valid_checker[storage_type]()
 
     def _is_minio_valid(self) -> bool:
-        """check if minio config is valid"""
-        # required values - keys and bucket already checked so skip
-        checks = {
-            "host": self.config.host
-        }
-        for prop, check in checks.items():
-            if not check:
-                log.error("%s is missing from minio configuration and is required", prop)
-                return False
+        """minio requires an explicit host; creds may resolve at call time."""
+        if not self.config.host:
+            log.error("host is missing from minio configuration and is required")
+            return False
+        return True
+
+    def _is_s3_valid(self) -> bool:
+        """s3 requires a region (host defaults from it); creds may come from the AWS
+        chain (incl. IAM role) at runtime, so they are NOT statically required here."""
+        if not self.config.region:
+            log.error("region is missing from s3 configuration and is required")
+            return False
         return True

--- a/bookstack_file_exporter/config_helper/remote.py
+++ b/bookstack_file_exporter/config_helper/remote.py
@@ -43,9 +43,9 @@ class StorageProviderConfig:
             "s3": self._is_s3_valid,
         }
 
-    def is_valid(self, storage_type: str) -> bool:
-        """check if object storage config is valid for the given type"""
-        return self._valid_checker[storage_type]()
+    def is_valid(self) -> bool:
+        """check if this target's config is valid, dispatched on its own type"""
+        return self._valid_checker[self.type]()
 
     def _is_minio_valid(self) -> bool:
         """minio requires an explicit host; creds may resolve at call time."""

--- a/bookstack_file_exporter/health/status.py
+++ b/bookstack_file_exporter/health/status.py
@@ -27,7 +27,7 @@ def _now() -> datetime:
 class RunStatus:  # pylint: disable=too-many-instance-attributes
     """Thread-safe last-run/next-run status for the health endpoint."""
     _lock: threading.Lock = field(default_factory=threading.Lock, repr=False)
-    _last_run_status: str = "never"   # never -> running -> success | failed
+    _last_run_status: str = "never"   # never -> running -> success | degraded | failed
     _started_at: datetime | None = None
     _finished_at: datetime | None = None
     _archive_file: str | None = None
@@ -49,6 +49,20 @@ class RunStatus:  # pylint: disable=too-many-instance-attributes
         """Transition to success state, record finish time, and increment run count."""
         with self._lock:
             self._last_run_status = "success"
+            self._finished_at = _now()
+            self._error = None
+            self._archive_file = (
+                os.path.basename(result.local)
+                if result is not None and result.local
+                else None
+            )
+            self._run_count += 1
+
+    def mark_degraded(self, result: NotifyResult | None) -> None:
+        """Partial run: a copy survived but a target failed. Counts as a run, NOT a
+        failure (operators alert on it via the notification, not failure_count)."""
+        with self._lock:
+            self._last_run_status = "degraded"
             self._finished_at = _now()
             self._error = None
             self._archive_file = (

--- a/bookstack_file_exporter/notify/handler.py
+++ b/bookstack_file_exporter/notify/handler.py
@@ -2,7 +2,7 @@ import logging
 
 from bookstack_file_exporter.config_helper import models, notifications
 from bookstack_file_exporter.notify import notifiers
-from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult
 
 
 log = logging.getLogger(__name__)
@@ -47,7 +47,10 @@ class NotifyHandler:
         a_config = notifications.AppRiseNotifyConfig(config)
         a_config.validate()
         apprise = notifiers.AppRiseNotify(a_config)
-        # only send notification if on_success or on_failure is set
-        if (not excep and a_config.on_success) or (excep and a_config.on_failure):
+        # PARTIAL is a degraded run: treat it like a failure for gating so on_failure
+        # subscribers are alerted (a copy survived, but a target did not receive it).
+        is_partial = result is not None and result.status is ExportStatus.PARTIAL
+        fire_failure = excep is not None or is_partial
+        if (not fire_failure and a_config.on_success) or (fire_failure and a_config.on_failure):
             log.info("Sending notification for run status")
             apprise.notify(excep, result)

--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -10,10 +10,12 @@ class ExportStatus(Enum):
 
 @dataclass
 class UploadOutcome:
-    """Per-target upload result. dest set on success, error set on failure."""
+    """Per-target upload result. dest set on success; error set on upload failure;
+    warning set when the upload landed but post-upload retention cleanup failed."""
     label: str                  # provider_config.config.label
     dest: str | None = None     # "bucket/object" on success
-    error: str | None = None    # str(exception) on failure
+    error: str | None = None    # str(exception) on upload failure
+    warning: str | None = None  # str(exception) when upload OK but retention cleanup failed
 
 
 @dataclass

--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -1,9 +1,25 @@
 from dataclasses import dataclass, field
+from enum import Enum
+
+
+class ExportStatus(Enum):
+    """Terminal run outcome. Hard failure is a raised exception, never a value here."""
+    SUCCESS = "success"
+    PARTIAL = "partial"
+
+
+@dataclass
+class UploadOutcome:
+    """Per-target upload result. dest set on success, error set on failure."""
+    label: str                  # provider_config.config.label
+    dest: str | None = None     # "bucket/object" on success
+    error: str | None = None    # str(exception) on failure
 
 
 @dataclass
 class NotifyResult:
-    """What an export run produced, for the success notification."""
-    local: str | None = None          # full local .tgz path, None if no archive made
-    remote: list[str] = field(default_factory=list)   # remote destinations, one per target
-    removed: list[str] = field(default_factory=list)   # local files clean_up() actually deleted
+    """What an export run produced, for notifications."""
+    status: ExportStatus = ExportStatus.SUCCESS
+    local: str | None = None                            # local .tgz path, None if no archive
+    uploads: list[UploadOutcome] = field(default_factory=list)  # one per configured target
+    removed: list[str] = field(default_factory=list)    # local files clean_up() deleted

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -66,7 +66,7 @@ class AppRiseNotify:
                 f"Error message: {str(error_msg)}",
             ])
         partial = result is not None and result.status is ExportStatus.PARTIAL
-        headline = ("Bookstack File Exporter completed with upload errors."
+        headline = ("Bookstack File Exporter completed with errors."
                     if partial else
                     "Bookstack File Exporter completed successfully.")
         lines = ["", headline, "", f"Completed At: {timestamp}"]
@@ -85,6 +85,8 @@ class AppRiseNotify:
             for outcome in result.uploads:
                 if not outcome.dest:
                     lines.append(f"Failed: {outcome.label} - {outcome.error}")
+                elif outcome.warning:
+                    lines.append(f"Warning: {outcome.label} - {outcome.warning}")
             pruned_count = len(removed_abs - {local_abs})
             if pruned_count > 0:
                 lines.append(f"Pruned {pruned_count} old local archive(s)")

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from apprise import Apprise, AppriseAsset, AppriseConfig
 
 from bookstack_file_exporter.config_helper import notifications
-from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify.models import NotifyResult, ExportStatus
 
 _DEFAULT_TITLE_PREFIX = "Bookstack File Exporter "
 
@@ -43,55 +43,57 @@ class AppRiseNotify:
         client.asset=asset
         return client
 
-    def _get_title(self, excep: None | Exception) -> str:
+    def _get_title(self, excep: None | Exception,
+                   result: NotifyResult | None = None) -> str:
         if self.config.custom_title:
             return self.config.custom_title
         if excep:
             return _DEFAULT_TITLE_PREFIX + "Failed"
+        if result is not None and result.status is ExportStatus.PARTIAL:
+            return _DEFAULT_TITLE_PREFIX + "Partial"
         return _DEFAULT_TITLE_PREFIX + "Success"
 
     def _get_message_text(self, error_msg: None | Exception,
                           result: NotifyResult | None = None) -> str:
         timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
         if error_msg:
-            error_str = str(error_msg)
-            lines = [
+            return "\n".join([
                 "",
                 "Bookstack File Exporter encountered an unrecoverable error.",
                 "",
                 f"Occurred At: {timestamp}",
                 "",
-                f"Error message: {error_str}",
-            ]
-        else:
-            lines = [
-                "",
-                "Bookstack File Exporter completed successfully.",
-                "",
-                f"Completed At: {timestamp}",
-            ]
-            if result is not None and result.local is not None:
-                local_abs = os.path.abspath(result.local)
-                removed_abs = {os.path.abspath(p) for p in result.removed}
-                was_removed = local_abs in removed_abs
-
-                archive_line = f"Archive: {result.local}"
-                if was_removed:
-                    archive_line += " (removed locally after upload)"
-                lines.append(archive_line)
-
-                if result.remote:
-                    lines.append(f"Uploaded to: {', '.join(result.remote)}")
-
-                pruned_count = len(removed_abs - {local_abs})
-                if pruned_count > 0:
-                    lines.append(f"Pruned {pruned_count} old local archive(s)")
+                f"Error message: {str(error_msg)}",
+            ])
+        partial = result is not None and result.status is ExportStatus.PARTIAL
+        headline = ("Bookstack File Exporter completed with upload errors."
+                    if partial else
+                    "Bookstack File Exporter completed successfully.")
+        lines = ["", headline, "", f"Completed At: {timestamp}"]
+        if result is not None and result.local is not None:
+            local_abs = os.path.abspath(result.local)
+            removed_abs = {os.path.abspath(p) for p in result.removed}
+            archive_line = f"Archive: {result.local}"
+            if local_abs in removed_abs:
+                archive_line += " (removed locally after upload)"
+            lines.append(archive_line)
+            # Preserve the concise "Uploaded to:" success line for targets that succeeded;
+            # list any failures explicitly below it (partial runs).
+            ok_dests = [o.dest for o in result.uploads if o.dest]
+            if ok_dests:
+                lines.append(f"Uploaded to: {', '.join(ok_dests)}")
+            for outcome in result.uploads:
+                if not outcome.dest:
+                    lines.append(f"Failed: {outcome.label} - {outcome.error}")
+            pruned_count = len(removed_abs - {local_abs})
+            if pruned_count > 0:
+                lines.append(f"Pruned {pruned_count} old local archive(s)")
         return "\n".join(lines)
 
     def notify(self, excep: Exception | None = None, result: NotifyResult | None = None):
         """send notification with exception message"""
         custom_body = self._get_message_text(excep, result)
-        title_ = self._get_title(excep)
+        title_ = self._get_title(excep, result)
         if self.config.custom_attachment:
             self._client.notify(
                 title=title_,

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -12,7 +12,7 @@ from bookstack_file_exporter.exporter.filter import NodeFilter
 from bookstack_file_exporter.archiver.archiver import Archiver
 from bookstack_file_exporter.common.util import HttpHelper, seconds_until_next_cron
 from bookstack_file_exporter.notify.handler import NotifyHandler
-from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify.models import NotifyResult, ExportStatus
 from bookstack_file_exporter.health.status import RunStatus
 from bookstack_file_exporter.health.server import start_health_server
 
@@ -63,7 +63,9 @@ def _run_once(config: ConfigNode) -> int:
     signal.signal(signal.SIGINT, _handle_signal)
 
     try:
-        run(config)
+        result = run(config)
+        if result is not None and result.status is ExportStatus.PARTIAL:
+            return 3
         return 0
     except KeyboardInterrupt:
         signum = int(received.get("signum", signal.SIGINT))
@@ -112,7 +114,10 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
         try:
             result = run(config, stop)
             if status:
-                status.mark_success(result)
+                if result is not None and result.status is ExportStatus.PARTIAL:
+                    status.mark_degraded(result)
+                else:
+                    status.mark_success(result)
         except Exception as err:  # pylint: disable=broad-except
             # log-and-continue: a failed cycle still waits the interval below
             # before retrying (no busy-loop), and the failure notification has
@@ -235,16 +240,18 @@ def exporter(config: ConfigNode, stop=None):
         # create tar if needed and gzip tar
         archive.create_archive()
 
-        # archive to remote targets
-        remote = archive.archive_remote()
-        # if remote target is specified and clean is true
-        # clean up the .tgz archive since it is already uploaded
+        # attempt every remote target, then derive status (raises only when no copy survives)
+        outcomes = archive.archive_remote()
+        status = archive.resolve_remote_status(outcomes)
+
+        # clean_up only runs when a durable copy survives (hard-fail raised above, so the
+        # local .tgz is preserved for retry).
         removed = archive.clean_up()
 
         local = archive.archive_file
         log.info("Created file archive: %s.tgz", archive.archive_dir)
         log.info("Completed run")
-        return NotifyResult(local=local, remote=remote, removed=removed)
+        return NotifyResult(status=status, local=local, uploads=outcomes, removed=removed)
     finally:
         # Eager cleanup of THIS cycle's partial on every terminal path (stop,
         # exception, one-shot KeyboardInterrupt). No-op on success: the tar is

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -561,7 +561,7 @@ def test_clean_up_keep_last_positive_returns_only_old_archives(
 
 
 # ---------------------------------------------------------------------------
-# MinioArchiver._generate_path — trailing-slash normalisation
+# S3CompatibleArchiver._generate_path — trailing-slash normalisation
 # ---------------------------------------------------------------------------
 
 @pytest.mark.parametrize("input_path,expected", [

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -489,14 +489,6 @@ def test_archive_remote_two_same_type_entries_no_collision(archiver_instance, mo
     assert archiver_instance.archive_remote() == ["b1/x.tgz", "b2/x.tgz"]
 
 
-def test_archive_remote_raises_on_unknown_type(archiver_instance, mock_config):
-    """Entry with an unsupported type → ValueError."""
-    mock_config.object_storage_config = [_provider_entry("gcs")]
-    archiver_instance._s3_archiver_cls = MagicMock()
-    with pytest.raises(ValueError, match="unsupported remote storage type"):
-        archiver_instance.archive_remote()
-
-
 def test_archive_remote_returns_empty_list_when_no_config(archiver_instance, mock_config):
     """No object storage config → returns []."""
     mock_config.object_storage_config = []

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -551,6 +551,28 @@ def test_resolve_status_empty_is_success(archiver_instance):
     assert archiver_instance.resolve_remote_status([]) is ExportStatus.SUCCESS
 
 
+def test_archive_remote_retention_failure_is_warning_not_failure(archiver_instance, mock_config):
+    """Upload succeeds but remote retention cleanup raises -> dest kept, warning set."""
+    mock_config.object_storage_config = [_provider_entry("s3", "s3/aws")]
+    inst = MagicMock()
+    inst.upload_backup.return_value = "s3-aws/a.tgz"
+    inst.clean_up.side_effect = RuntimeError("delete denied")
+    archiver_instance._s3_archiver_cls = MagicMock(return_value=inst)
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    outcomes = archiver_instance.archive_remote()
+
+    assert outcomes[0].dest == "s3-aws/a.tgz"
+    assert outcomes[0].error is None
+    assert "delete denied" in outcomes[0].warning
+
+
+def test_resolve_status_upload_ok_but_warning_is_partial(archiver_instance):
+    out = [UploadOutcome(label="a", dest="a/x.tgz", error=None, warning="prune failed")]
+    assert archiver_instance.resolve_remote_status(out) is ExportStatus.PARTIAL
+
+
 # ---------------------------------------------------------------------------
 # clean_up
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bookstack_file_exporter.archiver.archiver import Archiver
-from bookstack_file_exporter.archiver.minio_archiver import S3CompatibleArchiver
+from bookstack_file_exporter.archiver.s3_archiver import S3CompatibleArchiver
 from bookstack_file_exporter.archiver.node_archiver import (
     BookArchiver,
     ChapterArchiver,

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -11,7 +11,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from bookstack_file_exporter.archiver.archiver import Archiver
-from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
+from bookstack_file_exporter.archiver.minio_archiver import S3CompatibleArchiver
 from bookstack_file_exporter.archiver.node_archiver import (
     BookArchiver,
     ChapterArchiver,
@@ -32,7 +32,7 @@ def mock_config():
     config.user_inputs.keep_last = 1
     config.user_inputs.output_path = ""
     config.user_inputs.export_level = "pages"
-    config.object_storage_config = {}
+    config.object_storage_config = []
     return config
 
 
@@ -199,7 +199,7 @@ class TestBuildArchiver:
         config.base_dir_name = "bkps"
         config.user_inputs.keep_last = 0
         config.user_inputs.output_path = ""
-        config.object_storage_config = {}
+        config.object_storage_config = []
         archiver = Archiver(config, mock_http_client)
         assert isinstance(archiver._archiver, BookArchiver)
 
@@ -208,7 +208,7 @@ class TestBuildArchiver:
         config.base_dir_name = "bkps"
         config.user_inputs.keep_last = 0
         config.user_inputs.output_path = ""
-        config.object_storage_config = {}
+        config.object_storage_config = []
         archiver = Archiver(config, mock_http_client)
         assert isinstance(archiver._archiver, ChapterArchiver)
 
@@ -217,7 +217,7 @@ class TestBuildArchiver:
         config.base_dir_name = "bkps"
         config.user_inputs.keep_last = 0
         config.user_inputs.output_path = ""
-        config.object_storage_config = {}
+        config.object_storage_config = []
         archiver = Archiver(config, mock_http_client)
         assert isinstance(archiver._archiver, PageArchiver)
 
@@ -444,55 +444,63 @@ def test_create_export_dir_permission_error_logs_warning(
 # archive_remote
 # ---------------------------------------------------------------------------
 
-def test_archive_remote_dispatches_minio(archiver_instance, mock_config):
-    """object_storage_config has 'minio' key → MinioArchiver constructed via injected class."""
-    obj_config = MagicMock()
-    obj_config.access_key = "mykey"
-    obj_config.secret_key = "mysecret"
-    obj_config.config = MagicMock()
-    mock_config.object_storage_config = {"minio": obj_config}
+def _provider_entry(storage_type="minio"):
+    obj = MagicMock()
+    obj.type = storage_type
+    return obj
 
-    fake_minio_instance = MagicMock()
-    fake_minio_instance.upload_backup.return_value = "bucket/path/archive.tgz"
-    fake_minio_cls = MagicMock(return_value=fake_minio_instance)
 
-    archiver_instance._minio_archiver_cls = fake_minio_cls
+def test_archive_remote_empty_list_no_calls(archiver_instance, mock_config):
+    """object_storage_config=[] → returns [], no archiver constructed."""
+    mock_config.object_storage_config = []
+    fake_cls = MagicMock()
+    archiver_instance._s3_archiver_cls = fake_cls
+    assert archiver_instance.archive_remote() == []
+    fake_cls.assert_not_called()
+
+
+def test_archive_remote_uploads_each_entry_via_shared_archiver(archiver_instance, mock_config):
+    """Both minio and s3 entries go through the same S3CompatibleArchiver; dests collected."""
+    mock_config.object_storage_config = [_provider_entry("minio"), _provider_entry("s3")]
+    fake_instance = MagicMock()
+    fake_instance.upload_backup.side_effect = ["bucket1/a.tgz", "bucket2/b.tgz"]
+    fake_cls = MagicMock(return_value=fake_instance)
+    archiver_instance._s3_archiver_cls = fake_cls
     archiver_instance._archiver.archive_file = "/local/archive.tgz"
     archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
 
-    archiver_instance.archive_remote()
+    result = archiver_instance.archive_remote()
 
-    fake_minio_cls.assert_called_once_with(
-        obj_config.access_key, obj_config.secret_key, obj_config.config
-    )
+    assert result == ["bucket1/a.tgz", "bucket2/b.tgz"]
+    assert fake_cls.call_count == 2
+    fake_instance.upload_backup.assert_called_with("/local/archive.tgz")
+    assert fake_instance.clean_up.call_count == 2
 
 
-def test_archive_remote_raises_on_unknown_storage_type(mock_config, mock_http_client):
-    """object_storage_config has unknown key → ValueError raised."""
-    mock_config.object_storage_config = {"gcs": MagicMock()}
-    archiver = Archiver(mock_config, mock_http_client, node_archiver=MagicMock())
+def test_archive_remote_two_same_type_entries_no_collision(archiver_instance, mock_config):
+    """Two minio entries both upload (list permits same-type; a dict would drop one)."""
+    mock_config.object_storage_config = [_provider_entry("minio"), _provider_entry("minio")]
+    fake_instance = MagicMock()
+    fake_instance.upload_backup.side_effect = ["b1/x.tgz", "b2/x.tgz"]
+    archiver_instance._s3_archiver_cls = MagicMock(return_value=fake_instance)
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    assert archiver_instance.archive_remote() == ["b1/x.tgz", "b2/x.tgz"]
+
+
+def test_archive_remote_raises_on_unknown_type(archiver_instance, mock_config):
+    """Entry with an unsupported type → ValueError."""
+    mock_config.object_storage_config = [_provider_entry("gcs")]
+    archiver_instance._s3_archiver_cls = MagicMock()
     with pytest.raises(ValueError, match="unsupported remote storage type"):
-        archiver.archive_remote()
+        archiver_instance.archive_remote()
 
 
-def test_archive_remote_s3_raises_not_implemented(mock_http_client):
-    """archive_remote routes 's3' to _archive_s3 which is intentionally not implemented"""
-    config = MagicMock()
-    config.object_storage_config = {"s3": MagicMock()}
-    config.base_dir_name = "bkps"
-    archiver = Archiver(config, mock_http_client, node_archiver=MagicMock())
-    with pytest.raises(NotImplementedError, match="S3 remote storage"):
-        archiver.archive_remote()
-
-
-def test_archive_remote_empty_config_no_calls(archiver_instance, mock_config):
-    """object_storage_config={} → no remote export methods called."""
-    mock_config.object_storage_config = {}
-    archiver_instance._archive_minio = MagicMock()
-    archiver_instance._archive_s3 = MagicMock()
-    archiver_instance.archive_remote()
-    archiver_instance._archive_minio.assert_not_called()
-    archiver_instance._archive_s3.assert_not_called()
+def test_archive_remote_returns_empty_list_when_no_config(archiver_instance, mock_config):
+    """No object storage config → returns []."""
+    mock_config.object_storage_config = []
+    assert archiver_instance.archive_remote() == []
 
 
 # ---------------------------------------------------------------------------
@@ -561,61 +569,6 @@ def test_clean_up_keep_last_positive_returns_only_old_archives(
 
 
 # ---------------------------------------------------------------------------
-# archive_remote — return value
-# ---------------------------------------------------------------------------
-
-def test_archive_remote_returns_empty_list_when_no_config(archiver_instance, mock_config):
-    """No object storage config → returns []."""
-    mock_config.object_storage_config = {}
-    result = archiver_instance.archive_remote()
-    assert result == []
-
-
-def test_archive_remote_returns_minio_dest_list(archiver_instance, mock_config):
-    """Minio handler called → returned dest string collected in list."""
-    obj_config = MagicMock()
-    obj_config.access_key = "k"
-    obj_config.secret_key = "s"
-    obj_config.config = MagicMock()
-    mock_config.object_storage_config = {"minio": obj_config}
-    expected_dest = "my-bucket/backups/export.tgz"
-
-    fake_minio_instance = MagicMock()
-    fake_minio_instance.upload_backup.return_value = expected_dest
-    fake_minio_cls = MagicMock(return_value=fake_minio_instance)
-
-    archiver_instance._minio_archiver_cls = fake_minio_cls
-    archiver_instance._archiver.archive_file = "/local/archive.tgz"
-    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
-
-    result = archiver_instance.archive_remote()
-    assert result == [expected_dest]
-
-
-def test_archive_minio_returns_dest_string(archiver_instance):
-    """_archive_minio returns the bucket/path dest from upload_backup."""
-    obj_config = MagicMock()
-    obj_config.access_key = "key"
-    obj_config.secret_key = "secret"
-    obj_config.config = MagicMock()
-
-    expected_dest = "test-bucket/backups/archive.tgz"
-    mock_minio = MagicMock()
-    mock_minio.upload_backup.return_value = expected_dest
-
-    fake_minio_cls = MagicMock(return_value=mock_minio)
-    archiver_instance._minio_archiver_cls = fake_minio_cls
-    archiver_instance._archiver.archive_file = "/local/archive.tgz"
-    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
-
-    dest = archiver_instance._archive_minio(obj_config)
-    assert dest == expected_dest
-    fake_minio_cls.assert_called_once_with(
-        obj_config.access_key, obj_config.secret_key, obj_config.config
-    )
-
-
-# ---------------------------------------------------------------------------
 # MinioArchiver._generate_path — trailing-slash normalisation
 # ---------------------------------------------------------------------------
 
@@ -629,7 +582,7 @@ def test_archive_minio_returns_dest_string(archiver_instance):
 ])
 def test_generate_path_strips_all_trailing_slashes(input_path, expected):
     """_generate_path must strip ALL trailing slashes, not just one."""
-    result = MinioArchiver._generate_path(None, input_path)
+    result = S3CompatibleArchiver._generate_path(None, input_path)
     assert result == expected
 
 
@@ -648,7 +601,7 @@ class TestBooksArchiverModifyLinksWiring:
         config.base_dir_name = "bkps"
         config.user_inputs.keep_last = 0
         config.user_inputs.output_path = ""
-        config.object_storage_config = {}
+        config.object_storage_config = []
         archiver = Archiver(config, mock_http_client)
         assert archiver._archiver.modify_links is True
 
@@ -662,6 +615,6 @@ class TestBooksArchiverModifyLinksWiring:
         config.base_dir_name = "bkps"
         config.user_inputs.keep_last = 0
         config.user_inputs.output_path = ""
-        config.object_storage_config = {}
+        config.object_storage_config = []
         archiver = Archiver(config, mock_http_client)
         assert archiver._archiver.modify_links is True

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -10,8 +10,9 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from bookstack_file_exporter.archiver.archiver import Archiver
+from bookstack_file_exporter.archiver.archiver import Archiver, AggregateUploadError
 from bookstack_file_exporter.archiver.s3_archiver import S3CompatibleArchiver
+from bookstack_file_exporter.notify.models import ExportStatus, UploadOutcome
 from bookstack_file_exporter.archiver.node_archiver import (
     BookArchiver,
     ChapterArchiver,
@@ -444,14 +445,18 @@ def test_create_export_dir_permission_error_logs_warning(
 # archive_remote
 # ---------------------------------------------------------------------------
 
-def _provider_entry(storage_type="minio"):
+# ---------------------------------------------------------------------------
+# archive_remote — attempt-all, returns list[UploadOutcome]
+# ---------------------------------------------------------------------------
+
+def _provider_entry(storage_type="minio", label="minio/b"):
     obj = MagicMock()
     obj.type = storage_type
+    obj.config.label = label
     return obj
 
 
-def test_archive_remote_empty_list_no_calls(archiver_instance, mock_config):
-    """object_storage_config=[] → returns [], no archiver constructed."""
+def test_archive_remote_empty_list_no_outcomes(archiver_instance, mock_config):
     mock_config.object_storage_config = []
     fake_cls = MagicMock()
     archiver_instance._s3_archiver_cls = fake_cls
@@ -459,40 +464,91 @@ def test_archive_remote_empty_list_no_calls(archiver_instance, mock_config):
     fake_cls.assert_not_called()
 
 
-def test_archive_remote_uploads_each_entry_via_shared_archiver(archiver_instance, mock_config):
-    """Both minio and s3 entries go through the same S3CompatibleArchiver; dests collected."""
-    mock_config.object_storage_config = [_provider_entry("minio"), _provider_entry("s3")]
+def test_archive_remote_all_success(archiver_instance, mock_config):
+    mock_config.object_storage_config = [
+        _provider_entry("minio", "minio/b"), _provider_entry("s3", "s3/aws")]
     fake_instance = MagicMock()
-    fake_instance.upload_backup.side_effect = ["bucket1/a.tgz", "bucket2/b.tgz"]
-    fake_cls = MagicMock(return_value=fake_instance)
-    archiver_instance._s3_archiver_cls = fake_cls
-    archiver_instance._archiver.archive_file = "/local/archive.tgz"
-    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
-
-    result = archiver_instance.archive_remote()
-
-    assert result == ["bucket1/a.tgz", "bucket2/b.tgz"]
-    assert fake_cls.call_count == 2
-    fake_instance.upload_backup.assert_called_with("/local/archive.tgz")
-    assert fake_instance.clean_up.call_count == 2
-
-
-def test_archive_remote_two_same_type_entries_no_collision(archiver_instance, mock_config):
-    """Two minio entries both upload (list permits same-type; a dict would drop one)."""
-    mock_config.object_storage_config = [_provider_entry("minio"), _provider_entry("minio")]
-    fake_instance = MagicMock()
-    fake_instance.upload_backup.side_effect = ["b1/x.tgz", "b2/x.tgz"]
+    fake_instance.upload_backup.side_effect = ["minio-b/a.tgz", "s3-aws/a.tgz"]
     archiver_instance._s3_archiver_cls = MagicMock(return_value=fake_instance)
     archiver_instance._archiver.archive_file = "/local/archive.tgz"
     archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
 
-    assert archiver_instance.archive_remote() == ["b1/x.tgz", "b2/x.tgz"]
+    outcomes = archiver_instance.archive_remote()
+
+    assert [(o.label, o.dest, o.error) for o in outcomes] == [
+        ("minio/b", "minio-b/a.tgz", None), ("s3/aws", "s3-aws/a.tgz", None)]
 
 
-def test_archive_remote_returns_empty_list_when_no_config(archiver_instance, mock_config):
-    """No object storage config → returns []."""
-    mock_config.object_storage_config = []
-    assert archiver_instance.archive_remote() == []
+def test_archive_remote_one_fails_others_still_attempted(archiver_instance, mock_config):
+    """A failing target does not abort the loop; its outcome records the error."""
+    mock_config.object_storage_config = [
+        _provider_entry("minio", "minio/b"), _provider_entry("s3", "s3/dr")]
+    good = MagicMock()
+    good.upload_backup.return_value = "minio-b/a.tgz"
+    bad = MagicMock()
+    bad.upload_backup.side_effect = RuntimeError("connection refused")
+    archiver_instance._s3_archiver_cls = MagicMock(side_effect=[good, bad])
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    outcomes = archiver_instance.archive_remote()
+
+    assert outcomes[0].dest == "minio-b/a.tgz" and outcomes[0].error is None
+    assert outcomes[1].dest is None
+    assert "connection refused" in outcomes[1].error
+
+
+def test_archive_remote_construction_failure_recorded(archiver_instance, mock_config):
+    """A failure constructing the archiver (e.g. bucket validation) is also caught."""
+    mock_config.object_storage_config = [_provider_entry("s3", "s3/dr")]
+    archiver_instance._s3_archiver_cls = MagicMock(side_effect=ValueError("no such bucket"))
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    outcomes = archiver_instance.archive_remote()
+
+    assert outcomes[0].label == "s3/dr"
+    assert outcomes[0].dest is None
+    assert "no such bucket" in outcomes[0].error
+
+
+# ---------------------------------------------------------------------------
+# resolve_remote_status
+# ---------------------------------------------------------------------------
+
+def _ok(label="a"):
+    return UploadOutcome(label=label, dest=f"{label}/x.tgz", error=None)
+
+
+def _fail(label="a"):
+    return UploadOutcome(label=label, dest=None, error="boom")
+
+
+def test_resolve_status_all_success(archiver_instance):
+    status = archiver_instance.resolve_remote_status([_ok("a"), _ok("b")])
+    assert status is ExportStatus.SUCCESS
+
+
+def test_resolve_status_some_fail_is_partial(archiver_instance, mock_config):
+    mock_config.user_inputs.keep_last = -1   # even with -1, a remote copy survived
+    status = archiver_instance.resolve_remote_status([_ok("a"), _fail("b")])
+    assert status is ExportStatus.PARTIAL
+
+
+def test_resolve_status_all_fail_local_kept_is_partial(archiver_instance, mock_config):
+    mock_config.user_inputs.keep_last = 0    # local copy retained -> degraded, not lost
+    status = archiver_instance.resolve_remote_status([_fail("a"), _fail("b")])
+    assert status is ExportStatus.PARTIAL
+
+
+def test_resolve_status_all_fail_no_local_raises(archiver_instance, mock_config):
+    mock_config.user_inputs.keep_last = -1   # local deleted + all uploads fail = total loss
+    with pytest.raises(AggregateUploadError, match="a, b"):
+        archiver_instance.resolve_remote_status([_fail("a"), _fail("b")])
+
+
+def test_resolve_status_empty_is_success(archiver_instance):
+    assert archiver_instance.resolve_remote_status([]) is ExportStatus.SUCCESS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_asset_archiver_config.py
+++ b/tests/unit/test_asset_archiver_config.py
@@ -4,11 +4,20 @@
 import argparse
 import logging
 
+import pytest
+from pydantic import ValidationError
+
 from bookstack_file_exporter.config_helper.models import Assets
 from bookstack_file_exporter.config_helper.config_helper import (
     ConfigNode,
-    check_legacy_keys,
+    build_user_input,
 )
+
+_VALID_RAW = {
+    "host": "https://wiki.example.com",
+    "credentials": {"token_id": "abc", "token_secret": "def"},
+    "formats": ["markdown"],
+}
 
 
 # ---------------------------------------------------------------------------
@@ -112,15 +121,11 @@ assets:
         # modify_links wins via alias; only one DEPRECATED warning emitted
         assert any("DEPRECATED" in m and "modify_markdown" in m for m in warning_msgs)
 
-    def test_check_legacy_keys_non_dict_assets_does_not_crash(self, caplog):
-        """assets: true (or other non-dict) must not crash before pydantic validates."""
-        logger_name = "bookstack_file_exporter.config_helper.config_helper"
-        with caplog.at_level(logging.WARNING, logger=logger_name):
-            check_legacy_keys({"assets": True})
-            check_legacy_keys({"assets": "bad_string"})
-            check_legacy_keys({"assets": 42})
-        our_records = [r for r in caplog.records if r.name == logger_name]
-        assert our_records == [], (
-            f"non-dict assets must produce zero warnings from this logger; "
-            f"got: {[r.message for r in our_records]}"
-        )
+    @pytest.mark.parametrize("bad_assets", [True, "bad_string", 42])
+    def test_non_dict_assets_raises_clean_validation_error(self, bad_assets):
+        """assets: true (or other non-dict) must surface as a pydantic ValidationError,
+        not an AttributeError from the deprecation-warn validator's dict access."""
+        raw = dict(_VALID_RAW)
+        raw["assets"] = bad_assets
+        with pytest.raises(ValidationError):
+            build_user_input(raw)

--- a/tests/unit/test_asset_archiver_config.py
+++ b/tests/unit/test_asset_archiver_config.py
@@ -7,7 +7,7 @@ import logging
 from bookstack_file_exporter.config_helper.models import Assets
 from bookstack_file_exporter.config_helper.config_helper import (
     ConfigNode,
-    check_legacy_modify_markdown,
+    check_legacy_keys,
 )
 
 
@@ -89,7 +89,7 @@ assets:
         ]
         assert len(deprecation_warnings) == 1
 
-    def test_second_warning_when_both_keys_present_different_values(self, tmp_path, caplog):
+    def test_deprecation_warning_when_both_keys_present(self, tmp_path, caplog):
         config_content = """
 host: https://wiki.example.com
 credentials:
@@ -109,17 +109,16 @@ assets:
             ConfigNode(args)
 
         warning_msgs = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-        # Should have the deprecation warning + ignored legacy warning
-        assert len(warning_msgs) >= 2
-        assert any("ignored" in m.lower() for m in warning_msgs)
+        # modify_links wins via alias; only one DEPRECATED warning emitted
+        assert any("DEPRECATED" in m and "modify_markdown" in m for m in warning_msgs)
 
-    def test_check_legacy_modify_markdown_non_dict_assets_does_not_crash(self, caplog):
+    def test_check_legacy_keys_non_dict_assets_does_not_crash(self, caplog):
         """assets: true (or other non-dict) must not crash before pydantic validates."""
         logger_name = "bookstack_file_exporter.config_helper.config_helper"
         with caplog.at_level(logging.WARNING, logger=logger_name):
-            check_legacy_modify_markdown({"assets": True})
-            check_legacy_modify_markdown({"assets": "bad_string"})
-            check_legacy_modify_markdown({"assets": 42})
+            check_legacy_keys({"assets": True})
+            check_legacy_keys({"assets": "bad_string"})
+            check_legacy_keys({"assets": 42})
         our_records = [r for r in caplog.records if r.name == logger_name]
         assert our_records == [], (
             f"non-dict assets must produce zero warnings from this logger; "

--- a/tests/unit/test_config_helper.py
+++ b/tests/unit/test_config_helper.py
@@ -121,11 +121,13 @@ def test_build_user_input_logs_error_on_schema_failure(caplog):
 
 
 def test_build_user_input_emits_deprecation_warning_for_legacy_key(caplog):
-    """build_user_input emits a DEPRECATED warning when modify_markdown is present."""
+    """build_user_input emits a DEPRECATED warning when modify_markdown is present.
+
+    The warning now originates from the Assets model validator, hence the models logger."""
     raw = dict(_VALID_RAW)
     raw["assets"] = {"modify_markdown": True}
 
-    logger_name = "bookstack_file_exporter.config_helper.config_helper"
+    logger_name = "bookstack_file_exporter.config_helper.models"
     with caplog.at_level(logging.WARNING, logger=logger_name):
         build_user_input(raw)
 
@@ -144,7 +146,7 @@ def test_build_user_input_no_warning_without_legacy_key(caplog):
     raw = dict(_VALID_RAW)
     raw["assets"] = {"modify_links": True}
 
-    logger_name = "bookstack_file_exporter.config_helper.config_helper"
+    logger_name = "bookstack_file_exporter.config_helper.models"
     with caplog.at_level(logging.WARNING, logger=logger_name):
         build_user_input(raw)
 

--- a/tests/unit/test_config_helper.py
+++ b/tests/unit/test_config_helper.py
@@ -186,3 +186,41 @@ def test_generate_urls_preserves_existing_scheme(host):
     """Hosts that already carry a scheme are left untouched (no prefix added)."""
     urls = _config_with_host(host)._generate_urls()
     assert urls["books"] == f"{host}/api/books"
+
+
+# ---------------------------------------------------------------------------
+# _generate_remote_config — orchestration loop (list build + per-entry validate)
+# ---------------------------------------------------------------------------
+def _config_with_object_storage(entries) -> ConfigNode:
+    """Build a bare ConfigNode exposing only what _generate_remote_config reads."""
+    node = ConfigNode.__new__(ConfigNode)
+    node.user_inputs = SimpleNamespace(object_storage=entries)
+    return node
+
+
+def test_generate_remote_config_empty_when_unset():
+    """No object_storage configured → empty list (not None, not a dict)."""
+    assert _config_with_object_storage(None)._generate_remote_config() == []
+
+
+def test_generate_remote_config_builds_resolved_list():
+    """Each entry becomes a StorageProviderConfig with resolved type + endpoint, in order.
+
+    Exercises the full orchestration seam: list iteration, _resolve_endpoint (minio host
+    vs s3 default-from-region), _resolve_credentials, and is_valid acceptance.
+    """
+    entries = [
+        models.BaseStorageConfig(type="minio", bucket="b1", host="minio.local:9000"),
+        models.BaseStorageConfig(type="s3", bucket="b2", region="eu-west-1"),
+    ]
+    result = _config_with_object_storage(entries)._generate_remote_config()
+    assert [c.type for c in result] == ["minio", "s3"]
+    assert result[0].endpoint == "minio.local:9000"           # explicit host
+    assert result[1].endpoint == "s3.eu-west-1.amazonaws.com"  # s3 default-from-region
+
+
+def test_generate_remote_config_raises_on_invalid_entry():
+    """An entry failing per-type validation (s3 without region) raises at config load."""
+    entries = [models.BaseStorageConfig(type="s3", bucket="b", region=None)]
+    with pytest.raises(ValueError, match="provided s3 configuration is invalid"):
+        _config_with_object_storage(entries)._generate_remote_config()

--- a/tests/unit/test_config_helper.py
+++ b/tests/unit/test_config_helper.py
@@ -202,7 +202,9 @@ def _config_with_object_storage(entries) -> ConfigNode:
 
 def test_generate_remote_config_empty_when_unset():
     """No object_storage configured → empty list (not None, not a dict)."""
-    assert _config_with_object_storage(None)._generate_remote_config() == []
+    result = _config_with_object_storage(None)._generate_remote_config()
+    assert isinstance(result, list)
+    assert result == []  # pylint: disable=use-implicit-booleaness-not-comparison
 
 
 def test_generate_remote_config_builds_resolved_list():

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 
 from bookstack_file_exporter.health.server import start_health_server
 from bookstack_file_exporter.health.status import RunStatus
-from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult
 
 
 # ---------------------------------------------------------------------------
@@ -109,6 +109,20 @@ class TestRunStatusSnapshot:
         status.mark_running()
         status.mark_success(NotifyResult(local="/a/b.tgz"))
         json.dumps(status.snapshot())  # must not raise
+
+    def test_mark_degraded_sets_status_and_counts(self):
+        status = RunStatus()
+        status.mark_degraded(NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz"))
+        snap = status.snapshot()
+        assert snap["last_run"]["status"] == "degraded"
+        assert snap["run_count"] == 1
+        assert snap["failure_count"] == 0          # degraded is NOT a hard failure
+        assert snap["last_run"]["archive_file"] == "b.tgz"
+
+    def test_mark_degraded_no_error_field(self):
+        status = RunStatus()
+        status.mark_degraded(NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz"))
+        assert status.snapshot()["last_run"]["error"] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_legacy_keys.py
+++ b/tests/unit/test_legacy_keys.py
@@ -23,6 +23,13 @@ def test_minio_with_object_storage_warns_not_raises(caplog):
                for r in caplog.records if r.name == _LOGGER)
 
 
+def test_minio_with_empty_object_storage_raises():
+    # empty list is not a real replacement -> would silently drop backups; must fail loud
+    raw = {"minio": {"host": "x"}, "object_storage": []}
+    with pytest.raises(ValueError, match="was removed in v3"):
+        check_legacy_keys(raw)
+
+
 def test_modify_markdown_warns(caplog):
     raw = {"assets": {"modify_markdown": True}}
     with caplog.at_level(logging.WARNING, logger=_LOGGER):

--- a/tests/unit/test_legacy_keys.py
+++ b/tests/unit/test_legacy_keys.py
@@ -3,9 +3,9 @@
 
 Deprecated/removed keys are now handled inside the pydantic models (Assets and
 UserInput before-validators), exercised here through build_user_input:
-  - removed 'minio:' with no usable 'object_storage:' -> hard error (ValidationError)
-  - removed 'minio:' alongside a real 'object_storage:' -> warn only (stale leftover)
-  - deprecated 'assets.modify_markdown' -> warn only (value still honored via alias)
+  - REMOVED 'minio:' -> hard error on ANY presence (deprecated != removed; it no
+    longer does anything, so warning would be misleading)
+  - DEPRECATED 'assets.modify_markdown' -> warn only (value still honored via alias)
 """
 import logging
 
@@ -33,18 +33,18 @@ def test_minio_without_object_storage_raises():
 
 
 def test_minio_with_empty_object_storage_raises():
-    # empty list is not a real replacement -> would silently drop backups; must fail loud
+    # any 'minio:' presence is a hard error regardless of object_storage
     raw = _raw(minio={"host": "x"}, object_storage=[])
     with pytest.raises(ValidationError, match="was removed in v3"):
         build_user_input(raw)
 
 
-def test_minio_with_object_storage_warns_not_raises(caplog):
+def test_minio_alongside_valid_object_storage_still_raises():
+    # removed key is an error even next to a working object_storage block: a removed
+    # key does nothing, so warn-and-continue would be misleading. Force a clean config.
     raw = _raw(minio={"host": "x"}, object_storage=[_VALID_OBJ])
-    with caplog.at_level(logging.WARNING, logger=_LOGGER):
-        build_user_input(raw)  # must NOT raise
-    assert any("minio" in r.message and "ignored" in r.message.lower()
-               for r in caplog.records if r.name == _LOGGER)
+    with pytest.raises(ValidationError, match="was removed in v3"):
+        build_user_input(raw)
 
 
 def test_modify_markdown_warns(caplog):

--- a/tests/unit/test_legacy_keys.py
+++ b/tests/unit/test_legacy_keys.py
@@ -1,0 +1,44 @@
+# pylint: disable=missing-function-docstring
+"""Tests for the legacy/removed config-key guard (check_legacy_keys)."""
+import logging
+
+import pytest
+
+from bookstack_file_exporter.config_helper.config_helper import check_legacy_keys
+
+_LOGGER = "bookstack_file_exporter.config_helper.config_helper"
+
+
+def test_minio_without_object_storage_raises():
+    raw = {"minio": {"host": "minio.local", "bucket": "b"}}
+    with pytest.raises(ValueError, match="was removed in v3"):
+        check_legacy_keys(raw)
+
+
+def test_minio_with_object_storage_warns_not_raises(caplog):
+    raw = {"minio": {"host": "x"}, "object_storage": [{"type": "minio", "bucket": "b"}]}
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        check_legacy_keys(raw)  # must NOT raise
+    assert any("minio" in r.message and "ignored" in r.message.lower()
+               for r in caplog.records if r.name == _LOGGER)
+
+
+def test_modify_markdown_warns(caplog):
+    raw = {"assets": {"modify_markdown": True}}
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        check_legacy_keys(raw)  # must NOT raise (alias still honored)
+    assert any("DEPRECATED" in r.message and "modify_markdown" in r.message
+               for r in caplog.records if r.name == _LOGGER)
+
+
+def test_clean_config_no_warning_no_error(caplog):
+    raw = {"host": "https://x", "formats": ["markdown"],
+           "object_storage": [{"type": "s3", "bucket": "b", "region": "us-east-1"}]}
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        check_legacy_keys(raw)
+    assert not [r for r in caplog.records if r.name == _LOGGER]
+
+
+def test_non_dict_assets_does_not_crash():
+    # e.g. `assets: true` — let pydantic produce the real error later, don't blow up here
+    check_legacy_keys({"assets": True})

--- a/tests/unit/test_legacy_keys.py
+++ b/tests/unit/test_legacy_keys.py
@@ -32,13 +32,6 @@ def test_minio_without_object_storage_raises():
         build_user_input(raw)
 
 
-def test_minio_with_empty_object_storage_raises():
-    # any 'minio:' presence is a hard error regardless of object_storage
-    raw = _raw(minio={"host": "x"}, object_storage=[])
-    with pytest.raises(ValidationError, match="was removed in v3"):
-        build_user_input(raw)
-
-
 def test_minio_alongside_valid_object_storage_still_raises():
     # removed key is an error even next to a working object_storage block: a removed
     # key does nothing, so warn-and-continue would be misleading. Force a clean config.

--- a/tests/unit/test_legacy_keys.py
+++ b/tests/unit/test_legacy_keys.py
@@ -1,51 +1,62 @@
 # pylint: disable=missing-function-docstring
-"""Tests for the legacy/removed config-key guard (check_legacy_keys)."""
+"""Tests for legacy/removed config-key handling.
+
+Deprecated/removed keys are now handled inside the pydantic models (Assets and
+UserInput before-validators), exercised here through build_user_input:
+  - removed 'minio:' with no usable 'object_storage:' -> hard error (ValidationError)
+  - removed 'minio:' alongside a real 'object_storage:' -> warn only (stale leftover)
+  - deprecated 'assets.modify_markdown' -> warn only (value still honored via alias)
+"""
 import logging
 
 import pytest
+from pydantic import ValidationError
 
-from bookstack_file_exporter.config_helper.config_helper import check_legacy_keys
+from bookstack_file_exporter.config_helper.config_helper import build_user_input
 
-_LOGGER = "bookstack_file_exporter.config_helper.config_helper"
+# warnings now originate from the models module, not config_helper
+_LOGGER = "bookstack_file_exporter.config_helper.models"
+
+_VALID_OBJ = {"type": "minio", "bucket": "b", "host": "minio.local"}
+
+
+def _raw(**overrides):
+    base = {"host": "https://wiki.example.com", "formats": ["markdown"]}
+    base.update(overrides)
+    return base
 
 
 def test_minio_without_object_storage_raises():
-    raw = {"minio": {"host": "minio.local", "bucket": "b"}}
-    with pytest.raises(ValueError, match="was removed in v3"):
-        check_legacy_keys(raw)
-
-
-def test_minio_with_object_storage_warns_not_raises(caplog):
-    raw = {"minio": {"host": "x"}, "object_storage": [{"type": "minio", "bucket": "b"}]}
-    with caplog.at_level(logging.WARNING, logger=_LOGGER):
-        check_legacy_keys(raw)  # must NOT raise
-    assert any("minio" in r.message and "ignored" in r.message.lower()
-               for r in caplog.records if r.name == _LOGGER)
+    raw = _raw(minio={"host": "minio.local", "bucket": "b"})
+    with pytest.raises(ValidationError, match="was removed in v3"):
+        build_user_input(raw)
 
 
 def test_minio_with_empty_object_storage_raises():
     # empty list is not a real replacement -> would silently drop backups; must fail loud
-    raw = {"minio": {"host": "x"}, "object_storage": []}
-    with pytest.raises(ValueError, match="was removed in v3"):
-        check_legacy_keys(raw)
+    raw = _raw(minio={"host": "x"}, object_storage=[])
+    with pytest.raises(ValidationError, match="was removed in v3"):
+        build_user_input(raw)
+
+
+def test_minio_with_object_storage_warns_not_raises(caplog):
+    raw = _raw(minio={"host": "x"}, object_storage=[_VALID_OBJ])
+    with caplog.at_level(logging.WARNING, logger=_LOGGER):
+        build_user_input(raw)  # must NOT raise
+    assert any("minio" in r.message and "ignored" in r.message.lower()
+               for r in caplog.records if r.name == _LOGGER)
 
 
 def test_modify_markdown_warns(caplog):
-    raw = {"assets": {"modify_markdown": True}}
+    raw = _raw(assets={"modify_markdown": True})
     with caplog.at_level(logging.WARNING, logger=_LOGGER):
-        check_legacy_keys(raw)  # must NOT raise (alias still honored)
+        build_user_input(raw)  # must NOT raise (alias still honors the value)
     assert any("DEPRECATED" in r.message and "modify_markdown" in r.message
                for r in caplog.records if r.name == _LOGGER)
 
 
 def test_clean_config_no_warning_no_error(caplog):
-    raw = {"host": "https://x", "formats": ["markdown"],
-           "object_storage": [{"type": "s3", "bucket": "b", "region": "us-east-1"}]}
+    raw = _raw(object_storage=[{"type": "s3", "bucket": "b", "region": "us-east-1"}])
     with caplog.at_level(logging.WARNING, logger=_LOGGER):
-        check_legacy_keys(raw)
+        build_user_input(raw)
     assert not [r for r in caplog.records if r.name == _LOGGER]
-
-
-def test_non_dict_assets_does_not_crash():
-    # e.g. `assets: true` — let pydantic produce the real error later, don't blow up here
-    check_legacy_keys({"assets": True})

--- a/tests/unit/test_minio_archiver.py
+++ b/tests/unit/test_minio_archiver.py
@@ -1,53 +1,63 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name
 # pylint: disable=protected-access
-"""Unit tests for MinioArchiver.upload_backup return value."""
-from unittest.mock import MagicMock
+"""Unit tests for S3CompatibleArchiver: upload return value + client construction."""
+from unittest.mock import MagicMock, patch
 
-from bookstack_file_exporter.archiver.minio_archiver import MinioArchiver
+from bookstack_file_exporter.archiver.minio_archiver import S3CompatibleArchiver
 
 
-def _make_minio_archiver(bucket: str, path: str | None = None):
-    """Build a MinioArchiver bypassing real Minio init."""
-    instance = MinioArchiver.__new__(MinioArchiver)
+def _make_archiver(bucket: str, path: str | None = None):
+    """Build an S3CompatibleArchiver bypassing real Minio init."""
+    instance = S3CompatibleArchiver.__new__(S3CompatibleArchiver)
     instance._client = MagicMock()
     instance.bucket = bucket
-    instance.path = MinioArchiver._generate_path(instance, path)
+    instance.path = S3CompatibleArchiver._generate_path(instance, path)
     instance.keep_last = 0
     return instance
 
 
 class TestUploadBackupReturnValue:
     def test_returns_bucket_slash_object_path_with_prefix(self):
-        archiver = _make_minio_archiver("my-bucket", "backups/2024")
-        mock_result = MagicMock()
-        mock_result.object_name = "backups/2024/export.tgz"
-        mock_result.etag = "abc123"
-        mock_result.version_id = None
-        archiver._client.fput_object.return_value = mock_result
-
-        dest = archiver.upload_backup("/local/path/export.tgz")
-
-        assert dest == "my-bucket/backups/2024/export.tgz"
+        archiver = _make_archiver("my-bucket", "backups/2024")
+        result = MagicMock(object_name="backups/2024/export.tgz", etag="abc", version_id=None)
+        archiver._client.fput_object.return_value = result
+        assert archiver.upload_backup("/local/export.tgz") == "my-bucket/backups/2024/export.tgz"
 
     def test_returns_bucket_slash_filename_without_prefix(self):
-        archiver = _make_minio_archiver("my-bucket", None)
-        mock_result = MagicMock()
-        mock_result.object_name = "export.tgz"
-        mock_result.etag = "def456"
-        mock_result.version_id = "v1"
-        archiver._client.fput_object.return_value = mock_result
-
-        dest = archiver.upload_backup("/some/path/export.tgz")
-
-        assert dest == "my-bucket/export.tgz"
+        archiver = _make_archiver("my-bucket", None)
+        result = MagicMock(object_name="export.tgz", etag="def", version_id="v1")
+        archiver._client.fput_object.return_value = result
+        assert archiver.upload_backup("/some/export.tgz") == "my-bucket/export.tgz"
 
     def test_fput_object_called_with_correct_args(self):
-        archiver = _make_minio_archiver("bucket-x", "uploads")
-        mock_result = MagicMock()
-        archiver._client.fput_object.return_value = mock_result
-
+        archiver = _make_archiver("bucket-x", "uploads")
+        archiver._client.fput_object.return_value = MagicMock()
         archiver.upload_backup("/data/archive.tgz")
-
         archiver._client.fput_object.assert_called_once_with(
             "bucket-x", "uploads/archive.tgz", "/data/archive.tgz"
         )
+
+
+class TestClientConstruction:
+    def test_minio_client_built_with_endpoint_secure_region_credentials(self):
+        creds = MagicMock()
+        provider_config = MagicMock()
+        provider_config.endpoint = "minio.local:9000"
+        provider_config.secure = False
+        provider_config.credentials = creds
+        provider_config.config = MagicMock(bucket="b", path="p", keep_last=0, region="us-east-1")
+
+        with patch("bookstack_file_exporter.archiver.minio_archiver.Minio") as mock_minio:
+            instance = S3CompatibleArchiver.__new__(S3CompatibleArchiver)
+            # call the real __init__ but stub bucket validation
+            with patch.object(S3CompatibleArchiver, "_validate_bucket", lambda self: None):
+                S3CompatibleArchiver.__init__(instance, provider_config)
+
+        mock_minio.assert_called_once_with(
+            "minio.local:9000",
+            credentials=creds,
+            secure=False,
+            region="us-east-1",
+        )
+        assert instance.bucket == "b"
+        assert instance.keep_last == 0

--- a/tests/unit/test_minio_archiver.py
+++ b/tests/unit/test_minio_archiver.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,redefined-outer-name
-# pylint: disable=protected-access
+# pylint: disable=protected-access,too-few-public-methods
 """Unit tests for S3CompatibleArchiver: upload return value + client construction."""
 from unittest.mock import MagicMock, patch
 

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -66,3 +66,68 @@ def test_userinput_parses_object_storage_list():
 def test_userinput_object_storage_defaults_none():
     ui = models.UserInput(host="https://x", formats=["markdown"])
     assert ui.object_storage is None
+
+
+# --- name field and label property ---
+
+def test_name_defaults_none():
+    cfg = models.BaseStorageConfig(**_entry())
+    assert cfg.name is None
+
+
+def test_name_parses_when_given():
+    cfg = models.BaseStorageConfig(**_entry(name="primary"))
+    assert cfg.name == "primary"
+
+
+def test_label_falls_back_to_type_bucket():
+    cfg = models.BaseStorageConfig(**_entry(type="minio", bucket="b"))
+    assert cfg.label == "minio/b"
+
+
+def test_label_uses_name_when_set():
+    cfg = models.BaseStorageConfig(**_entry(name="primary"))
+    assert cfg.label == "primary"
+
+
+# --- UserInput label-uniqueness validator ---
+
+def _user_input(*entries):
+    return {
+        "host": "https://wiki.example.com",
+        "formats": ["markdown"],
+        "object_storage": list(entries),
+    }
+
+
+def test_duplicate_derived_label_raises():
+    # Two entries with same type/bucket produce the same derived label → must fail
+    e1 = _entry(type="minio", bucket="b")
+    e2 = _entry(type="minio", bucket="b")
+    with pytest.raises(ValidationError, match="name"):
+        models.UserInput(**_user_input(e1, e2))
+
+
+def test_duplicate_derived_label_with_distinct_names_ok():
+    e1 = _entry(type="minio", bucket="b", name="primary")
+    e2 = _entry(type="minio", bucket="b", name="secondary")
+    ui = models.UserInput(**_user_input(e1, e2))
+    assert ui.object_storage is not None
+    # pylint: disable-next=not-an-iterable
+    assert [e.name for e in ui.object_storage] == ["primary", "secondary"]
+
+
+def test_duplicate_explicit_name_raises():
+    e1 = _entry(name="same")
+    e2 = _entry(bucket="other", name="same")
+    with pytest.raises(ValidationError, match="name"):
+        models.UserInput(**_user_input(e1, e2))
+
+
+def test_distinct_buckets_no_name_ok():
+    e1 = _entry(type="minio", bucket="b1")
+    e2 = _entry(type="minio", bucket="b2")
+    ui = models.UserInput(**_user_input(e1, e2))
+    assert ui.object_storage is not None
+    # pylint: disable-next=not-an-iterable
+    assert len(ui.object_storage) == 2

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -58,6 +58,8 @@ def test_userinput_parses_object_storage_list():
         ],
     }
     ui = models.UserInput(**raw)
+    assert ui.object_storage is not None
+    # pylint: disable-next=not-an-iterable
     assert [e.type for e in ui.object_storage] == ["minio", "s3"]
 
 

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -1,0 +1,66 @@
+# pylint: disable=missing-function-docstring
+"""Unit tests for BaseStorageConfig and UserInput.object_storage parsing."""
+import pytest
+from pydantic import ValidationError
+
+from bookstack_file_exporter.config_helper import models
+
+
+def _entry(**overrides):
+    base = {"type": "minio", "bucket": "b", "host": "minio.local"}
+    base.update(overrides)
+    return base
+
+
+def test_minio_entry_defaults():
+    cfg = models.BaseStorageConfig(**_entry())
+    assert cfg.type == "minio"
+    assert cfg.bucket == "b"
+    assert cfg.secure is True          # TLS default preserves today's behavior
+    assert cfg.region is None          # region optional for minio
+    assert cfg.keep_last == 0
+
+
+def test_s3_entry_minimal():
+    cfg = models.BaseStorageConfig(type="s3", bucket="aws-b", region="us-east-1")
+    assert cfg.type == "s3"
+    assert cfg.host == ""              # host optional for s3 (defaulted later from region)
+
+
+def test_invalid_type_rejected():
+    with pytest.raises(ValidationError):
+        models.BaseStorageConfig(type="gcs", bucket="b")
+
+
+def test_inline_cred_half_pair_rejected():
+    with pytest.raises(ValidationError, match="access_key and secret_key"):
+        models.BaseStorageConfig(**_entry(access_key="AKIA"))  # secret missing
+
+
+def test_env_name_half_pair_rejected():
+    with pytest.raises(ValidationError, match="access_key_env and secret_key_env"):
+        models.BaseStorageConfig(**_entry(access_key_env="A_ENV"))  # secret env missing
+
+
+def test_full_inline_pair_ok():
+    cfg = models.BaseStorageConfig(**_entry(access_key="AKIA", secret_key="wJal"))
+    assert cfg.access_key == "AKIA"
+    assert cfg.secret_key == "wJal"
+
+
+def test_userinput_parses_object_storage_list():
+    raw = {
+        "host": "https://wiki.example.com",
+        "formats": ["markdown"],
+        "object_storage": [
+            {"type": "minio", "bucket": "b1", "host": "minio.local"},
+            {"type": "s3", "bucket": "b2", "region": "us-east-1"},
+        ],
+    }
+    ui = models.UserInput(**raw)
+    assert [e.type for e in ui.object_storage] == ["minio", "s3"]
+
+
+def test_userinput_object_storage_defaults_none():
+    ui = models.UserInput(host="https://x", formats=["markdown"])
+    assert ui.object_storage is None

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -4,7 +4,8 @@
 import os
 from unittest.mock import MagicMock
 
-from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify import notifiers
+from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult, UploadOutcome
 from bookstack_file_exporter.notify.notifiers import AppRiseNotify
 
 
@@ -34,14 +35,14 @@ class TestGetMessageTextSuccessBranch:
 
     def test_result_local_none_produces_generic_success_body(self):
         notifier = _make_notifier()
-        result = NotifyResult(local=None, remote=[], removed=[])
+        result = NotifyResult(local=None, uploads=[], removed=[])
         body = notifier._get_message_text(None, result=result)
         assert "completed successfully" in body
         assert "Archive:" not in body
 
     def test_local_only_shows_archive_line_no_suffix_no_remote_no_pruned(self):
         notifier = _make_notifier()
-        result = NotifyResult(local="/data/export.tgz", remote=[], removed=[])
+        result = NotifyResult(local="/data/export.tgz", uploads=[], removed=[])
         body = notifier._get_message_text(None, result=result)
         assert "Archive: /data/export.tgz" in body
         assert "(removed locally after upload)" not in body
@@ -51,7 +52,7 @@ class TestGetMessageTextSuccessBranch:
     def test_local_in_removed_shows_suffix(self):
         notifier = _make_notifier()
         local = "/data/export.tgz"
-        result = NotifyResult(local=local, remote=[], removed=[local])
+        result = NotifyResult(local=local, uploads=[], removed=[local])
         body = notifier._get_message_text(None, result=result)
         assert "Archive: /data/export.tgz (removed locally after upload)" in body
 
@@ -59,7 +60,8 @@ class TestGetMessageTextSuccessBranch:
         notifier = _make_notifier()
         result = NotifyResult(
             local="/data/export.tgz",
-            remote=["bucket1/backups/export.tgz", "bucket2/export.tgz"],
+            uploads=[UploadOutcome("t1", "bucket1/backups/export.tgz"),
+                     UploadOutcome("t2", "bucket2/export.tgz")],
             removed=[],
         )
         body = notifier._get_message_text(None, result=result)
@@ -69,7 +71,7 @@ class TestGetMessageTextSuccessBranch:
         notifier = _make_notifier()
         local = "/data/new.tgz"
         removed = ["/data/old1.tgz", "/data/old2.tgz", local]
-        result = NotifyResult(local=local, remote=[], removed=removed)
+        result = NotifyResult(local=local, uploads=[], removed=removed)
         body = notifier._get_message_text(None, result=result)
         # local is in removed (suffix present) + 2 old archives pruned
         assert "(removed locally after upload)" in body
@@ -79,7 +81,7 @@ class TestGetMessageTextSuccessBranch:
         notifier = _make_notifier()
         local = "/data/new.tgz"
         removed = ["/data/old1.tgz", "/data/old2.tgz"]
-        result = NotifyResult(local=local, remote=[], removed=removed)
+        result = NotifyResult(local=local, uploads=[], removed=removed)
         body = notifier._get_message_text(None, result=result)
         assert "(removed locally after upload)" not in body
         assert "Pruned 2 old local archive(s)" in body
@@ -92,7 +94,7 @@ class TestGetMessageTextSuccessBranch:
         local_abs = os.path.join(cwd, "export.tgz")
         local_rel = "export.tgz"
         # Pass abs as local, relative form in removed — should still match
-        result = NotifyResult(local=local_abs, remote=[], removed=[local_rel])
+        result = NotifyResult(local=local_abs, uploads=[], removed=[local_rel])
         body = notifier._get_message_text(None, result=result)
         assert "(removed locally after upload)" in body
 
@@ -101,7 +103,7 @@ class TestGetMessageTextSuccessBranch:
         notifier = _make_notifier()
         local_rel = "export.tgz"
         removed_abs = os.path.join(os.getcwd(), "export.tgz")
-        result = NotifyResult(local=local_rel, remote=[], removed=[removed_abs])
+        result = NotifyResult(local=local_rel, uploads=[], removed=[removed_abs])
         body = notifier._get_message_text(None, result=result)
         assert "(removed locally after upload)" in body
 
@@ -111,7 +113,7 @@ class TestGetMessageTextSuccessBranch:
         notifier = _make_notifier()
         local_rel = "new.tgz"
         removed = [os.path.join(os.getcwd(), "new.tgz"), "/data/old1.tgz", "/data/old2.tgz"]
-        result = NotifyResult(local=local_rel, remote=[], removed=removed)
+        result = NotifyResult(local=local_rel, uploads=[], removed=removed)
         body = notifier._get_message_text(None, result=result)
         # current archive (mixed form) → suffix, NOT counted among pruned old archives
         assert "(removed locally after upload)" in body
@@ -120,10 +122,49 @@ class TestGetMessageTextSuccessBranch:
     def test_failure_branch_unchanged_no_archive_lines(self):
         notifier = _make_notifier()
         err = ValueError("something broke")
-        result = NotifyResult(local="/data/export.tgz", remote=["bucket/x"], removed=[])
+        result = NotifyResult(
+            local="/data/export.tgz", uploads=[UploadOutcome("t", "bucket/x")], removed=[]
+        )
         body = notifier._get_message_text(err, result=result)
         assert "unrecoverable error" in body
         assert "something broke" in body
         assert "Archive:" not in body
         assert "Uploaded to:" not in body
         assert "Pruned" not in body
+
+
+# ---------------------------------------------------------------------------
+# New tests for 3-state title and partial body rendering (Task 3)
+# ---------------------------------------------------------------------------
+
+def _notifier():
+    inst = notifiers.AppRiseNotify.__new__(notifiers.AppRiseNotify)
+    inst.config = MagicMock(custom_title=None)
+    return inst
+
+
+def test_title_partial():
+    inst = _notifier()
+    result = NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz")
+    assert inst._get_title(None, result).endswith("Partial")
+
+
+def test_title_success():
+    inst = _notifier()
+    result = NotifyResult(status=ExportStatus.SUCCESS, local="/a/b.tgz")
+    assert inst._get_title(None, result).endswith("Success")
+
+
+def test_title_failed_on_exception():
+    assert _notifier()._get_title(ValueError("x"), None).endswith("Failed")
+
+
+def test_body_lists_ok_and_failed_targets():
+    inst = _notifier()
+    result = NotifyResult(
+        status=ExportStatus.PARTIAL, local="/a/b.tgz",
+        uploads=[UploadOutcome("minio/b", "minio-b/a.tgz", None),
+                 UploadOutcome("s3/dr", None, "connection refused")])
+    body = inst._get_message_text(None, result)
+    assert "Uploaded to: minio-b/a.tgz" in body      # ok target -> dest
+    assert "Failed: s3/dr - connection refused" in body  # failed target -> label + error

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -168,3 +168,13 @@ def test_body_lists_ok_and_failed_targets():
     body = inst._get_message_text(None, result)
     assert "Uploaded to: minio-b/a.tgz" in body      # ok target -> dest
     assert "Failed: s3/dr - connection refused" in body  # failed target -> label + error
+
+
+def test_body_lists_retention_warning():
+    inst = _notifier()
+    result = NotifyResult(
+        status=ExportStatus.PARTIAL, local="/a/b.tgz",
+        uploads=[UploadOutcome("s3/aws", "s3-aws/a.tgz", None, "delete denied")])
+    body = inst._get_message_text(None, result)
+    assert "Uploaded to: s3-aws/a.tgz" in body
+    assert "Warning: s3/aws - delete denied" in body

--- a/tests/unit/test_notify_handler.py
+++ b/tests/unit/test_notify_handler.py
@@ -1,0 +1,37 @@
+# pylint: disable=missing-function-docstring,protected-access
+from unittest.mock import MagicMock, patch
+
+from bookstack_file_exporter.notify.handler import NotifyHandler
+from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult
+
+
+def _handler():
+    return NotifyHandler.__new__(NotifyHandler)
+
+
+def _run_gate(excep, result, on_success, on_failure):
+    """Drive _handle_apprise and report whether a notification was sent."""
+    h = _handler()
+    a_config = MagicMock(on_success=on_success, on_failure=on_failure)
+    with patch("bookstack_file_exporter.notify.handler.notifications") as notif_mod, \
+         patch("bookstack_file_exporter.notify.handler.notifiers") as notif_pkg:
+        notif_mod.AppRiseNotifyConfig.return_value = a_config
+        sender = MagicMock()
+        notif_pkg.AppRiseNotify.return_value = sender
+        h._handle_apprise(MagicMock(), excep, result)
+        return sender.notify.called
+
+
+def test_partial_fires_on_failure():
+    result = NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz")
+    assert _run_gate(None, result, on_success=False, on_failure=True) is True
+
+
+def test_partial_suppressed_when_on_failure_false():
+    result = NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz")
+    assert _run_gate(None, result, on_success=True, on_failure=False) is False
+
+
+def test_success_fires_on_success():
+    result = NotifyResult(status=ExportStatus.SUCCESS, local="/a/b.tgz")
+    assert _run_gate(None, result, on_success=True, on_failure=False) is True

--- a/tests/unit/test_notify_models.py
+++ b/tests/unit/test_notify_models.py
@@ -1,0 +1,30 @@
+# pylint: disable=missing-function-docstring,use-implicit-booleaness-not-comparison
+"""Unit tests for ExportStatus / UploadOutcome / NotifyResult."""
+from bookstack_file_exporter.notify.models import (
+    ExportStatus, UploadOutcome, NotifyResult,
+)
+
+
+def test_export_status_members():
+    assert ExportStatus.SUCCESS != ExportStatus.PARTIAL
+
+
+def test_upload_outcome_success_and_failure():
+    ok = UploadOutcome(label="minio/b", dest="b/x.tgz", error=None)
+    bad = UploadOutcome(label="s3/dr", dest=None, error="boom")
+    assert ok.dest == "b/x.tgz" and ok.error is None
+    assert bad.dest is None and bad.error == "boom"
+
+
+def test_notify_result_defaults():
+    r = NotifyResult(status=ExportStatus.SUCCESS, local="/a/b.tgz")
+    assert r.status is ExportStatus.SUCCESS
+    assert r.local == "/a/b.tgz"
+    assert r.uploads == []
+    assert r.removed == []
+
+
+def test_notify_result_carries_uploads():
+    out = [UploadOutcome("minio/b", "b/x.tgz", None)]
+    r = NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz", uploads=out)
+    assert r.uploads[0].label == "minio/b"

--- a/tests/unit/test_notify_models.py
+++ b/tests/unit/test_notify_models.py
@@ -28,3 +28,8 @@ def test_notify_result_carries_uploads():
     out = [UploadOutcome("minio/b", "b/x.tgz", None)]
     r = NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz", uploads=out)
     assert r.uploads[0].label == "minio/b"
+
+
+def test_upload_outcome_warning_defaults_none_and_settable():
+    assert UploadOutcome(label="x").warning is None
+    assert UploadOutcome(label="x", dest="d", warning="w").warning == "w"

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -1,21 +1,45 @@
-"""Tests for StorageProviderConfig validation dispatch."""
-from bookstack_file_exporter.config_helper.models import ObjectStorageConfig
-from bookstack_file_exporter.config_helper.remote import StorageProviderConfig
+# pylint: disable=missing-function-docstring
+"""Tests for StorageProviderConfig validation dispatch and AWS endpoint helper."""
+from unittest.mock import MagicMock
+
+from bookstack_file_exporter.config_helper.models import BaseStorageConfig
+from bookstack_file_exporter.config_helper.remote import (
+    StorageProviderConfig,
+    aws_endpoint_from_region,
+)
 
 
-def _config(**overrides):
-    base = {"bucket": "b", "region": "us-east-1", "host": "minio.local"}
-    base.update(overrides)
-    return ObjectStorageConfig(**base)
+def _provider(entry: BaseStorageConfig) -> StorageProviderConfig:
+    # credentials Provider is opaque here; a MagicMock stands in.
+    return StorageProviderConfig(
+        storage_type=entry.type,
+        endpoint=entry.host or "",
+        secure=entry.secure,
+        credentials=MagicMock(),
+        config=entry,
+    )
 
 
-def test_is_valid_true_when_host_present():
-    """is_valid returns True when the minio host is set."""
-    cfg = StorageProviderConfig("ak", "sk", _config(host="minio.local"))
-    assert cfg.is_valid("minio") is True
+def test_minio_valid_when_host_present():
+    entry = BaseStorageConfig(type="minio", bucket="b", host="minio.local")
+    assert _provider(entry).is_valid("minio") is True
 
 
-def test_is_valid_false_when_host_missing():
-    """is_valid returns False when the minio host is empty."""
-    cfg = StorageProviderConfig("ak", "sk", _config(host=""))
-    assert cfg.is_valid("minio") is False
+def test_minio_invalid_when_host_missing():
+    entry = BaseStorageConfig(type="minio", bucket="b", host="")
+    assert _provider(entry).is_valid("minio") is False
+
+
+def test_s3_valid_when_region_present():
+    entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1")
+    assert _provider(entry).is_valid("s3") is True
+
+
+def test_s3_invalid_when_region_missing():
+    entry = BaseStorageConfig(type="s3", bucket="b", region=None)
+    assert _provider(entry).is_valid("s3") is False
+
+
+def test_aws_endpoint_from_region():
+    assert aws_endpoint_from_region("us-east-1") == "s3.us-east-1.amazonaws.com"
+    assert aws_endpoint_from_region("eu-west-2") == "s3.eu-west-2.amazonaws.com"

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -22,22 +22,22 @@ def _provider(entry: BaseStorageConfig) -> StorageProviderConfig:
 
 def test_minio_valid_when_host_present():
     entry = BaseStorageConfig(type="minio", bucket="b", host="minio.local")
-    assert _provider(entry).is_valid("minio") is True
+    assert _provider(entry).is_valid() is True
 
 
 def test_minio_invalid_when_host_missing():
     entry = BaseStorageConfig(type="minio", bucket="b", host="")
-    assert _provider(entry).is_valid("minio") is False
+    assert _provider(entry).is_valid() is False
 
 
 def test_s3_valid_when_region_present():
     entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1")
-    assert _provider(entry).is_valid("s3") is True
+    assert _provider(entry).is_valid() is True
 
 
 def test_s3_invalid_when_region_missing():
     entry = BaseStorageConfig(type="s3", bucket="b", region=None)
-    assert _provider(entry).is_valid("s3") is False
+    assert _provider(entry).is_valid() is False
 
 
 def test_aws_endpoint_from_region():

--- a/tests/unit/test_remote_credentials.py
+++ b/tests/unit/test_remote_credentials.py
@@ -2,6 +2,7 @@
 """Tests for credential resolution precedence and endpoint defaulting."""
 from minio.credentials import (
     StaticProvider, ChainedProvider, EnvMinioProvider,
+    EnvAWSProvider, IamAwsProvider,
 )
 
 from bookstack_file_exporter.config_helper.models import BaseStorageConfig
@@ -62,7 +63,9 @@ def test_s3_ambient_env_beats_inline(monkeypatch):
     assert _resolve_credentials(entry).retrieve().access_key == "env-ak"
 
 
-def test_s3_inline_beats_aws_files_when_env_unset(monkeypatch):
+def test_s3_inline_beats_imds_when_env_unset(monkeypatch):
+    # With AWS_* env unset, inline StaticProvider precedes IamAwsProvider in the chain
+    # and short-circuits — retrieve() returns the inline key without any network/IMDS call.
     monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
     monkeypatch.delenv("AWS_ACCESS_KEY", raising=False)
     monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
@@ -72,8 +75,12 @@ def test_s3_inline_beats_aws_files_when_env_unset(monkeypatch):
 
 
 def test_s3_bare_uses_aws_chain():
+    # Chain must be [EnvAWSProvider, IamAwsProvider] — no ~/.aws file tier.
     entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1")
-    assert isinstance(_resolve_credentials(entry), ChainedProvider)
+    provider = _resolve_credentials(entry)
+    assert isinstance(provider, ChainedProvider)
+    types = [type(p) for p in provider._providers]
+    assert types == [EnvAWSProvider, IamAwsProvider]
 
 
 def test_minio_bare_uses_env_minio_provider():

--- a/tests/unit/test_remote_credentials.py
+++ b/tests/unit/test_remote_credentials.py
@@ -48,14 +48,14 @@ def test_inline_used_when_no_env_names(monkeypatch):
     assert _resolve_credentials(entry).retrieve().access_key == "inline-ak"
 
 
-def test_minio_ambient_env_beats_inline(monkeypatch):
+def test_minio_standard_env_beats_inline(monkeypatch):
     monkeypatch.setenv("MINIO_ACCESS_KEY", "env-ak")
     monkeypatch.setenv("MINIO_SECRET_KEY", "env-sk")
     entry = _entry(access_key="inline-ak", secret_key="inline-sk")
     assert _resolve_credentials(entry).retrieve().access_key == "env-ak"
 
 
-def test_s3_ambient_env_beats_inline(monkeypatch):
+def test_s3_standard_env_beats_inline(monkeypatch):
     monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-ak")
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-sk")
     entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1",

--- a/tests/unit/test_remote_credentials.py
+++ b/tests/unit/test_remote_credentials.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-function-docstring,protected-access
 """Tests for credential resolution precedence and endpoint defaulting."""
 from minio.credentials import (
-    StaticProvider, ChainedProvider, EnvMinioProvider,
+    StaticProvider, EnvMinioProvider,
     EnvAWSProvider, IamAwsProvider,
 )
 
@@ -9,6 +9,7 @@ from bookstack_file_exporter.config_helper.models import BaseStorageConfig
 from bookstack_file_exporter.config_helper.config_helper import (
     _resolve_credentials,
     _resolve_endpoint,
+    _s3_provider_chain,
 )
 
 
@@ -75,12 +76,17 @@ def test_s3_inline_beats_imds_when_env_unset(monkeypatch):
 
 
 def test_s3_bare_uses_aws_chain():
-    # Chain must be [EnvAWSProvider, IamAwsProvider] — no ~/.aws file tier.
+    # Assert composition on OUR returned list (no reach into minio-py private _providers).
     entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1")
-    provider = _resolve_credentials(entry)
-    assert isinstance(provider, ChainedProvider)
-    types = [type(p) for p in provider._providers]
-    assert types == [EnvAWSProvider, IamAwsProvider]
+    chain = _s3_provider_chain(entry)
+    assert [type(p) for p in chain] == [EnvAWSProvider, IamAwsProvider]
+
+
+def test_s3_chain_inserts_inline_between_env_and_iam():
+    entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1",
+                              access_key="ak", secret_key="sk")
+    chain = _s3_provider_chain(entry)
+    assert [type(p) for p in chain] == [EnvAWSProvider, StaticProvider, IamAwsProvider]
 
 
 def test_minio_bare_uses_env_minio_provider():

--- a/tests/unit/test_remote_credentials.py
+++ b/tests/unit/test_remote_credentials.py
@@ -40,11 +40,35 @@ def test_per_entry_env_names_unset_raises(monkeypatch):
         assert "MISSING_AK" in str(err)
 
 
-def test_inline_used_when_no_env_names():
+def test_inline_used_when_no_env_names(monkeypatch):
+    monkeypatch.delenv("MINIO_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("MINIO_SECRET_KEY", raising=False)
     entry = _entry(access_key="inline-ak", secret_key="inline-sk")
-    provider = _resolve_credentials(entry)
-    assert isinstance(provider, StaticProvider)
-    assert provider.retrieve().access_key == "inline-ak"
+    assert _resolve_credentials(entry).retrieve().access_key == "inline-ak"
+
+
+def test_minio_ambient_env_beats_inline(monkeypatch):
+    monkeypatch.setenv("MINIO_ACCESS_KEY", "env-ak")
+    monkeypatch.setenv("MINIO_SECRET_KEY", "env-sk")
+    entry = _entry(access_key="inline-ak", secret_key="inline-sk")
+    assert _resolve_credentials(entry).retrieve().access_key == "env-ak"
+
+
+def test_s3_ambient_env_beats_inline(monkeypatch):
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-ak")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-sk")
+    entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1",
+                              access_key="inline-ak", secret_key="inline-sk")
+    assert _resolve_credentials(entry).retrieve().access_key == "env-ak"
+
+
+def test_s3_inline_beats_aws_files_when_env_unset(monkeypatch):
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1",
+                              access_key="inline-ak", secret_key="inline-sk")
+    assert _resolve_credentials(entry).retrieve().access_key == "inline-ak"
 
 
 def test_s3_bare_uses_aws_chain():

--- a/tests/unit/test_remote_credentials.py
+++ b/tests/unit/test_remote_credentials.py
@@ -1,0 +1,73 @@
+# pylint: disable=missing-function-docstring,protected-access
+"""Tests for credential resolution precedence and endpoint defaulting."""
+from minio.credentials import (
+    StaticProvider, ChainedProvider, EnvMinioProvider,
+)
+
+from bookstack_file_exporter.config_helper.models import BaseStorageConfig
+from bookstack_file_exporter.config_helper.config_helper import (
+    _resolve_credentials,
+    _resolve_endpoint,
+)
+
+
+def _entry(**overrides):
+    base = {"type": "minio", "bucket": "b", "host": "minio.local"}
+    base.update(overrides)
+    return BaseStorageConfig(**base)
+
+
+def test_per_entry_env_names_win(monkeypatch):
+    monkeypatch.setenv("M2_AK", "ak-env")
+    monkeypatch.setenv("M2_SK", "sk-env")
+    entry = _entry(access_key="inline-ak", secret_key="inline-sk",
+                   access_key_env="M2_AK", secret_key_env="M2_SK")
+    provider = _resolve_credentials(entry)
+    assert isinstance(provider, StaticProvider)
+    creds = provider.retrieve()
+    assert creds.access_key == "ak-env"      # env names beat inline
+    assert creds.secret_key == "sk-env"
+
+
+def test_per_entry_env_names_unset_raises(monkeypatch):
+    monkeypatch.delenv("MISSING_AK", raising=False)
+    monkeypatch.delenv("MISSING_SK", raising=False)
+    entry = _entry(access_key_env="MISSING_AK", secret_key_env="MISSING_SK")
+    try:
+        _resolve_credentials(entry)
+        assert False, "expected ValueError for unset referenced env vars"
+    except ValueError as err:
+        assert "MISSING_AK" in str(err)
+
+
+def test_inline_used_when_no_env_names():
+    entry = _entry(access_key="inline-ak", secret_key="inline-sk")
+    provider = _resolve_credentials(entry)
+    assert isinstance(provider, StaticProvider)
+    assert provider.retrieve().access_key == "inline-ak"
+
+
+def test_s3_bare_uses_aws_chain():
+    entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1")
+    assert isinstance(_resolve_credentials(entry), ChainedProvider)
+
+
+def test_minio_bare_uses_env_minio_provider():
+    entry = _entry()  # no creds at all
+    assert isinstance(_resolve_credentials(entry), EnvMinioProvider)
+
+
+def test_endpoint_uses_explicit_host():
+    entry = BaseStorageConfig(type="s3", bucket="b", region="us-east-1",
+                              host="custom.example.com")
+    assert _resolve_endpoint(entry) == "custom.example.com"
+
+
+def test_endpoint_s3_defaults_from_region():
+    entry = BaseStorageConfig(type="s3", bucket="b", region="eu-west-1")
+    assert _resolve_endpoint(entry) == "s3.eu-west-1.amazonaws.com"
+
+
+def test_endpoint_minio_empty_when_no_host():
+    entry = BaseStorageConfig(type="minio", bucket="b", host="")
+    assert _resolve_endpoint(entry) == ""

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bookstack_file_exporter import run
-from bookstack_file_exporter.notify.models import NotifyResult
+from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult, UploadOutcome
 
 
 def _config(run_interval, run_once=False, run_schedule=None, health_port=None):
@@ -707,7 +707,9 @@ class TestExporterReturnValue:
             chapter_nodes={}, page_nodes={10: MagicMock()}
         )
         mock_archiver.has_exported_content = True
-        mock_archiver.archive_remote.return_value = ["bucket/export.tgz"]
+        mock_archiver.archive_remote.return_value = [
+            UploadOutcome("s3/b", "bucket/export.tgz", None)]
+        mock_archiver.resolve_remote_status.return_value = ExportStatus.SUCCESS
         mock_archiver.clean_up.return_value = ["/local/export.tgz"]
         mock_archiver.archive_file = "/local/export.tgz"
 
@@ -715,7 +717,8 @@ class TestExporterReturnValue:
 
         assert isinstance(result, NotifyResult)
         assert result.local == "/local/export.tgz"
-        assert result.remote == ["bucket/export.tgz"]
+        assert result.status is ExportStatus.SUCCESS
+        assert [o.dest for o in result.uploads] == ["bucket/export.tgz"]
         assert result.removed == ["/local/export.tgz"]
 
     def test_success_path_do_notify_called_with_result(self, monkeypatch):
@@ -728,6 +731,7 @@ class TestExporterReturnValue:
         )
         mock_archiver.has_exported_content = True
         mock_archiver.archive_remote.return_value = []
+        mock_archiver.resolve_remote_status.return_value = ExportStatus.SUCCESS
         mock_archiver.clean_up.return_value = []
         mock_archiver.archive_file = "/local/export.tgz"
 
@@ -954,3 +958,33 @@ class TestDoubleSignalForceKill:
         assert result == 0
         # run() received the stop event positionally or by keyword
         assert mock_run.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _run_once() — direct status/exit-code tests
+# ---------------------------------------------------------------------------
+
+def test_run_once_returns_zero_on_success():
+    with patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(run, "run",
+                      return_value=NotifyResult(status=ExportStatus.SUCCESS, local="/a/b.tgz")):
+        assert run._run_once(MagicMock()) == 0
+
+
+def test_run_once_returns_three_on_partial():
+    with patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(run, "run",
+                      return_value=NotifyResult(status=ExportStatus.PARTIAL, local="/a/b.tgz")):
+        assert run._run_once(MagicMock()) == 3
+
+
+def test_run_once_returns_one_on_exception():
+    with patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(run, "run", side_effect=RuntimeError("boom")):
+        assert run._run_once(MagicMock()) == 1
+
+
+def test_run_once_returns_zero_when_result_none():
+    with patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(run, "run", return_value=None):
+        assert run._run_once(MagicMock()) == 0

--- a/tests/unit/test_s3_archiver.py
+++ b/tests/unit/test_s3_archiver.py
@@ -3,7 +3,7 @@
 """Unit tests for S3CompatibleArchiver: upload return value + client construction."""
 from unittest.mock import MagicMock, patch
 
-from bookstack_file_exporter.archiver.minio_archiver import S3CompatibleArchiver
+from bookstack_file_exporter.archiver.s3_archiver import S3CompatibleArchiver
 
 
 def _make_archiver(bucket: str, path: str | None = None):
@@ -47,7 +47,7 @@ class TestClientConstruction:
         provider_config.credentials = creds
         provider_config.config = MagicMock(bucket="b", path="p", keep_last=0, region="us-east-1")
 
-        with patch("bookstack_file_exporter.archiver.minio_archiver.Minio") as mock_minio:
+        with patch("bookstack_file_exporter.archiver.s3_archiver.Minio") as mock_minio:
             instance = S3CompatibleArchiver.__new__(S3CompatibleArchiver)
             # call the real __init__ but stub bucket validation
             with patch.object(S3CompatibleArchiver, "_validate_bucket", lambda self: None):

--- a/tests/unit/test_s3_archiver.py
+++ b/tests/unit/test_s3_archiver.py
@@ -38,6 +38,28 @@ class TestUploadBackupReturnValue:
         )
 
 
+class TestScanObjectsPrefix:
+    def test_scan_uses_path_slash_prefix_when_path_set(self):
+        archiver = _make_archiver("b", "uploads")
+        archiver._client.list_objects.return_value = []
+        archiver._scan_objects(".tgz")
+        archiver._client.list_objects.assert_called_once_with("b", prefix="uploads/")
+
+    def test_scan_uses_empty_prefix_when_path_empty(self):
+        # empty path -> root listing; a "/" prefix matches nothing, silently breaking retention
+        archiver = _make_archiver("b", None)
+        archiver._client.list_objects.return_value = []
+        archiver._scan_objects(".tgz")
+        archiver._client.list_objects.assert_called_once_with("b", prefix="")
+
+    def test_scan_filters_managed_objects_at_root(self):
+        archiver = _make_archiver("b", None)
+        managed = MagicMock(object_name="bookstack_export_2024.tgz")
+        unmanaged = MagicMock(object_name="unrelated.tgz")
+        archiver._client.list_objects.return_value = [managed, unmanaged]
+        assert archiver._scan_objects(".tgz") == [managed]
+
+
 class TestClientConstruction:
     def test_minio_client_built_with_endpoint_secure_region_credentials(self):
         creds = MagicMock()


### PR DESCRIPTION
## Changes

- Replaces the single `minio:` config block with an `object_storage:` **list**. Each entry is tagged `type: minio | s3`; dispatch is keyed on `type`.
- Adds first-class **AWS S3 / S3-compatible** upload. No new dependency — the existing `minio>=7.2.20` client speaks the S3 protocol against AWS (verified against the installed SDK); **no boto3**.
- Per-entry credentials resolve to a minio-py `Provider` via layered precedence (first match wins): (1) per-entry env var **names** `access_key_env`/`secret_key_env`; (2) inline `access_key`/`secret_key`; (3) `type: s3` default AWS chain (`AWS_*` env → `~/.aws/credentials` → EC2/ECS/EKS IAM role via IMDS); (4) `type: minio` fixed `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` env (v2 behavior preserved).
- One generalized `S3CompatibleArchiver` (was `MinioArchiver`) serves both types — upload/cleanup/bucket-validate is identical S3 API surface.
- Runtime collection `object_storage_config` is now a `list[StorageProviderConfig]` (was a type-keyed dict) so two same-type targets cannot collide.
- New fields per entry: `secure` (TLS, default `true` — set `false` for plain-HTTP local MinIO), and the `*_env` credential-name fields. A half credential pair (key without secret, or `*_env` without its partner) is a config error (pydantic validator).
- **Fail-fast guard:** an un-migrated `minio:` key with no `object_storage:` raises at config load (pydantic ignores unknown keys, so without this a stale `minio:` block would silently disable backups). If both are present it only warns. Implemented as a small legacy-key registry that also subsumes the existing `modify_markdown` deprecation.
- README: new `object_storage:` docs + credential-resolution reference + "Migrating from v2" section + breaking-upgrade table entry.

## Motivation

S3 was the main missing upload target (stub existed, no implementation). Reusing minio-py avoids ~10MB of boto3/botocore + a duplicate archiver; minio-py auto-selects path-style vs virtual-host addressing for AWS, so the one real boto3 advantage is moot.

## BREAKING CHANGE (v3.0.0)

The `minio:` config key is removed; only `object_storage:` is accepted. Migration is a mechanical edit — see the "Migrating from v2" README section. `MINIO_ACCESS_KEY`/`MINIO_SECRET_KEY` continue to work unchanged for a single MinIO entry.

## Test plan

- `pytest` — full suite green (590 passed), pure-mock per the existing archiver test pattern. Covers: credential resolution for all 4 layers + precedence + half-pair rejection; endpoint defaulting (explicit host vs `s3.<region>.amazonaws.com`); per-type `is_valid`; archiver dispatch (mixed minio+s3, two same-type no-collision, unknown-type error, empty list); `_generate_remote_config` orchestration; legacy-key guard (raise / warn / clean / non-dict).
- **Not covered by mocks:** real AWS SigV4 / IAM / bucket interop. Recommend one LocalStack or real-bucket smoke upload before tagging v3.0.0.

## In-depth

- **Kept all 4 credential layers.** The per-entry `*_env` layer is the only out-of-file credential path for two same-type targets; marginal cost is low and it's isolated. Alternative (defer it) saved little since the list refactor is required regardless.
- **Loose model + runtime `is_valid`** rather than per-type pydantic models — matches the existing codebase pattern; per-type models deferred until fields genuinely diverge (YAGNI).
- **Follow-ups (non-blocking):** the module is still named `minio_archiver.py` and a few internal log strings say "minio" though the shared class now serves both — cosmetic rename deferred to avoid import churn here.