### PR TITLE
ci: enable renovate lockfile maintenance + track python base image tag

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,6 +4,19 @@
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
   "minimumReleaseAge": "3 days",
+  "lockFileMaintenance": {
+    "enabled": true
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^Taskfile\\.ya?ml$/"],
+      "matchStrings": ["BASE_IMAGE_TAG[^\"]*default \"(?<currentValue>[^\"]+)\""],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "python",
+      "versioningTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "matchManagers": ["github-actions"],


### PR DESCRIPTION
## Changes

- Enable `lockFileMaintenance` in `renovate.json` — renovate now periodically refreshes `uv.lock`. `config:recommended` does not enable this by default, so the locked (shipped) dependency versions were never being refreshed on their own.
- Add a `customManagers` regex entry so renovate tracks the `BASE_IMAGE_TAG` default in `Taskfile.yml` (datasource `docker`, depName `python`, versioning `docker` — the `-slim-bookworm` compatibility suffix is preserved).
- The published `Dockerfile` base image (`ARG BASE_IMAGE_TAG` consumed by `FROM ${BASE_IMAGE}:${BASE_IMAGE_TAG}`) is bumped by renovate's **native** dockerfile manager — no annotation required.

## Motivation

Renovate only auto-bumps version strings it can map to a manager + datasource. Previously the python patch version only updated in `.devcontainer` (the python feature, e.g. #115), while the **shipped artifact** — the Dockerfile base image — and the Taskfile build default stayed stale and drifted. This makes the actually-shipped python image and the local-build default track upstream too. Enabling lockfile maintenance keeps the locked dependency set current rather than frozen.

## Assumptions / notes

- `requires-python = ">=3.11"`, `.python-version` (`3.14`, minor-only), the CI test matrix, and `.pylintrc`/README references are intentionally left as ranges/minor-pins/prose and are not renovate-managed. A previously-considered `rangeStrategy: "bump"` was deliberately omitted — it would have raised `requires-python` and dropped 3.11–3.13 support that the CI matrix tests.
- README prose ("tested on `3.14.5`") remains a manual update (not a datasource).
- Existing devcontainer/Dockerfile drift (devcontainer at 3.14.6 via #115, Dockerfile still 3.14.5): once this merges, renovate's next run should open a PR bumping the Dockerfile + Taskfile to match.

## Test plan

- `renovate.json` validates as JSON; fields (`managerFilePatterns`, `customType: regex`, `matchStrings`, `datasourceTemplate`, `depNameTemplate`, `versioningTemplate`) are current renovate config keys.
- The customManager regex was verified to capture `3.14.5-slim-bookworm` from the Taskfile default and to NOT match the `--build-arg BASE_IMAGE_TAG={{.BASE_IMAGE_TAG}}` lines.
- Behavioral confirmation (renovate opening the expected PRs) happens on renovate's next run against the branch/after merge.