### PR TITLE
feat: grouped failure bullets + opt-in markdown notification body

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -198,12 +198,12 @@ class Archiver:
         # Upload landed. A retention-prune failure is housekeeping, not a backup failure:
         # keep dest (never flip to failed) but flag a warning so the run is degraded.
         try:
-            archiver.clean_up(self._archiver.file_extension_map['tgz'])
+            pruned = archiver.clean_up(self._archiver.file_extension_map['tgz'])
         except Exception as err:  # pylint: disable=broad-except
             log.error("Remote retention cleanup for target '%s' failed (upload OK): %s",
                       label, err)
             return UploadOutcome(label=label, dest=dest, error=None, warning=str(err))
-        return UploadOutcome(label=label, dest=dest, error=None)
+        return UploadOutcome(label=label, dest=dest, error=None, pruned=pruned)
 
     def resolve_remote_status(self, outcomes: list[UploadOutcome]) -> ExportStatus:
         """Derive run status from upload outcomes. Raise AggregateUploadError only when

--- a/bookstack_file_exporter/archiver/s3_archiver.py
+++ b/bookstack_file_exporter/archiver/s3_archiver.py
@@ -86,13 +86,14 @@ class S3CompatibleArchiver:
         log.info("Uploaded object: %s to bucket: %s", object_path, self.bucket)
         return f"{self.bucket}/{object_path}"
 
-    def clean_up(self, file_extension: str):
-        """delete objects based on 'keep_last' number"""
+    def clean_up(self, file_extension: str) -> int:
+        """delete objects based on 'keep_last' number; return number deleted"""
         if not self.keep_last:  # captures keep_last == 0
-            return
+            return 0
         to_delete = self._get_stale_objects(file_extension)
         if to_delete:
             self._delete_objects(to_delete)
+        return len(to_delete)
 
     def _scan_objects(self, file_extension: str) -> list[dict]:
         """List managed objects directly under the prefix (top-level only).

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -179,6 +179,7 @@ class AppRiseNotifyConfig(StrictModel):
     custom_attachment_path: str | None = ""
     on_success: bool | None = False
     on_failure: bool | None = True
+    body_format: Literal["text", "markdown"] = "text"
 
 class Notifications(StrictModel):
     """YAML schema for user provided notification settings"""

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -28,6 +28,7 @@ class AppRiseNotifyConfig:
         self.custom_attachment = config.custom_attachment_path
         self.on_success = config.on_success
         self.on_failure = config.on_failure
+        self.body_format = config.body_format
 
     def validate(self) -> None:
         """Validate apprise configuration (pure predicate over resolved state)."""

--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -16,6 +16,7 @@ class UploadOutcome:
     dest: str | None = None     # "bucket/object" on success
     error: str | None = None    # str(exception) on upload failure
     warning: str | None = None  # str(exception) when upload OK but retention cleanup failed
+    pruned: int = 0             # objects deleted by remote retention (0 when cleanup failed)
 
 
 @dataclass

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -112,9 +112,15 @@ class AppRiseNotify:
                     failed.append(f"- {outcome.label}: {outcome.error}")
                 elif outcome.warning:
                     warnings.append(f"- {outcome.label}: {outcome.warning}")
-            pruned_count = len(removed_abs - {local_abs})
-            if pruned_count > 0:
-                lines.extend(["", f"Pruned {pruned_count} old local archive(s)"])
+            # Pruned: group covers local retention plus per-target remote retention,
+            # local bullet first, zero-count targets omitted.
+            pruned_local = len(removed_abs - {local_abs})
+            pruned = [f"- local: {pruned_local} archive(s)"] if pruned_local > 0 else []
+            pruned.extend(f"- {o.label}: {o.pruned} archive(s)"
+                          for o in result.uploads if o.pruned > 0)
+            if pruned:
+                lines.extend(["", "Pruned:"])
+                lines.extend(pruned)
         if result is not None and result.cleanup_error:
             warnings.append(f"- local cleanup failed: {result.cleanup_error}")
         if failed:
@@ -164,11 +170,13 @@ class AppRiseNotify:
                     failed.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.error)}")
                 elif outcome.warning:
                     warnings.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.warning)}")
-            pruned_count = len(removed_abs - {local_abs})
-            if pruned_count > 0:
-                # blank line first: a plain line straight after the upload bullets
-                # would be lazily absorbed into the last bullet in MARKDOWN->HTML
-                lines.extend(["", f"Pruned {pruned_count} old local archive(s)"])
+            pruned_local = len(removed_abs - {local_abs})
+            pruned = [f"- local: {pruned_local} archive(s)"] if pruned_local > 0 else []
+            pruned.extend(f"- {_md_code(o.label)}: {o.pruned} archive(s)"
+                          for o in result.uploads if o.pruned > 0)
+            if pruned:
+                lines.extend(["", "**Pruned:**", ""])
+                lines.extend(pruned)
         if result is not None and result.cleanup_error:
             warnings.append(f"- local cleanup failed: {_md_code(result.cleanup_error)}")
         # Blank line before AND after each group header: without the leading one,

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -117,10 +117,10 @@ class AppRiseNotify:
         if result is not None and result.cleanup_error:
             warnings.append(f"- local cleanup failed: {result.cleanup_error}")
         if failed:
-            lines.append("Failed:")
+            lines.extend(["", "Failed:"])
             lines.extend(failed)
         if warnings:
