### PR TITLE
feat: support LOG_LEVEL env var for log level

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ The main use case is to backup all docs in a relational directory-tree format to
 5. Provide an easy way to do automated file backups locally, in docker, or [kubernetes](https://github.com/homeylab/helm-charts/tree/main/charts/bookstack#file-exporter-backup-your-pages) for Bookstack page contents.
 
 ## Documentation
-
 Detailed docs live under [`docs/`](docs/):
 
 - [Getting Started](docs/getting-started.md) — install via Pip/Docker/Helm, run modes, scheduling, health endpoint, authentication

--- a/bookstack_file_exporter/__main__.py
+++ b/bookstack_file_exporter/__main__.py
@@ -11,7 +11,7 @@ def main(argv=None) -> int:
     """run entrypoint (argv=None -> sys.argv)"""
     args: argparse.Namespace = run_args.get_args(argv)
     logging.basicConfig(
-        level=run_args.get_log_level(args.log_level),
+        level=run_args.get_log_level(run_args.resolve_log_level(args)),
         handlers=[bfe_logging.build_handler(run_args.resolve_log_format(args))])
     return run.entrypoint(args)
 

--- a/bookstack_file_exporter/__main__.py
+++ b/bookstack_file_exporter/__main__.py
@@ -11,7 +11,7 @@ def main(argv=None) -> int:
     """run entrypoint (argv=None -> sys.argv)"""
     args: argparse.Namespace = run_args.get_args(argv)
     logging.basicConfig(
-        level=run_args.get_log_level(run_args.resolve_log_level(args)),
+        level=run_args.resolve_log_level(args).upper(),
         handlers=[bfe_logging.build_handler(run_args.resolve_log_format(args))])
     return run.entrypoint(args)
 

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -4,21 +4,10 @@ import os
 
 log = logging.getLogger(__name__)
 
-LOG_LEVEL = {
-    'debug': logging.DEBUG,
-    'info': logging.INFO,
-    'warning': logging.WARNING,
-    'error': logging.ERROR
-}
-
+LOG_LEVEL = ("debug", "info", "warning", "error")
 LOG_FORMAT = ("text", "json")
 _LOG_FORMAT_ENV = "LOG_FORMAT"
 _LOG_LEVEL_ENV = "LOG_LEVEL"
-
-
-def get_log_level(log_level:str) -> int:
-    """return log level int"""
-    return LOG_LEVEL[log_level]
 
 def get_args(argv=None) -> argparse.Namespace:
     """return user cmd line options (argv=None -> sys.argv)"""
@@ -41,7 +30,7 @@ def get_args(argv=None) -> argparse.Namespace:
                     default=None,
                     help=('Set verbosity level for logging. CLI overrides the'
                           ' LOG_LEVEL env var; default info.'),
-                    choices=LOG_LEVEL.keys())
+                    choices=LOG_LEVEL)
     parser.add_argument('--run-once',
                     action='store_true',
                     default=False,

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -69,8 +69,8 @@ def resolve_log_format(args: argparse.Namespace) -> str:
     env_val = env_val.lower()
     if env_val in LOG_FORMAT:
         return env_val
-    log.warning("Invalid %s '%s'; supported: text (default), json. Using text.",
-                _LOG_FORMAT_ENV, env_val)
+    log.warning("Invalid %s '%s'; supported: %s. Using text.",
+                _LOG_FORMAT_ENV, env_val, ", ".join(LOG_FORMAT))
     return "text"
 
 

--- a/bookstack_file_exporter/run_args.py
+++ b/bookstack_file_exporter/run_args.py
@@ -13,6 +13,7 @@ LOG_LEVEL = {
 
 LOG_FORMAT = ("text", "json")
 _LOG_FORMAT_ENV = "LOG_FORMAT"
+_LOG_LEVEL_ENV = "LOG_LEVEL"
 
 
 def get_log_level(log_level:str) -> int:
@@ -37,8 +38,9 @@ def get_args(argv=None) -> argparse.Namespace:
     parser.add_argument('-v',
                     '--log-level',
                     type=str.lower,
-                    default='info',
-                    help='Set verbosity level for logging.',
+                    default=None,
+                    help=('Set verbosity level for logging. CLI overrides the'
+                          ' LOG_LEVEL env var; default info.'),
                     choices=LOG_LEVEL.keys())
     parser.add_argument('--run-once',
                     action='store_true',
@@ -70,3 +72,21 @@ def resolve_log_format(args: argparse.Namespace) -> str:
     log.warning("Invalid %s '%s'; supported: text (default), json. Using text.",
                 _LOG_FORMAT_ENV, env_val)
     return "text"
+
+
+def resolve_log_level(args: argparse.Namespace) -> str:
+    """Resolve log level: CLI flag, else LOG_LEVEL env, else info.
+
+    An invalid env value falls back to info (does not crash a container).
+    """
+    if args.log_level is not None:
+        return args.log_level  # argparse `choices` already validated this
+    env_val = os.environ.get(_LOG_LEVEL_ENV)
+    if env_val is None:
+        return "info"
+    env_val = env_val.lower()
+    if env_val in LOG_LEVEL:
+        return env_val
+    log.warning("Invalid %s '%s'; supported: %s. Using info.",
+                _LOG_LEVEL_ENV, env_val, ", ".join(LOG_LEVEL))
+    return "info"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -5,12 +5,14 @@
 > [!NOTE]
 > Credentials: BookStack API token setup (role permissions + generating `tokenId`/`tokenSecret`) lives in [Authentication & Permissions](getting-started.md#authentication-and-permissions). Object-storage credentials are documented in [Remote Storage](remote-storage.md#object-storage-upload).
 
+- [General](#general)
 - [Full Example](#full-example)
 - [Options and Descriptions](#options-and-descriptions)
 - [Valid Environment Variables](#valid-environment-variables)
 - [Export Level](#export-level)
 - [Parallel Export](#parallel-export)
 
+## General
 _Ensure [Authentication](getting-started.md#authentication-and-permissions) has been set up beforehand for required credentials._ For a simple config example to run quickly, refer to the one in the [Using This Application](getting-started.md#using-this-application) section.
 
 A full example is also shown below. _Optionally, look at `examples/` folder of the github repo for more examples with long descriptions_.

--- a/docs/filters.md
+++ b/docs/filters.md
@@ -2,6 +2,7 @@
 
 [← Back to README](../README.md#documentation)
 
+- [General](#general)
 - [Schema](#schema)
 - [Pattern matching](#pattern-matching)
 - [What the pattern matches](#what-the-pattern-matches)
@@ -12,11 +13,10 @@
 - [Validation](#validation)
   - [Known limitations](#known-limitations)
 
-
+## General
 The `filters` configuration option lets you include or exclude BookStack resources (shelves, books, chapters, pages) by name during export. Filtering runs during the tree build, before the exporter issues any detail API call for a node — excluded books, chapters, and pages — and all descendants of any excluded node — are never fetched.
 
 ## Schema
-
 All keys are optional. Omit a type entirely (or leave its lists empty/`[]`) to apply no filter for that type.
 
 ```yaml
@@ -99,15 +99,6 @@ filters:
 
 All patterns are compiled with `re.compile` at config load time. An invalid regex or an empty string `""` pattern is rejected with a clear error message before any API call is made.
 
-- [Schema](#schema)
-- [Pattern matching](#pattern-matching)
-- [What the pattern matches](#what-the-pattern-matches)
-- [Precedence](#precedence)
-- [Cascade](#cascade)
-- [Interaction with export\_level](#interaction-with-export_level)
-- [Excluding books with no shelf](#excluding-books-with-no-shelf)
-- [Validation](#validation)
-  - [Known limitations](#known-limitations)
 ### Known limitations
 
 - **Same-name resources cannot be individually disambiguated.** If two books share the same display name, a filter pattern will match both. Use cascade (exclude the parent shelf/book) to scope the filter more precisely, or rename one of the resources.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -117,7 +117,7 @@ Command line options:
 | ------ | ------- | -------- | ----------- |
 |`-c`, `--config-file`|—|True|Relative or Absolute path to a valid configuration file. This configuration file is checked against a schema for validation.|
 |`-o`, `--output-dir` |—|False|Optional output directory for exports. Takes precedence over `output_path` in the config file if both are set.|
-|`-v`, `--log-level` |—|False, default: info|Provide a valid log level: info, debug, warning, error.|
+|`-v`, `--log-level` |`LOG_LEVEL`|False, default: info|Provide a valid log level: info, debug, warning, error. CLI overrides the `LOG_LEVEL` env var.|
 |`--log-format` |`LOG_FORMAT`|False, default: text|Log output format. `text` (default) or `json` for JSON Lines. CLI overrides the `LOG_FORMAT` env var.|
 |`--run-once` |—|False|Force a single run and exit, ignoring `run_interval` and `run_schedule` in the config. Useful for a manual or CI-triggered run against a config that is otherwise set up for application (scheduled) mode.|
 

--- a/docs/remote-storage.md
+++ b/docs/remote-storage.md
@@ -8,11 +8,10 @@
 - [Multi-target upload behavior](#multi-target-upload-behavior)
 - [Migrating from v2](#migrating-from-v2)
 
-Optionally, one or more upload targets can be specified to push generated archives to remote object storage. Optionally, look at `examples/config.yml` in the github repo for a commented-out example.
-
 ## Object Storage Upload
+_Currently, s3 compatible object storage providers are supported. Feel free to create a github issue to request something else_.
 
-Currently, s3 compatible object storage providers are supported. Feel free to create a github issue to request something else.
+One or more upload targets can be specified to push generated archives to remote object storage. Optionally, look at `examples/config.yml` in the github repo for a commented-out example.
 
 Configure one or more upload targets under `object_storage:`. Each entry has a `type`
 (`minio` or `s3`). Any S3-compatible store — Wasabi, Cloudflare R2, Backblaze B2, Ceph, DigitalOcean Spaces — also works under `type: s3` (or `type: minio`) by setting an explicit `host`. These use the generic S3 API and the credential resolution below — there is no per-provider code, so most S3-compatible stores work as-is. If one fails under `type: s3` (addressing-style, signature, or checksum quirks), [open an issue](https://github.com/homeylab/bookstack-file-exporter/issues) with the provider name and the error.

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,13 +1,12 @@
 """Tests for __main__.main() return type and sys.exit wiring."""
 # pylint: disable=missing-class-docstring,missing-function-docstring
-import logging
 import sys
 from unittest.mock import patch
 
 from bookstack_file_exporter import run
 from bookstack_file_exporter.__main__ import main
 
-# Real argv so main() runs the real get_args -> get_log_level -> resolve_log_format
+# Real argv so main() runs the real get_args -> resolve_log_level -> resolve_log_format
 # -> build_handler chain. Only the genuine boundaries are patched per test:
 # run.entrypoint (network + disk) and logging.basicConfig (global root logger).
 _ARGV = ("--log-format", "text")
@@ -32,12 +31,16 @@ class TestMainReturnType:
 
 class TestLogLevelWiring:
     def test_log_level_env_drives_basicconfig_level(self, monkeypatch):
-        """With no -v flag, LOG_LEVEL env must set the configured logging level."""
+        """With no -v flag, LOG_LEVEL env must set the configured logging level.
+
+        __main__ passes the resolved level name uppercased; logging.basicConfig
+        accepts a level-name string and maps it to the int level.
+        """
         monkeypatch.setenv("LOG_LEVEL", "debug")
         with patch.object(run, "entrypoint", return_value=0), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig") as mock_bc:
             main(("--log-format", "text"))
-        assert mock_bc.call_args.kwargs["level"] == logging.DEBUG
+        assert mock_bc.call_args.kwargs["level"] == "DEBUG"
 
     def test_cli_flag_overrides_log_level_env(self, monkeypatch):
         """-v on the CLI must win over LOG_LEVEL env."""
@@ -45,7 +48,7 @@ class TestLogLevelWiring:
         with patch.object(run, "entrypoint", return_value=0), \
              patch("bookstack_file_exporter.__main__.logging.basicConfig") as mock_bc:
             main(("-v", "error", "--log-format", "text"))
-        assert mock_bc.call_args.kwargs["level"] == logging.ERROR
+        assert mock_bc.call_args.kwargs["level"] == "ERROR"
 
 
 class TestSysExitWiring:

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 """Tests for __main__.main() return type and sys.exit wiring."""
 # pylint: disable=missing-class-docstring,missing-function-docstring
+import logging
 import sys
 from unittest.mock import patch
 
@@ -27,6 +28,24 @@ class TestMainReturnType:
              patch("bookstack_file_exporter.__main__.logging.basicConfig"):
             result = main(_ARGV)
         assert result == sentinel
+
+
+class TestLogLevelWiring:
+    def test_log_level_env_drives_basicconfig_level(self, monkeypatch):
+        """With no -v flag, LOG_LEVEL env must set the configured logging level."""
+        monkeypatch.setenv("LOG_LEVEL", "debug")
+        with patch.object(run, "entrypoint", return_value=0), \
+             patch("bookstack_file_exporter.__main__.logging.basicConfig") as mock_bc:
+            main(("--log-format", "text"))
+        assert mock_bc.call_args.kwargs["level"] == logging.DEBUG
+
+    def test_cli_flag_overrides_log_level_env(self, monkeypatch):
+        """-v on the CLI must win over LOG_LEVEL env."""
+        monkeypatch.setenv("LOG_LEVEL", "debug")
+        with patch.object(run, "entrypoint", return_value=0), \
+             patch("bookstack_file_exporter.__main__.logging.basicConfig") as mock_bc:
+            main(("-v", "error", "--log-format", "text"))
+        assert mock_bc.call_args.kwargs["level"] == logging.ERROR
 
 
 class TestSysExitWiring:

--- a/tests/unit/test_run_args.py
+++ b/tests/unit/test_run_args.py
@@ -1,4 +1,4 @@
-"""Tests for run_args log-format flag parsing and precedence resolution."""
+"""Tests for run_args log-format/log-level flag parsing and precedence resolution."""
 # pylint: disable=missing-class-docstring,missing-function-docstring
 import argparse
 import logging
@@ -8,6 +8,10 @@ from bookstack_file_exporter import run_args
 
 def _args(log_format=None):
     return argparse.Namespace(log_format=log_format)
+
+
+def _lvl_args(log_level=None):
+    return argparse.Namespace(log_level=log_level)
 
 
 class TestLogFormatArg:
@@ -41,4 +45,38 @@ class TestResolveLogFormat:
         with caplog.at_level(logging.WARNING):
             assert run_args.resolve_log_format(_args()) == "text"
         assert any("yaml" in r.message and "LOG_FORMAT" in r.message
+                   for r in caplog.records)
+
+
+class TestLogLevelArg:
+    def test_default_is_none(self):
+        # --log-level absent -> None (so resolve_log_level can fall to env)
+        assert run_args.get_args([]).log_level is None
+
+    def test_flag_parsed_and_lowercased(self):
+        assert run_args.get_args(["-v", "DEBUG"]).log_level == "debug"
+
+
+class TestResolveLogLevel:
+    def test_cli_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "error")
+        assert run_args.resolve_log_level(_lvl_args(log_level="debug")) == "debug"
+
+    def test_env_used_when_no_flag(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "debug")
+        assert run_args.resolve_log_level(_lvl_args()) == "debug"
+
+    def test_env_is_case_insensitive(self, monkeypatch):
+        monkeypatch.setenv("LOG_LEVEL", "DEBUG")
+        assert run_args.resolve_log_level(_lvl_args()) == "debug"
+
+    def test_default_info_when_neither(self, monkeypatch):
+        monkeypatch.delenv("LOG_LEVEL", raising=False)
+        assert run_args.resolve_log_level(_lvl_args()) == "info"
+
+    def test_invalid_env_falls_back_to_info_with_warning(self, monkeypatch, caplog):
+        monkeypatch.setenv("LOG_LEVEL", "verbose")
+        with caplog.at_level(logging.WARNING):
+            assert run_args.resolve_log_level(_lvl_args()) == "info"
+        assert any("verbose" in r.message and "LOG_LEVEL" in r.message
                    for r in caplog.records)


### PR DESCRIPTION
## Changes
- Add `LOG_LEVEL` env-var resolution in `run_args.resolve_log_level`, mirroring the existing `LOG_FORMAT` handling. Precedence: CLI `-v/--log-level` flag > `LOG_LEVEL` env > `info`. An invalid env value falls back to `info` with a warning rather than crashing a container.
- `--log-level` default changed `'info'` → `None` so a CLI-set value is detectable (same idiom as `--log-format`); argparse `choices` still validates explicit CLI values.
- `__main__` passes the resolved level **name** (uppercased) straight to `logging.basicConfig`, which maps level-name strings to ints itself. `LOG_LEVEL` is a tuple of names (mirroring `LOG_FORMAT`); the old name->int dict and `get_log_level` helper were removed.
- Refactor: the `LOG_FORMAT` invalid-value warning is now built from the `LOG_FORMAT` tuple, so the supported-values list can't go stale and the two resolvers are exact mirrors.
- Docs (chore): note `LOG_LEVEL` in the getting-started Options table (`configuration.md` already listed it as a valid env var); add `## General` intro headings; remove a stray duplicate ToC wedged inside the Validation section of `filters.md`; reorder the remote-storage Object Storage Upload intro.

## Motivation
Only `LOG_FORMAT` was settable by environment; log level was CLI-only. In container/scheduled deployments (Docker/Helm) env is the natural knob, so the asymmetry was awkward and `configuration.md` already documented `LOG_LEVEL` as if it worked. This makes that documented behavior real.

## Test plan
- `pytest tests/` — 640 passed.
- New tests cover: `--log-level` default None, flag parse/lowercase, and `resolve_log_level` precedence (CLI>env), env-when-no-flag, case-insensitivity, invalid-env→info+warning; plus `__main__` wiring (env drives `basicConfig` level; CLI overrides env).
- `pylint bookstack_file_exporter/run_args.py bookstack_file_exporter/__main__.py` — 10.00/10.

## In-depth
`resolve_log_format` and `resolve_log_level` are kept as two separate ~14-line functions rather than factored into a generic helper: they differ in valid-value container (tuple vs dict), default, and warning wording, and with only two call sites a parametrized helper adds indirection for marginal gain (YAGNI). Independent reviewer confirmed idiomatic.
