### PR TITLE
feat: pre-v3 improvements — cleanup-failure PARTIAL, parallel uploads, is_aws single-sourcing

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -1,3 +1,4 @@
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 import logging
 import os
@@ -20,6 +21,11 @@ from bookstack_file_exporter.common.util import HttpHelper
 log = logging.getLogger(__name__)
 
 _DATE_STR_FORMAT = "%Y-%m-%d_%H-%M-%S"
+
+# Cap concurrent target uploads: targets are typically 1-3; beyond a few, wall clock
+# is bounded by upload bandwidth, not target count. Not user-configurable until
+# someone needs it (adding a knob later is non-breaking).
+_MAX_UPLOAD_WORKERS = 4
 
 
 class AggregateUploadError(Exception):
@@ -160,15 +166,25 @@ class Archiver:
         """Upload to every configured target, attempting all even if some fail.
 
         Returns one UploadOutcome per target (dest on success, error on upload
-        failure, or dest+warning when the upload landed but retention cleanup failed). Never
-        raises on a per-target upload error — aggregate status is decided by
-        resolve_remote_status. Each target gets its own S3CompatibleArchiver
-        instance (boto3), keeping credentials isolated; uploads run serially.
+        failure, or dest+warning when the upload landed but retention cleanup failed),
+        in config order. Never raises on a per-target upload error — aggregate status
+        is decided by resolve_remote_status.
+
+        Targets upload concurrently (one thread each, capped at _MAX_UPLOAD_WORKERS):
+        the work is I/O-bound (HeadBucket RTT, multi-MB upload, retention listing), the
+        same rationale as node_archiver's export_workers pool. Each _upload constructs
+        its own S3CompatibleArchiver with its own boto3 Session, so no client state is
+        shared across threads. executor.map preserves input order, and _upload's
+        catch-all means no worker exception can propagate out of map().
         """
-        outcomes: list[UploadOutcome] = []
-        for entry in self.config.object_storage_config or []:
-            outcomes.append(self._upload(entry))
-        return outcomes
+        entries = self.config.object_storage_config or []
+        if not entries:
+            return []
+        if len(entries) == 1:
+            return [self._upload(entries[0])]
+        workers = min(len(entries), _MAX_UPLOAD_WORKERS)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            return list(executor.map(self._upload, entries))
 
     def _upload(self, provider_config: S3ProviderConfig) -> UploadOutcome:
         label = provider_config.name

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -63,6 +63,15 @@ class S3StorageConfig(StrictModel):
     access_key_env: str | None = None
     secret_key_env: str | None = None
 
+    @property
+    def is_aws(self) -> bool:
+        """The schema's core discriminant, single-sourced: no 'endpoint' means AWS S3;
+        an 'endpoint' means a custom S3-compatible store. Validators and the
+        S3ProviderConfig resolvers read this instead of re-deriving from 'endpoint'
+        so the rule can only change in one place. Truthiness (not `is None`) so an
+        empty-string endpoint still selects AWS."""
+        return not self.endpoint
+
     @model_validator(mode="before")
     @classmethod
     def _reject_removed_or_renamed_keys(cls, raw):
@@ -119,7 +128,7 @@ class S3StorageConfig(StrictModel):
     def _check_region_for_aws(self):
         """A no-endpoint target is AWS S3, which needs a region for signing/endpoint. Require
         it unless ambient_auth is on (botocore can resolve region from env/profile)."""
-        if not self.endpoint and not self.region and not self.ambient_auth:
+        if self.is_aws and not self.region and not self.ambient_auth:
             raise ValueError(
                 f"object_storage target {self.name!r}: 'region' is required for AWS S3 "
                 "targets (no 'endpoint') unless ambient_auth resolves it.")

--- a/bookstack_file_exporter/config_helper/remote.py
+++ b/bookstack_file_exporter/config_helper/remote.py
@@ -48,10 +48,10 @@ class S3ProviderConfig:
     def _resolve_endpoint_url(entry: S3StorageConfig) -> str | None:
         """boto3 endpoint_url: explicit endpoint -> scheme://endpoint (scheme from `secure`);
         no endpoint -> None (AWS default regional endpoint, derived from region_name)."""