-            lines.append("Warnings:")
+            lines.extend(["", "Warnings:"])
             lines.extend(warnings)
         return "\n".join(lines)
 

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -20,15 +20,17 @@ def _md_code(text: str) -> str:
     return f"`{text}`"
 
 def _pruned_bullets(result: NotifyResult, local_abs: str, removed_abs: set[str],
-                    fmt_label) -> list[str]:
+                    wrap_labels: bool = False) -> list[str]:
     """Bullets for the Pruned: group, shared by both renderers: local retention
     count first, then one bullet per remote target that deleted objects
-    (zero-count targets omitted). fmt_label wraps untrusted target labels
-    (identity for text, _md_code for markdown)."""
+    (zero-count targets omitted). wrap_labels=True runs the untrusted target
+    labels through _md_code (markdown mode)."""
     pruned_local = len(removed_abs - {local_abs})
     bullets = [f"- local: {pruned_local} archive(s)"] if pruned_local > 0 else []
-    bullets.extend(f"- {fmt_label(o.label)}: {o.pruned} archive(s)"
-                   for o in result.uploads if o.pruned > 0)
+    for outcome in result.uploads:
+        if outcome.pruned > 0:
+            label = _md_code(outcome.label) if wrap_labels else outcome.label
+            bullets.append(f"- {label}: {outcome.pruned} archive(s)")
     return bullets
 
 # pylint: disable=too-few-public-methods
@@ -124,7 +126,7 @@ class AppRiseNotify:
                     failed.append(f"- {outcome.label}: {outcome.error}")
                 elif outcome.warning:
                     warnings.append(f"- {outcome.label}: {outcome.warning}")
-            pruned = _pruned_bullets(result, local_abs, removed_abs, lambda l: l)
+            pruned = _pruned_bullets(result, local_abs, removed_abs)
             if pruned:
                 lines.extend(["", "Pruned:"])
                 lines.extend(pruned)
@@ -177,7 +179,7 @@ class AppRiseNotify:
                     failed.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.error)}")
                 elif outcome.warning:
                     warnings.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.warning)}")
-            pruned = _pruned_bullets(result, local_abs, removed_abs, _md_code)
+            pruned = _pruned_bullets(result, local_abs, removed_abs, wrap_labels=True)
             if pruned:
                 lines.extend(["", "**Pruned:**", ""])
                 lines.extend(pruned)

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -70,6 +70,12 @@ class AppRiseNotify:
                     if partial else
                     "Bookstack File Exporter completed successfully.")
         lines = ["", headline, "", f"Completed At: {timestamp}"]
+        # Grouped trailers: every failed upload becomes a bullet under one "Failed:"
+        # header; per-target retention warnings and a local cleanup failure share one
+        # "Warnings:" header (one visual language for "non-fatal"). Plain "- " bullets
+        # render sensibly in both text and markdown notification targets.
+        failed: list[str] = []
+        warnings: list[str] = []
         if result is not None and result.local is not None:
             local_abs = os.path.abspath(result.local)
             removed_abs = {os.path.abspath(p) for p in result.removed}
@@ -78,20 +84,26 @@ class AppRiseNotify:
                 archive_line += " (removed locally after upload)"
             lines.append(archive_line)
             # Preserve the concise "Uploaded to:" success line for targets that succeeded;
-            # list any failures explicitly below it (partial runs).
+            # failures are grouped explicitly below it (partial runs).
             ok_dests = [o.dest for o in result.uploads if o.dest]
             if ok_dests:
                 lines.append(f"Uploaded to: {', '.join(ok_dests)}")
             for outcome in result.uploads:
                 if not outcome.dest:
-                    lines.append(f"Failed: {outcome.label} - {outcome.error}")
+                    failed.append(f"- {outcome.label}: {outcome.error}")
                 elif outcome.warning:
-                    lines.append(f"Warning: {outcome.label} - {outcome.warning}")
+                    warnings.append(f"- {outcome.label}: {outcome.warning}")
             pruned_count = len(removed_abs - {local_abs})
             if pruned_count > 0:
                 lines.append(f"Pruned {pruned_count} old local archive(s)")
         if result is not None and result.cleanup_error:
-            lines.append(f"Warning: local cleanup failed - {result.cleanup_error}")
+            warnings.append(f"- local cleanup failed: {result.cleanup_error}")
+        if failed:
+            lines.append("Failed:")
+            lines.extend(failed)
+        if warnings:
+            lines.append("Warnings:")
+            lines.extend(warnings)
         return "\n".join(lines)
 
     def notify(self, excep: Exception | None = None, result: NotifyResult | None = None):

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -167,13 +167,14 @@ class AppRiseNotify:
                 lines.append(f"Pruned {pruned_count} old local archive(s)")
         if result is not None and result.cleanup_error:
             warnings.append(f"- local cleanup failed: {_md_code(result.cleanup_error)}")
+        # Blank line before AND after each group header: without the leading one,
+        # CommonMark lazy continuation absorbs the header into the preceding bullet
+        # list; without the trailing one, the bullets never become a <ul>.
         if failed:
-            lines.append("**Failed:**")
-            lines.append("")
+            lines.extend(["", "**Failed:**", ""])
             lines.extend(failed)
         if warnings:
-            lines.append("**Warnings:**")
-            lines.append("")
+            lines.extend(["", "**Warnings:**", ""])
             lines.extend(warnings)
         return "\n".join(lines)
 

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -7,6 +7,18 @@ from bookstack_file_exporter.notify.models import NotifyResult, ExportStatus
 
 _DEFAULT_TITLE_PREFIX = "Bookstack File Exporter "
 
+def _md_code(text: str) -> str:
+    """Wrap untrusted interpolated text in a markdown code span.
+
+    Code spans are the sanitizer for the markdown body: python-markdown escapes
+    <>& inside them, so error strings containing raw HTML cannot be swallowed by
+    HTML-native targets (apprise's MARKDOWN->HTML conversion does NOT escape,
+    verified against apprise 1.10.0). Double-backtick delimiters with space
+    padding tolerate single backticks inside the text (CommonMark)."""
+    if "`" in text:
+        return f"`` {text} ``"
+    return f"`{text}`"
+
 # pylint: disable=too-few-public-methods
 class AppRiseNotify:
     """
@@ -55,6 +67,12 @@ class AppRiseNotify:
 
     def _get_message_text(self, error_msg: None | Exception,
                           result: NotifyResult | None = None) -> str:
+        if self.config.body_format == "markdown":
+            return self._markdown_body(error_msg, result)
+        return self._text_body(error_msg, result)
+
+    def _text_body(self, error_msg: None | Exception,
+                   result: NotifyResult | None = None) -> str:
         timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
         if error_msg:
             return "\n".join([
@@ -103,6 +121,59 @@ class AppRiseNotify:
             lines.extend(failed)
         if warnings:
             lines.append("Warnings:")
+            lines.extend(warnings)
+        return "\n".join(lines)
+
+    def _markdown_body(self, error_msg: None | Exception,
+                       result: NotifyResult | None = None) -> str:
+        # Mirrors _text_body's structure exactly (same content, same order) with
+        # markdown emphasis on headline/group headers and every interpolated
+        # untrusted value wrapped in _md_code(). See _md_code for why the wrapping
+        # is mandatory (apprise's MARKDOWN->HTML conversion does not escape HTML).
+        timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        if error_msg:
+            return "\n".join([
+                "",
+                "**Bookstack File Exporter encountered an unrecoverable error.**",
+                "",
+                f"Occurred At: {timestamp}",
+                "",
+                f"Error message: {_md_code(str(error_msg))}",
+            ])
+        partial = result is not None and result.status is ExportStatus.PARTIAL
+        headline = ("**Bookstack File Exporter completed with errors.**"
+                    if partial else
+                    "**Bookstack File Exporter completed successfully.**")
+        lines = ["", headline, "", f"Completed At: {timestamp}"]
+        failed: list[str] = []
+        warnings: list[str] = []
+        if result is not None and result.local is not None:
+            local_abs = os.path.abspath(result.local)
+            removed_abs = {os.path.abspath(p) for p in result.removed}
+            archive_line = f"Archive: {_md_code(result.local)}"
+            if local_abs in removed_abs:
+                archive_line += " (removed locally after upload)"
+            lines.append(archive_line)
+            ok_dests = [_md_code(o.dest) for o in result.uploads if o.dest]
+            if ok_dests:
+                lines.append(f"Uploaded to: {', '.join(ok_dests)}")
+            for outcome in result.uploads:
+                if not outcome.dest:
+                    failed.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.error)}")
+                elif outcome.warning:
+                    warnings.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.warning)}")
+            pruned_count = len(removed_abs - {local_abs})
+            if pruned_count > 0:
+                lines.append(f"Pruned {pruned_count} old local archive(s)")
+        if result is not None and result.cleanup_error:
+            warnings.append(f"- local cleanup failed: {_md_code(result.cleanup_error)}")
+        if failed:
+            lines.append("**Failed:**")
+            lines.append("")
+            lines.extend(failed)
+        if warnings:
+            lines.append("**Warnings:**")
+            lines.append("")
             lines.extend(warnings)
         return "\n".join(lines)
 

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -19,6 +19,18 @@ def _md_code(text: str) -> str:
         return f"`` {text} ``"
     return f"`{text}`"
 