-        if entry.endpoint:
-            scheme = "https" if entry.secure else "http"
-            return f"{scheme}://{entry.endpoint}"
-        return None
+        if entry.is_aws:
+            return None
+        scheme = "https" if entry.secure else "http"
+        return f"{scheme}://{entry.endpoint}"
 
     @staticmethod
     def _resolve_region(entry: S3StorageConfig) -> str | None:
@@ -61,9 +61,7 @@ class S3ProviderConfig:
         ambient_auth; botocore resolves region from env/profile)."""
         if entry.region:
             return entry.region
-        if entry.endpoint:
-            return "us-east-1"
-        return None
+        return None if entry.is_aws else "us-east-1"
 
     @staticmethod
     def _resolve_addressing(entry: S3StorageConfig) -> str:
@@ -74,4 +72,4 @@ class S3ProviderConfig:
         no endpoint (AWS) -> 'auto' (virtual-hosted)."""
         if entry.addressing_style:
             return entry.addressing_style
-        return "path" if entry.endpoint else "auto"
+        return "auto" if entry.is_aws else "path"

--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -25,3 +25,4 @@ class NotifyResult:
     local: str | None = None                            # local .tgz path, None if no archive
     uploads: list[UploadOutcome] = field(default_factory=list)  # one per configured target
     removed: list[str] = field(default_factory=list)    # local files clean_up() deleted
+    cleanup_error: str | None = None    # str(exception) when local retention pruning failed

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -90,6 +90,8 @@ class AppRiseNotify:
             pruned_count = len(removed_abs - {local_abs})
             if pruned_count > 0:
                 lines.append(f"Pruned {pruned_count} old local archive(s)")
+        if result is not None and result.cleanup_error:
+            lines.append(f"Warning: local cleanup failed - {result.cleanup_error}")
         return "\n".join(lines)
 
     def notify(self, excep: Exception | None = None, result: NotifyResult | None = None):

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -244,14 +244,24 @@ def exporter(config: ConfigNode, stop=None):
         outcomes = archive.archive_remote()
         status = archive.resolve_remote_status(outcomes)
 
-        # clean_up only runs when a durable copy survives (hard-fail raised above, so the
-        # local .tgz is preserved for retry).
-        removed = archive.clean_up()
+        # Local retention pruning is housekeeping: at this point durable copies exist
+        # (resolve_remote_status raised otherwise), so a failed local delete downgrades
+        # the run to PARTIAL instead of failing it — same treatment as a remote
+        # retention failure in archiver._upload. Stale local files are harmless; the
+        # next run prunes them.
+        removed: list[str] = []
+        cleanup_error: str | None = None
+        try:
+            removed = archive.clean_up()
+        except Exception as err:  # pylint: disable=broad-except
+            log.error("Local cleanup failed (export and uploads succeeded): %s", err)
+            status = ExportStatus.PARTIAL
+            cleanup_error = str(err)
 
-        local = archive.archive_file
         log.info("Created file archive: %s.tgz", archive.archive_dir)
         log.info("Completed run")
-        return NotifyResult(status=status, local=local, uploads=outcomes, removed=removed)
+        return NotifyResult(status=status, local=archive.archive_file, uploads=outcomes,
+                            removed=removed, cleanup_error=cleanup_error)
     finally:
         # Eager cleanup of THIS cycle's partial on every terminal path (stop,
         # exception, one-shot KeyboardInterrupt). No-op on success: the tar is