+def _pruned_bullets(result: NotifyResult, local_abs: str, removed_abs: set[str],
+                    fmt_label) -> list[str]:
+    """Bullets for the Pruned: group, shared by both renderers: local retention
+    count first, then one bullet per remote target that deleted objects
+    (zero-count targets omitted). fmt_label wraps untrusted target labels
+    (identity for text, _md_code for markdown)."""
+    pruned_local = len(removed_abs - {local_abs})
+    bullets = [f"- local: {pruned_local} archive(s)"] if pruned_local > 0 else []
+    bullets.extend(f"- {fmt_label(o.label)}: {o.pruned} archive(s)"
+                   for o in result.uploads if o.pruned > 0)
+    return bullets
+
 # pylint: disable=too-few-public-methods
 class AppRiseNotify:
     """
@@ -112,12 +124,7 @@ class AppRiseNotify:
                     failed.append(f"- {outcome.label}: {outcome.error}")
                 elif outcome.warning:
                     warnings.append(f"- {outcome.label}: {outcome.warning}")
-            # Pruned: group covers local retention plus per-target remote retention,
-            # local bullet first, zero-count targets omitted.
-            pruned_local = len(removed_abs - {local_abs})
-            pruned = [f"- local: {pruned_local} archive(s)"] if pruned_local > 0 else []
-            pruned.extend(f"- {o.label}: {o.pruned} archive(s)"
-                          for o in result.uploads if o.pruned > 0)
+            pruned = _pruned_bullets(result, local_abs, removed_abs, lambda l: l)
             if pruned:
                 lines.extend(["", "Pruned:"])
                 lines.extend(pruned)
@@ -170,10 +177,7 @@ class AppRiseNotify:
                     failed.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.error)}")
                 elif outcome.warning:
                     warnings.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.warning)}")
-            pruned_local = len(removed_abs - {local_abs})
-            pruned = [f"- local: {pruned_local} archive(s)"] if pruned_local > 0 else []
-            pruned.extend(f"- {_md_code(o.label)}: {o.pruned} archive(s)"
-                          for o in result.uploads if o.pruned > 0)
+            pruned = _pruned_bullets(result, local_abs, removed_abs, _md_code)
             if pruned:
                 lines.extend(["", "**Pruned:**", ""])
                 lines.extend(pruned)

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -1,6 +1,6 @@
 import os
 from datetime import datetime
-from apprise import Apprise, AppriseAsset, AppriseConfig
+from apprise import Apprise, AppriseAsset, AppriseConfig, NotifyFormat
 
 from bookstack_file_exporter.config_helper import notifications
 from bookstack_file_exporter.notify.models import NotifyResult, ExportStatus
@@ -181,14 +181,19 @@ class AppRiseNotify:
         """send notification with exception message"""
         custom_body = self._get_message_text(excep, result)
         title_ = self._get_title(excep, result)
+        body_format_ = (NotifyFormat.MARKDOWN
+                         if self.config.body_format == "markdown"
+                         else NotifyFormat.TEXT)
         if self.config.custom_attachment:
             self._client.notify(
                 title=title_,
                 body=custom_body,
-                attach=self.config.custom_attachment
+                attach=self.config.custom_attachment,
+                body_format=body_format_
             )
         else:
             self._client.notify(
                 title=title_,
-                body=custom_body
+                body=custom_body,
+                body_format=body_format_
             )

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -101,11 +101,12 @@ class AppRiseNotify:
             if local_abs in removed_abs:
                 archive_line += " (removed locally after upload)"
             lines.append(archive_line)
-            # Preserve the concise "Uploaded to:" success line for targets that succeeded;
-            # failures are grouped explicitly below it (partial runs).
-            ok_dests = [o.dest for o in result.uploads if o.dest]
-            if ok_dests:
-                lines.append(f"Uploaded to: {', '.join(ok_dests)}")
+            # Successful targets get labeled bullets under one "Uploaded to:" header,
+            # the same visual language as the Failed:/Warnings: groups below.
+            ok_uploads = [o for o in result.uploads if o.dest]
+            if ok_uploads:
+                lines.extend(["", "Uploaded to:"])
+                lines.extend(f"- {o.label}: {o.dest}" for o in ok_uploads)
             for outcome in result.uploads:
                 if not outcome.dest:
                     failed.append(f"- {outcome.label}: {outcome.error}")
@@ -113,7 +114,7 @@ class AppRiseNotify:
                     warnings.append(f"- {outcome.label}: {outcome.warning}")
             pruned_count = len(removed_abs - {local_abs})
             if pruned_count > 0:
-                lines.append(f"Pruned {pruned_count} old local archive(s)")
+                lines.extend(["", f"Pruned {pruned_count} old local archive(s)"])
         if result is not None and result.cleanup_error:
             warnings.append(f"- local cleanup failed: {result.cleanup_error}")
         if failed:
@@ -154,9 +155,10 @@ class AppRiseNotify:
             if local_abs in removed_abs:
                 archive_line += " (removed locally after upload)"
             lines.append(archive_line)
-            ok_dests = [_md_code(o.dest) for o in result.uploads if o.dest]
-            if ok_dests:
-                lines.append(f"Uploaded to: {', '.join(ok_dests)}")
+            ok_uploads = [o for o in result.uploads if o.dest]
+            if ok_uploads:
+                lines.extend(["", "**Uploaded to:**", ""])
+                lines.extend(f"- {_md_code(o.label)}: {_md_code(o.dest)}" for o in ok_uploads)
             for outcome in result.uploads:
                 if not outcome.dest:
                     failed.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.error)}")
@@ -164,7 +166,9 @@ class AppRiseNotify:
                     warnings.append(f"- {_md_code(outcome.label)}: {_md_code(outcome.warning)}")
             pruned_count = len(removed_abs - {local_abs})
             if pruned_count > 0:
-                lines.append(f"Pruned {pruned_count} old local archive(s)")
+                # blank line first: a plain line straight after the upload bullets
+                # would be lazily absorbed into the last bullet in MARKDOWN->HTML
+                lines.extend(["", f"Pruned {pruned_count} old local archive(s)"])
         if result is not None and result.cleanup_error:
             warnings.append(f"- local cleanup failed: {_md_code(result.cleanup_error)}")
         # Blank line before AND after each group header: without the leading one,

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -36,9 +36,11 @@ Uploaded to:
 - minio-main: my-bucket/bookstack/bookstack_export_2025-09-06_010527.tgz
 - aws-s3: my-bucket-s3/bookstack/bookstack_export_2025-09-06_010527.tgz
 
-Pruned 2 old local archive(s)
+Pruned:
+- local: 2 archive(s)
+- aws-s3: 1 archive(s)
 ```
-The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each successful target as a `- name: destination` bullet, and `Pruned N old local archive(s)` appears when `keep_last` removed older archives.
+The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each successful target as a `- name: destination` bullet, and the `Pruned:` group shows how many old archives `keep_last` retention removed — `local` for the export directory plus one bullet per remote target that deleted objects (zero-count targets are omitted).
 
 ### Body Format
 By default the notification body is sent as plain text (`body_format: text`), as shown in the examples above. Set `apprise.body_format: markdown` to render the body as Markdown instead: the headline and the `Failed:`/`Warnings:` group headers become bold, failed targets and warnings render as real bullet lists, and values like paths, destinations, and error messages are quoted in code spans.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -31,10 +31,14 @@ Bookstack File Exporter completed successfully.
 
 Completed At: 2025-09-06 01:05:27
 Archive: bkps/bookstack_export_2025-09-06_010527.tgz (removed locally after upload)
-Uploaded to: my-bucket/bookstack, my-bucket-s3/bookstack
+
+Uploaded to:
+- minio-main: my-bucket/bookstack/bookstack_export_2025-09-06_010527.tgz
+- aws-s3: my-bucket-s3/bookstack/bookstack_export_2025-09-06_010527.tgz
+
 Pruned 2 old local archive(s)
 ```
-The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each remote destination, and `Pruned N old local archive(s)` appears when `keep_last` removed older archives.
+The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each successful target as a `- name: destination` bullet, and `Pruned N old local archive(s)` appears when `keep_last` removed older archives.
 
 ### Body Format
 By default the notification body is sent as plain text (`body_format: text`), as shown in the examples above. Set `apprise.body_format: markdown` to render the body as Markdown instead: the headline and the `Failed:`/`Warnings:` group headers become bold, failed targets and warnings render as real bullet lists, and values like paths, destinations, and error messages are quoted in code spans.

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -36,6 +36,21 @@ Pruned 2 old local archive(s)
 ```
 The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each remote destination, and `Pruned N old local archive(s)` appears when `keep_last` removed older archives.
 
+### Body Format
+By default the notification body is sent as plain text (`body_format: text`), as shown in the examples above. Set `apprise.body_format: markdown` to render the body as Markdown instead: the headline and the `Failed:`/`Warnings:` group headers become bold, failed targets and warnings render as real bullet lists, and values like paths, destinations, and error messages are quoted in code spans.
+```yaml
+notifications:
+  apprise:
+    service_urls:
+      - "slack://TokenA/TokenB/TokenC/"
+    body_format: markdown
+```
+Whether `markdown` is an improvement depends on your notification targets:
+- Markdown-native targets (e.g. Slack) and HTML-native targets (e.g. Telegram, email) render the bold headers, bullet lists, and code-quoted error messages properly.
+- Plain-text targets (e.g. generic `json://` webhooks, ntfy, SMS) will show the literal `**` and backtick characters — apprise passes a Markdown body through to text targets unchanged, it does not strip the markup. This is why `markdown` is opt-in; choose based on your target mix.
+
+`body_format` is the input-side knob: it tells apprise what format the body is written in, and apprise then converts it to each service URL's native format. To override the target-side format for a specific URL, use apprise's per-URL `?format=` parameter (e.g. `json://host/notify?format=markdown`) — see the [apprise wiki](https://github.com/caronc/apprise/wiki) for details.
+
 ## apprise
 The apprise configuration is a part of the configuration yaml file under the notifications section and can be modified under `notifications.apprise`.
 
@@ -49,6 +64,7 @@ The apprise configuration is a part of the configuration yaml file under the not
 | `apprise.custom_attachment_path` | `str` | To include a custom attachment to the apprise notification, specify the path to a file | 
 | `apprise.on_success` | `bool` | Default: `false`, set to `true` if notifications should be sent on successful export runs |
 | `apprise.on_failure` | `bool` | Default: `true`, send notifications if run fails |
+| `apprise.body_format` | `str` | Default: `text`, set to `markdown` to render the notification body as Markdown. See [Body Format](#body-format) for the trade-offs |
 
 `apprise.service_urls` can contain sensitive information and can be specified as an environment variable instead as a string list, example: `export APPRISE_URLS='["json://localhost:8080/notify"]'`.
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -43,7 +43,7 @@ Pruned:
 The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each successful target as a `- name: destination` bullet, and the `Pruned:` group shows how many old archives `keep_last` retention removed — `local` for the export directory plus one bullet per remote target that deleted objects (zero-count targets are omitted).
 
 ### Body Format
-By default the notification body is sent as plain text (`body_format: text`), as shown in the examples above. Set `apprise.body_format: markdown` to render the body as Markdown instead: the headline and the `Failed:`/`Warnings:` group headers become bold, failed targets and warnings render as real bullet lists, and values like paths, destinations, and error messages are quoted in code spans.
+By default the notification body is sent as plain text (`body_format: text`), as shown in the examples above. Set `apprise.body_format: markdown` to render the body as Markdown instead: the headline and the `Uploaded to:`/`Pruned:`/`Failed:`/`Warnings:` group headers become bold, each group renders as a real bullet list, and values like paths, destinations, and error messages are quoted in code spans.
 ```yaml
 notifications:
   apprise:

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -143,3 +143,7 @@ notifications:
     custom_attachment_path: ""
     on_success: false
     on_failure: true
+    # optional - "text" (default) or "markdown"; markdown adds bold headers, bullet
+    # lists, and code-quoted values for markdown/HTML-capable targets (e.g. Slack,
+    # Telegram, email) but shows literal markup on plain-text targets
+    body_format: "text"

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -589,6 +589,22 @@ def test_resolve_status_empty_is_success(archiver_instance):
     assert archiver_instance.resolve_remote_status([]) is ExportStatus.SUCCESS
 
 
+def test_archive_remote_records_pruned_count(archiver_instance, mock_config):
+    """Remote retention deletions are carried on the outcome for notifications."""
+    mock_config.object_storage_config = [_provider_entry("s3/aws")]
+    inst = MagicMock()
+    inst.upload_backup.return_value = "s3-aws/a.tgz"
+    inst.clean_up.return_value = 3
+    archiver_instance._s3_archiver_cls = MagicMock(return_value=inst)
+    archiver_instance._archiver.archive_file = "/local/archive.tgz"
+    archiver_instance._archiver.file_extension_map = {"tgz": ".tgz"}
+
+    outcomes = archiver_instance.archive_remote()
+
+    assert outcomes[0].dest == "s3-aws/a.tgz"
+    assert outcomes[0].pruned == 3
+
+
 def test_archive_remote_retention_failure_is_warning_not_failure(archiver_instance, mock_config):
     """Upload succeeds but remote retention cleanup raises -> dest kept, warning set."""
     mock_config.object_storage_config = [_provider_entry("s3/aws")]

--- a/tests/unit/test_models_notify.py
+++ b/tests/unit/test_models_notify.py
@@ -1,0 +1,21 @@
+# pylint: disable=missing-function-docstring
+"""Unit tests for AppRiseNotifyConfig validation in models.py."""
+import pytest
+from pydantic import ValidationError
+
+from bookstack_file_exporter.config_helper.models import AppRiseNotifyConfig
+
+
+def test_body_format_defaults_to_text():
+    cfg = AppRiseNotifyConfig(service_urls=["json://localhost"])
+    assert cfg.body_format == "text"
+
+
+def test_body_format_accepts_markdown():
+    cfg = AppRiseNotifyConfig(service_urls=["json://localhost"], body_format="markdown")
+    assert cfg.body_format == "markdown"
+
+
+def test_body_format_rejects_unknown():
+    with pytest.raises(ValidationError):
+        AppRiseNotifyConfig(service_urls=["json://localhost"], body_format="html")

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -79,7 +79,7 @@ class TestGetMessageTextSuccessBranch:
         body = notifier._get_message_text(None, result=result)
         # local is in removed (suffix present) + 2 old archives pruned
         assert "(removed locally after upload)" in body
-        assert "Pruned 2 old local archive(s)" in body
+        assert "\n\nPruned:\n- local: 2 archive(s)" in body
 
     def test_old_files_only_no_local_in_removed(self):
         notifier = _make_notifier()
@@ -88,7 +88,7 @@ class TestGetMessageTextSuccessBranch:
         result = NotifyResult(local=local, uploads=[], removed=removed)
         body = notifier._get_message_text(None, result=result)
         assert "(removed locally after upload)" not in body
-        assert "Pruned 2 old local archive(s)" in body
+        assert "Pruned:\n- local: 2 archive(s)" in body
 
     def test_cleanup_error_shows_warning_line(self):
         notifier = _make_notifier()
@@ -135,7 +135,7 @@ class TestGetMessageTextSuccessBranch:
         body = notifier._get_message_text(None, result=result)
         # current archive (mixed form) → suffix, NOT counted among pruned old archives
         assert "(removed locally after upload)" in body
-        assert "Pruned 2 old local archive(s)" in body
+        assert "Pruned:\n- local: 2 archive(s)" in body
 
     def test_failure_branch_unchanged_no_archive_lines(self):
         notifier = _make_notifier()
@@ -216,6 +216,31 @@ def test_body_groups_failures_and_warnings_as_bullet_lists():
     assert body.count("Warnings:") == 1
 
 
+def test_body_pruned_group_lists_local_and_remote_targets():
+    """Local prune count and per-target remote retention counts share one
+    Pruned: group, local bullet first, zero-count targets omitted."""
+    inst = _notifier()
+    result = NotifyResult(
+        local="/a/b.tgz",
+        uploads=[UploadOutcome("minio/b", "minio-b/a.tgz", pruned=2),
+                 UploadOutcome("s3/aws", "s3-aws/a.tgz", pruned=0)],
+        removed=["/a/old.tgz"])
+    body = inst._get_message_text(None, result)
+    assert "\n\nPruned:\n- local: 1 archive(s)\n- minio/b: 2 archive(s)" in body
+    assert "s3/aws: 0" not in body
+
+
+def test_body_pruned_group_remote_only():
+    inst = _notifier()
+    result = NotifyResult(
+        local="/a/b.tgz",
+        uploads=[UploadOutcome("s3/aws", "s3-aws/a.tgz", pruned=4)],
+        removed=[])
+    body = inst._get_message_text(None, result)
+    assert "\n\nPruned:\n- s3/aws: 4 archive(s)" in body
+    assert "- local:" not in body
+
+
 def test_body_separates_groups_with_blank_line():
     """A blank line precedes each group header so sections don't run together."""
     inst = _notifier()
@@ -276,6 +301,15 @@ class TestMarkdownBody:
         assert "`Forbidden <edge>`" in body          # wrapped
         assert ": Forbidden <edge>" not in body      # never raw
 
+    def test_markdown_pruned_group_wraps_target_labels(self):
+        notifier = _make_notifier(body_format="markdown")
+        result = NotifyResult(
+            local="/a/b.tgz",
+            uploads=[UploadOutcome("s3/aws", "s3-aws/a.tgz", pruned=2)],
+            removed=["/a/old.tgz"])
+        body = notifier._get_message_text(None, result=result)
+        assert "\n\n**Pruned:**\n\n- local: 1 archive(s)\n- `s3/aws`: 2 archive(s)" in body
+
     def test_markdown_unrecoverable_error_bolded_and_code_wrapped(self):
         notifier = _make_notifier(body_format="markdown")
         body = notifier._get_message_text(RuntimeError("boom <tag> & `tick`"))
@@ -292,7 +326,7 @@ class TestMarkdownBody:
         assert "Archive: `/data/export.tgz` (removed locally after upload)" in body
         # blank line after the upload bullets: a plain line straight after a list
         # would be lazily absorbed into the last bullet in MARKDOWN->HTML
-        assert "- `s3/main`: `b/a.tgz`\n\nPruned 1 old local archive(s)" in body
+        assert "- `s3/main`: `b/a.tgz`\n\n**Pruned:**\n\n- local: 1 archive(s)" in body
         assert "**Warnings:**\n\n- `s3/main`: `retention failed <x>`" in body
 
     def test_text_mode_output_unchanged(self):

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -91,7 +91,7 @@ class TestGetMessageTextSuccessBranch:
         result = NotifyResult(status=ExportStatus.PARTIAL, local="/data/export.tgz",
                               uploads=[], removed=[], cleanup_error="permission denied")
         body = notifier._get_message_text(None, result=result)