--- a/docs/remote-storage.md
+++ b/docs/remote-storage.md
@@ -168,6 +168,10 @@ A target that uploads successfully but whose retention cleanup (pruning old obje
 fails also yields a **Partial** run — the backup is safely stored, but the failed cleanup is surfaced
 (exit 3 / `on_failure` / `degraded` health) so unbounded object growth is noticed.
 
+The same applies locally: if pruning old local archives (top-level `keep_last`) fails after the
+export and uploads succeeded, the run is **Partial** — the backup is safe, the failed cleanup is
+surfaced in the notification, and stale local files are left for the next run to prune.
+
 In scheduled mode the `/healthz` endpoint reports `last_run.status` as `degraded` for a partial
 run (distinct from `success` and `failed`).
 

--- a/docs/remote-storage.md
+++ b/docs/remote-storage.md
@@ -150,8 +150,9 @@ At startup each target's bucket is checked with a `HeadBucket` call:
 
 ## Multi-target upload behavior
 
-Every configured `object_storage` target is attempted, even if an earlier one fails. The run
-outcome is one of:
+Every configured `object_storage` target is attempted, even if others fail. Targets upload
+concurrently (one thread per target, capped at 4); log lines from different targets may
+interleave, and each is tagged with the target's `name`. The run outcome is one of:
 
 | Outcome | When | Exit code | Notification |
 |---|---|---|---|

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -463,11 +463,18 @@ def test_archive_remote_empty_list_no_outcomes(archiver_instance, mock_config):
 
 
 def test_archive_remote_all_success(archiver_instance, mock_config):
+    """All targets upload; outcome order matches config order regardless of which
+    upload finishes first (results are keyed by target, not by call order)."""
     mock_config.object_storage_config = [
         _provider_entry("minio/b"), _provider_entry("s3/aws")]
-    fake_instance = MagicMock()
-    fake_instance.upload_backup.side_effect = ["minio-b/a.tgz", "s3-aws/a.tgz"]
-    archiver_instance._s3_archiver_cls = MagicMock(return_value=fake_instance)
+    dests = {"minio/b": "minio-b/a.tgz", "s3/aws": "s3-aws/a.tgz"}
+
+    def make_instance(provider_config):
+        inst = MagicMock()
+        inst.upload_backup.return_value = dests[provider_config.name]
+        return inst
+
+    archiver_instance._s3_archiver_cls = MagicMock(side_effect=make_instance)
     archiver_instance._archiver.archive_file = "/local/archive.tgz"
     archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
 
@@ -478,14 +485,19 @@ def test_archive_remote_all_success(archiver_instance, mock_config):
 
 
 def test_archive_remote_one_fails_others_still_attempted(archiver_instance, mock_config):
-    """A failing target does not abort the loop; its outcome records the error."""
+    """A failing target does not abort the batch; its outcome records the error."""
     mock_config.object_storage_config = [
         _provider_entry("minio/b"), _provider_entry("s3/dr")]
-    good = MagicMock()
-    good.upload_backup.return_value = "minio-b/a.tgz"
-    bad = MagicMock()
-    bad.upload_backup.side_effect = RuntimeError("connection refused")
-    archiver_instance._s3_archiver_cls = MagicMock(side_effect=[good, bad])
+
+    def make_instance(provider_config):
+        inst = MagicMock()
+        if provider_config.name == "s3/dr":
+            inst.upload_backup.side_effect = RuntimeError("connection refused")
+        else:
+            inst.upload_backup.return_value = "minio-b/a.tgz"
+        return inst
+
+    archiver_instance._s3_archiver_cls = MagicMock(side_effect=make_instance)
     archiver_instance._archiver.archive_file = "/local/archive.tgz"
     archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
 

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -522,6 +522,34 @@ def test_archive_remote_construction_failure_recorded(archiver_instance, mock_co
     assert "no such bucket" in outcomes[0].error
 
 
+def test_archive_remote_uploads_run_concurrently(archiver_instance, mock_config):
+    """Both uploads must be in flight at once: each upload blocks on a 2-party
+    barrier, so a serial implementation deadlocks the first upload until the
+    5s barrier timeout turns it into an error outcome and fails the assert."""
+    barrier = threading.Barrier(2, timeout=5)
+    mock_config.object_storage_config = [
+        _provider_entry("minio/b"), _provider_entry("s3/aws")]
+
+    def make_instance(provider_config):
+        inst = MagicMock()
+
+        def upload(_path):
+            barrier.wait()
+            return f"{provider_config.name}/a.tgz"
+
+        inst.upload_backup.side_effect = upload
+        return inst
+
+    archiver_instance._s3_archiver_cls = MagicMock(side_effect=make_instance)
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    outcomes = archiver_instance.archive_remote()
+
+    assert [o.dest for o in outcomes] == ["minio/b/a.tgz", "s3/aws/a.tgz"]
+    assert [o.error for o in outcomes] == [None, None]
+
+
 # ---------------------------------------------------------------------------
 # resolve_remote_status
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -22,6 +22,18 @@ def test_entry_defaults():
     assert cfg.keep_last == 0
 
 
+def test_is_aws_discriminant():
+    """Single source for 'no endpoint => AWS': validators and resolvers read this."""
+    custom = S3StorageConfig(**_entry(access_key="a", secret_key="s"))
+    aws = S3StorageConfig(**_entry(endpoint=None, region="us-east-1",
+                                   access_key="a", secret_key="s"))
+    empty = S3StorageConfig(**_entry(endpoint="", region="us-east-1",
+                                     access_key="a", secret_key="s"))
+    assert custom.is_aws is False
+    assert aws.is_aws is True
+    assert empty.is_aws is True  # truthiness: empty-string endpoint still selects AWS
+
+
 def test_inline_cred_half_pair_rejected():
     with pytest.raises(ValidationError, match="access_key and secret_key"):
         S3StorageConfig(**_entry(access_key="AKIA"))  # secret missing

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -86,6 +86,20 @@ class TestGetMessageTextSuccessBranch:
         assert "(removed locally after upload)" not in body
         assert "Pruned 2 old local archive(s)" in body
 
+    def test_cleanup_error_shows_warning_line(self):
+        notifier = _make_notifier()
+        result = NotifyResult(status=ExportStatus.PARTIAL, local="/data/export.tgz",
+                              uploads=[], removed=[], cleanup_error="permission denied")
+        body = notifier._get_message_text(None, result=result)
+        assert "Warning: local cleanup failed - permission denied" in body
+        assert "completed with errors" in body
+
+    def test_no_cleanup_error_no_warning_line(self):
+        notifier = _make_notifier()
+        result = NotifyResult(local="/data/export.tgz", uploads=[], removed=[])
+        body = notifier._get_message_text(None, result=result)
+        assert "local cleanup failed" not in body
+
     def test_abspath_normalization_relative_vs_absolute(self):
         """Relative and absolute path forms of the same file are treated as the same."""
         notifier = _make_notifier()

--- a/tests/unit/test_remote_credentials.py
+++ b/tests/unit/test_remote_credentials.py
@@ -57,11 +57,3 @@ def test_addressing_inferred_and_overridden(make_storage_entry):
     assert S3ProviderConfig._resolve_addressing(make_storage_entry(
         endpoint=None, region="us-east-1", ambient_auth=True,
         access_key="", secret_key="", addressing_style="path")) == "path"
-
-def test_construction_wires_all_resolved_fields(make_storage_entry):
-    # custom-store entry: all four resolvers should wire together on the instance
-    provider = S3ProviderConfig(make_storage_entry(secure=True))
-    assert provider.endpoint_url == "https://minio.local:9000"
-    assert provider.region == "us-east-1"           # endpoint set, no explicit region
-    assert provider.addressing_style == "path"      # inferred from endpoint
-    assert (provider.access_key, provider.secret_key) == ("a", "s")

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -720,6 +720,30 @@ class TestExporterReturnValue:
         assert result.status is ExportStatus.SUCCESS
         assert [o.dest for o in result.uploads] == ["bucket/export.tgz"]
         assert result.removed == ["/local/export.tgz"]
+        assert result.cleanup_error is None
+
+    def test_local_cleanup_failure_downgrades_to_partial(self, monkeypatch):
+        """clean_up() raising must not fail the run: the export and uploads already
+        produced durable copies, so a failed local prune is housekeeping (mirrors the
+        remote retention-failure pattern in archiver._upload)."""
+        config = _make_exporter_config("pages")
+        mock_archiver, _ = _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={10: MagicMock()}
+        )
+        mock_archiver.has_exported_content = True
+        mock_archiver.archive_remote.return_value = [
+            UploadOutcome("s3/b", "bucket/export.tgz", None)]
+        mock_archiver.resolve_remote_status.return_value = ExportStatus.SUCCESS
+        mock_archiver.clean_up.side_effect = OSError("permission denied")
+        mock_archiver.archive_file = "/local/export.tgz"
+
+        result = run.exporter(config)
+
+        assert isinstance(result, NotifyResult)
+        assert result.status is ExportStatus.PARTIAL
+        assert not result.removed
+        assert "permission denied" in result.cleanup_error
 
     def test_success_path_do_notify_called_with_result(self, monkeypatch):
         """On success, run() calls do_notify(result=<NotifyResult>)."""


### PR DESCRIPTION
Pre-v3.0.0 window improvements promoted from the post-v3 backlog (`.claude/_plans/2026-07-02-post-v3-backlog.md`, items D1, D2, S1, S3). Follows #149; intended to land before the v3.0.0 tag.

## Changes

- **Local cleanup failure downgrades run to PARTIAL instead of FAILED** (`fix`): `archive.clean_up()` raising in `run.exporter()` no longer fails the run — at that point the export and every upload already produced durable copies. New `NotifyResult.cleanup_error` field carries the message; the notification body gains a `Warning: local cleanup failed - <err>` line; status/exit-code/healthcheck wiring (PARTIAL → exit 3 → degraded → `on_failure` notify) is the pre-existing path. Mirrors the remote retention-failure pattern in `archiver._upload`.
- **Multi-target uploads run concurrently** (`feat`): `Archiver.archive_remote()` uses a `ThreadPoolExecutor` with `max_workers=min(len(targets), 4)`; no config knob (can be added later non-breaking). Each `_upload` already constructs its own `S3CompatibleArchiver` with its own `boto3.session.Session`, so no client state is shared across threads; `_upload` never raises, and `executor.map` preserves config order. Two previously order-dependent mock tests rewritten keyed-by-target-name; new `Barrier(2)`-based test proves both uploads are in flight simultaneously.
- **`S3StorageConfig.is_aws` property** (`refactor`): single-sources the "no `endpoint` ⇒ AWS S3" discriminant previously re-derived in 4 places (`_check_region_for_aws` validator + the three `S3ProviderConfig` resolvers). Truthiness deliberately (empty-string endpoint still selects AWS); behavior unchanged.
- **Deleted duplicate test** (`test`): `test_construction_wires_all_resolved_fields` in `test_remote_credentials.py` was a strict subset of `test_holds_boto3_ready_values` in `test_remote_config.py`; its one unique aspect (`secure=True` → `https`) has its own dedicated resolver test.

Docs: `docs/remote-storage.md` extended for both behavior changes (concurrent targets + local-cleanup PARTIAL semantics).

## Motivation

The first two items change observable run semantics (cleanup failure: FAILED/exit-1 → PARTIAL/exit-3; uploads: serial → concurrent with interleaved per-target logs) — cleanest to land inside the v3.0.0 major boundary rather than after the tag.

## Test plan / verification

- `pytest tests/unit -q` → **651 passed** (baseline on main is 647: +3 D1, +1 D2, +1 S1, −1 S3)
- `pylint bookstack_file_exporter` → 10.00/10; aggregate (`bookstack_file_exporter tests`) → 10.00/10
- `examples/config.yml` still parses through `UserInput`
- Concurrency test run repeatedly (3×) to spot-check flakiness — stable, ~0.5s; a serial regression is caught deterministically (barrier timeout → error outcome → assert fails, no hang)
- Each item implemented TDD (failing test observed first); per-task spec + code-quality review plus a final whole-branch review

## In-depth

- **Assumption/known gap:** D2 has no live multi-target benchmark (single MinIO instance in the test lab); the speedup rationale is the same I/O-bound argument as the existing `export_workers` pool. Backlog trigger for measuring stands.
- **Known lint note:** `test_run.py` crossed pylint's `max-module-lines` (1014/1000, C0302; score unaffected, CI green). Left visible rather than suppressed — follow-up: split the module.
- Pre-existing (not introduced here, D1 makes it visible): if `clean_up()` deletes some files then raises, `NotifyResult.removed` under-reports the files that were deleted. Candidate for backlog.
- Remaining backlog items (D3 provider restructure, S2/S4/S5) stay deliberately skipped with revisit triggers recorded in the backlog doc.