-        assert "Warning: local cleanup failed - permission denied" in body
+        assert "Warnings:\n- local cleanup failed: permission denied" in body
         assert "completed with errors" in body
 
     def test_no_cleanup_error_no_warning_line(self):
@@ -181,7 +181,7 @@ def test_body_lists_ok_and_failed_targets():
                  UploadOutcome("s3/dr", None, "connection refused")])
     body = inst._get_message_text(None, result)
     assert "Uploaded to: minio-b/a.tgz" in body      # ok target -> dest
-    assert "Failed: s3/dr - connection refused" in body  # failed target -> label + error
+    assert "Failed:\n- s3/dr: connection refused" in body  # failed target -> bullet under header
 
 
 def test_body_lists_retention_warning():
@@ -191,4 +191,22 @@ def test_body_lists_retention_warning():
         uploads=[UploadOutcome("s3/aws", "s3-aws/a.tgz", None, "delete denied")])
     body = inst._get_message_text(None, result)
     assert "Uploaded to: s3-aws/a.tgz" in body
-    assert "Warning: s3/aws - delete denied" in body
+    assert "Warnings:\n- s3/aws: delete denied" in body
+
+
+def test_body_groups_failures_and_warnings_as_bullet_lists():
+    """All failure bullets sit under one Failed: header; per-target retention
+    warnings and the local cleanup error share one Warnings: header."""
+    inst = _notifier()
+    result = NotifyResult(
+        status=ExportStatus.PARTIAL, local="/a/b.tgz",
+        uploads=[UploadOutcome("minio/b", None, "connection refused"),
+                 UploadOutcome("s3/dr", None, "Forbidden"),
+                 UploadOutcome("s3/aws", "s3-aws/a.tgz", None, "delete denied")],
+        cleanup_error="permission denied")
+    body = inst._get_message_text(None, result)
+    assert "Failed:\n- minio/b: connection refused\n- s3/dr: Forbidden" in body
+    assert ("Warnings:\n- s3/aws: delete denied\n"
+            "- local cleanup failed: permission denied") in body
+    assert body.count("Failed:") == 1
+    assert body.count("Warnings:") == 1

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -68,7 +68,8 @@ class TestGetMessageTextSuccessBranch:
             removed=[],
         )
         body = notifier._get_message_text(None, result=result)
-        assert "Uploaded to: bucket1/backups/export.tgz, bucket2/export.tgz" in body
+        assert ("\n\nUploaded to:\n- t1: bucket1/backups/export.tgz\n"
+                "- t2: bucket2/export.tgz" in body)
 
     def test_removed_has_old_files_shows_pruned_count(self):
         notifier = _make_notifier()
@@ -183,7 +184,7 @@ def test_body_lists_ok_and_failed_targets():
         uploads=[UploadOutcome("minio/b", "minio-b/a.tgz", None),
                  UploadOutcome("s3/dr", None, "connection refused")])
     body = inst._get_message_text(None, result)
-    assert "Uploaded to: minio-b/a.tgz" in body      # ok target -> dest
+    assert "Uploaded to:\n- minio/b: minio-b/a.tgz" in body  # ok target -> labeled bullet
     assert "Failed:\n- s3/dr: connection refused" in body  # failed target -> bullet under header
 
 
@@ -193,7 +194,7 @@ def test_body_lists_retention_warning():
         status=ExportStatus.PARTIAL, local="/a/b.tgz",
         uploads=[UploadOutcome("s3/aws", "s3-aws/a.tgz", None, "delete denied")])
     body = inst._get_message_text(None, result)
-    assert "Uploaded to: s3-aws/a.tgz" in body
+    assert "Uploaded to:\n- s3/aws: s3-aws/a.tgz" in body
     assert "Warnings:\n- s3/aws: delete denied" in body
 
 
@@ -255,7 +256,7 @@ class TestMarkdownBody:
         body = notifier._get_message_text(None, result=self._partial_result())
         assert "**Bookstack File Exporter completed with errors.**" in body
         assert "Archive: `/data/export.tgz`" in body
-        assert "Uploaded to: `minio-b/a.tgz`" in body
+        assert "**Uploaded to:**\n\n- `minio/b`: `minio-b/a.tgz`" in body
         # blank line between header and bullets => real <ul> after conversion
         assert "**Failed:**\n\n- `s3/dr`: `Forbidden <edge>`" in body
         assert "**Warnings:**\n\n- local cleanup failed: `permission denied`" in body
@@ -289,7 +290,9 @@ class TestMarkdownBody:
         notifier = _make_notifier(body_format="markdown")
         body = notifier._get_message_text(None, result=result)
         assert "Archive: `/data/export.tgz` (removed locally after upload)" in body
-        assert "Pruned 1 old local archive(s)" in body
+        # blank line after the upload bullets: a plain line straight after a list
+        # would be lazily absorbed into the last bullet in MARKDOWN->HTML
+        assert "- `s3/main`: `b/a.tgz`\n\nPruned 1 old local archive(s)" in body
         assert "**Warnings:**\n\n- `s3/main`: `retention failed <x>`" in body
 
     def test_text_mode_output_unchanged(self):

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -9,7 +9,7 @@ from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult, Up
 from bookstack_file_exporter.notify.notifiers import AppRiseNotify
 
 
-def _make_notifier():
+def _make_notifier(body_format="text"):
     """Build AppRiseNotify bypassing Apprise client init."""
     instance = AppRiseNotify.__new__(AppRiseNotify)
     config = MagicMock()
@@ -19,6 +19,7 @@ def _make_notifier():
     config.config_path = None
     config.service_urls = []
     config.custom_attachment = None
+    config.body_format = body_format
     instance.config = config
     instance._client = MagicMock()
     return instance
@@ -210,3 +211,50 @@ def test_body_groups_failures_and_warnings_as_bullet_lists():
             "- local cleanup failed: permission denied") in body
     assert body.count("Failed:") == 1
     assert body.count("Warnings:") == 1
+
+
+class TestMdCode:
+    def test_plain_string_single_backticks(self):
+        assert notifiers._md_code("connection refused") == "`connection refused`"
+
+    def test_string_with_backtick_uses_double_delimiters_and_padding(self):
+        # double-backtick delimiters + space padding per CommonMark so an inner
+        # backtick cannot terminate the span
+        assert notifiers._md_code("a `tick` inside") == "`` a `tick` inside ``"
+
+    def test_angle_brackets_survive_inside_span(self):
+        # the whole point: code spans neutralize raw HTML for MARKDOWN->HTML targets
+        out = notifiers._md_code("Forbidden <edge & chars>")
+        assert out == "`Forbidden <edge & chars>`"
+
+
+class TestMarkdownBody:
+    def _partial_result(self):
+        return NotifyResult(
+            status=ExportStatus.PARTIAL, local="/data/export.tgz",
+            uploads=[UploadOutcome("minio/b", "minio-b/a.tgz", None),
+                     UploadOutcome("s3/dr", None, "Forbidden <edge>")],
+            removed=[], cleanup_error="permission denied")
+
+    def test_markdown_body_structure(self):
+        notifier = _make_notifier(body_format="markdown")
+        body = notifier._get_message_text(None, result=self._partial_result())
+        assert "**Bookstack File Exporter completed with errors.**" in body
+        assert "Archive: `/data/export.tgz`" in body
+        assert "Uploaded to: `minio-b/a.tgz`" in body
+        # blank line between header and bullets => real <ul> after conversion
+        assert "**Failed:**\n\n- `s3/dr`: `Forbidden <edge>`" in body
+        assert "**Warnings:**\n\n- local cleanup failed: `permission denied`" in body
+
+    def test_markdown_error_strings_are_code_wrapped(self):
+        notifier = _make_notifier(body_format="markdown")
+        body = notifier._get_message_text(None, result=self._partial_result())
+        assert "`Forbidden <edge>`" in body          # wrapped
+        assert ": Forbidden <edge>" not in body      # never raw
+
+    def test_text_mode_output_unchanged(self):
+        """Default mode must render the exact current text body."""
+        notifier = _make_notifier()  # body_format defaults to text
+        body = notifier._get_message_text(None, result=self._partial_result())
+        assert "Failed:\n- s3/dr: Forbidden <edge>" in body
+        assert "**" not in body and "`" not in body

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -215,6 +215,18 @@ def test_body_groups_failures_and_warnings_as_bullet_lists():
     assert body.count("Warnings:") == 1
 
 
+def test_body_separates_groups_with_blank_line():
+    """A blank line precedes each group header so sections don't run together."""
+    inst = _notifier()
+    result = NotifyResult(
+        status=ExportStatus.PARTIAL, local="/a/b.tgz",
+        uploads=[UploadOutcome("s3/dr", None, "Forbidden")],
+        cleanup_error="permission denied")
+    body = inst._get_message_text(None, result)
+    assert "\n\nFailed:\n- s3/dr: Forbidden" in body
+    assert "\n\nWarnings:\n- local cleanup failed: permission denied" in body
+
+
 class TestMdCode:
     def test_plain_string_single_backticks(self):
         assert notifiers._md_code("connection refused") == "`connection refused`"

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -263,6 +263,23 @@ class TestMarkdownBody:
         assert "`Forbidden <edge>`" in body          # wrapped
         assert ": Forbidden <edge>" not in body      # never raw
 
+    def test_markdown_unrecoverable_error_bolded_and_code_wrapped(self):
+        notifier = _make_notifier(body_format="markdown")
+        body = notifier._get_message_text(RuntimeError("boom <tag> & `tick`"))
+        assert "**Bookstack File Exporter encountered an unrecoverable error.**" in body
+        assert "Error message: `` boom <tag> & `tick` ``" in body
+
+    def test_markdown_warning_pruned_and_removed_suffix(self):
+        result = NotifyResult(
+            status=ExportStatus.PARTIAL, local="/data/export.tgz",
+            uploads=[UploadOutcome("s3/main", "b/a.tgz", warning="retention failed <x>")],
+            removed=["/data/export.tgz", "/data/old.tgz"])
+        notifier = _make_notifier(body_format="markdown")
+        body = notifier._get_message_text(None, result=result)
+        assert "Archive: `/data/export.tgz` (removed locally after upload)" in body
+        assert "Pruned 1 old local archive(s)" in body
+        assert "**Warnings:**\n\n- `s3/main`: `retention failed <x>`" in body
+
     def test_text_mode_output_unchanged(self):
         """Default mode must render the exact current text body."""
         notifier = _make_notifier()  # body_format defaults to text

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -4,6 +4,8 @@
 import os
 from unittest.mock import MagicMock
 
+from apprise import NotifyFormat
+
 from bookstack_file_exporter.notify import notifiers
 from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult, UploadOutcome
 from bookstack_file_exporter.notify.notifiers import AppRiseNotify
@@ -258,3 +260,24 @@ class TestMarkdownBody:
         body = notifier._get_message_text(None, result=self._partial_result())
         assert "Failed:\n- s3/dr: Forbidden <edge>" in body
         assert "**" not in body and "`" not in body
+
+
+class TestNotifyBodyFormat:
+    def test_notify_declares_text_body_format_by_default(self):
+        notifier = _make_notifier()
+        notifier.notify(result=NotifyResult(local=None, uploads=[], removed=[]))
+        kwargs = notifier._client.notify.call_args.kwargs
+        assert kwargs["body_format"] == NotifyFormat.TEXT
+
+    def test_notify_declares_markdown_body_format_when_opted_in(self):
+        notifier = _make_notifier(body_format="markdown")
+        notifier.notify(result=NotifyResult(local=None, uploads=[], removed=[]))
+        kwargs = notifier._client.notify.call_args.kwargs
+        assert kwargs["body_format"] == NotifyFormat.MARKDOWN
+
+    def test_notify_declares_body_format_with_attachment(self):
+        notifier = _make_notifier(body_format="markdown")
+        notifier.config.custom_attachment = "/tmp/export.tgz"
+        notifier.notify(result=NotifyResult(local=None, uploads=[], removed=[]))
+        kwargs = notifier._client.notify.call_args.kwargs
+        assert kwargs["body_format"] == NotifyFormat.MARKDOWN

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -248,6 +248,15 @@ class TestMarkdownBody:
         assert "**Failed:**\n\n- `s3/dr`: `Forbidden <edge>`" in body
         assert "**Warnings:**\n\n- local cleanup failed: `permission denied`" in body
 
+    def test_markdown_group_headers_separated_from_preceding_lines(self):
+        """A blank line must precede each group header too: CommonMark lazy
+        continuation otherwise absorbs **Warnings:** into the last Failed bullet
+        (one merged <ul> after apprise's MARKDOWN->HTML conversion)."""
+        notifier = _make_notifier(body_format="markdown")
+        body = notifier._get_message_text(None, result=self._partial_result())
+        assert "\n\n**Failed:**\n\n" in body
+        assert "\n\n**Warnings:**\n\n" in body
+
     def test_markdown_error_strings_are_code_wrapped(self):
         notifier = _make_notifier(body_format="markdown")
         body = notifier._get_message_text(None, result=self._partial_result())

--- a/tests/unit/test_s3_archiver.py
+++ b/tests/unit/test_s3_archiver.py
@@ -112,16 +112,18 @@ def _seed(client, bucket, keys):
 def test_clean_up_deletes_oldest_beyond_keep_last(aws, provider):
     client = boto3.client("s3", region_name="us-east-1")
     _seed(client, "test-bucket", [f"uploads/bookstack_export_{i}.tgz" for i in range(5)])
-    S3CompatibleArchiver(provider(prefix="uploads", keep_last=2)).clean_up(".tgz")
+    deleted = S3CompatibleArchiver(provider(prefix="uploads", keep_last=2)).clean_up(".tgz")
     remaining = client.list_objects_v2(Bucket="test-bucket").get("Contents", [])
     assert len(remaining) == 2
+    assert deleted == 3
 
 
 def test_clean_up_keep_last_zero_deletes_nothing(aws, provider):
     client = boto3.client("s3", region_name="us-east-1")
     _seed(client, "test-bucket", ["uploads/bookstack_export_1.tgz", "uploads/unrelated.tgz"])
-    S3CompatibleArchiver(provider(prefix="uploads", keep_last=0)).clean_up(".tgz")
+    deleted = S3CompatibleArchiver(provider(prefix="uploads", keep_last=0)).clean_up(".tgz")
     assert len(client.list_objects_v2(Bucket="test-bucket").get("Contents", [])) == 2
+    assert deleted == 0
 
 
 def test_scan_paginates_beyond_1000(aws, provider):


### PR DESCRIPTION
## Changes

- Notification body groups failed targets and warnings as bullet lists (`Failed:` / `Warnings:`, one `- label: message` line each) instead of inline sentences (`1bb7381`).
- `Uploaded to:` is likewise a header with `- name: destination` bullets (`bb68885`), and blank lines separate all body sections in text mode (`f108e26`).
- Per-target pruned counts (`e1af62f`): `s3_archiver.clean_up()` returns its deletion count, carried on a new `UploadOutcome.pruned` field; the body shows a `Pruned:` group — `- local: N archive(s)` plus one bullet per remote target that deleted objects (zero counts omitted; a target whose cleanup failed shows a warning instead, count unknown).
- New opt-in `notifications.apprise.body_format: text|markdown` config option (default `text`; unknown values rejected by pydantic) (`0e06cab`).
- Markdown renderer behind the option: bold headline and group headers, real bullet lists, and every interpolated untrusted string (paths, destinations, labels, error/warning messages) wrapped in code spans via a `_md_code()` helper (`590725a`, `351e6d9`, `e7dc380`).
- `notify()` declares `body_format=` (TEXT or MARKDOWN) explicitly on both apprise `client.notify()` call sites — TEXT was previously implicit (`c606cce`).
- Docs: `Body Format` section + options-table row in `docs/notifications.md`, updated body examples; commented example in `examples/config.yml` (`313265e`).

## Motivation

Failure notifications with several targets were hard to scan as prose; bullets + one visual language per group (Uploaded to/Pruned/Failed/Warnings) fix that for all targets. Markdown mode upgrades rendering on markdown/HTML-native targets (Slack, Telegram, email) with bold headers, real `<ul>` lists, and code-quoted error strings. Remote retention deletions were previously invisible in notifications (count discarded at the source); the `Pruned:` group surfaces them per target.

Markdown is opt-in, not the default, because apprise's MARKDOWN→TEXT conversion is a pass-through: plain-text targets (generic `json://` webhooks, ntfy, SMS) of a markdown body would see literal `**` and backticks.

The code-span wrapping is load-bearing, not cosmetic: apprise 1.10.0's MARKDOWN→HTML conversion does not escape raw HTML, so an error string containing `<...>` would be swallowed as an unknown tag by email clients. python-markdown escapes `<>&` inside code spans, making them the sanitizer.

## Verification

- 672 unit tests pass (652 baseline + 20 new across config validation, `_md_code` escaping, body structure both modes, group separation, pruned plumbing s3→outcome→renderer, `body_format` kwarg wiring); pylint 10.00/10 aggregate.
- Live smoke against a local capture server via real apprise (`json://127.0.0.1`): worst-case PARTIAL result (failed upload with `<edge & chars>` + backtick in the error, retention warning, cleanup_error, pruned local + remote archives) fired in both modes.
- Captured markdown body run through apprise's `convert_between(MARKDOWN, HTML)`: four separate `<ul>` lists (Uploaded to/Pruned/Failed/Warnings), headers as own paragraphs, error strings inside `<code>` with `<>&` escaped, inner backticks preserved.
- Two independent whole-branch reviews (second at `e1af62f`): PASS; the two Minor findings (R0914 locals, docs paragraph completeness) fixed in `e7dc380`.

## In-depth

- The live smoke caught a real CommonMark gotcha, fixed in `351e6d9`/`bb68885`: any plain line or header directly after a bullet list is lazily absorbed into the last list item during MARKDOWN→HTML conversion — every group header and the standalone lines need a preceding blank line.
- Text mode is deliberately no longer byte-identical to the pre-PR body (blank section separators, labeled upload bullets, Pruned group) — all inside this unreleased PR.
- A target whose retention cleanup fails reports `pruned: 0` (count unknown — `_delete_objects` raises before returning a count) plus the warning bullet; a returned count always means all listed objects were deleted.
- `body_format` is the input-side knob; apprise's per-URL `?format=` remains the target-side override (documented).
- Follow-up candidates live in `_plans/2026-07-02-post-v3-backlog.md`.