### PR TITLE
fix: retention ordering, entrypoint exec, and apprise asset propagation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ LABEL \
 
 # Get security updates and clean up apt cache for smaller size
 RUN apt update -y && apt upgrade -y && \
-    apt install dumb-init && \
+    apt-get install -y dumb-init && \
     rm -rf /var/lib/apt/lists/*
 
 # create docker user

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -107,7 +107,7 @@ class Archiver:
         One-shot mode never calls this, so the archiver's flag stays None (no-op
         at every checkpoint). Scheduled mode forwards its threading.Event here.
         """
-        self._archiver._stop = stop  # pylint: disable=protected-access
+        self._archiver.set_stop(stop)
 
     def discard_partial(self):
         """Remove this run's intermediate tar and any .tgz.partial; never the final .tgz.

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -278,7 +278,11 @@ class Archiver:
         """get older archives based on keep number"""
         files_to_clean = common_util.oldest_beyond_keep(
             file_list,
-            key=lambda f: os.stat(f).st_ctime,
+            # ctime is inode-change time, not creation time -- a chmod/chown -R or
+            # volume restore resets it, making prune order arbitrary. The filename
+            # embeds the run timestamp (..._%Y-%m-%d_%H-%M-%S.tgz), which sorts
+            # lexicographically in chronological order, so use that instead.
+            key=os.path.basename,
             keep_last=self.config.user_inputs.keep_last,
         )
         log.debug("%d local archives will be cleaned up", len(files_to_clean))

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -120,6 +120,10 @@ class NodeArchiver:
                 self.export_workers,
             )
 
+    def set_stop(self, stop) -> None:
+        """Inject the shutdown flag (threading.Event) for cooperative cancel."""
+        self._stop = stop
+
     def _stop_requested(self) -> bool:
         """True when a shutdown signal has flagged this run for cancellation."""
         return self._stop is not None and self._stop.is_set()

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -6,7 +6,7 @@ _APPRISE_FIELDS = {
 }
 
 # pylint: disable=too-few-public-methods, too-many-instance-attributes
-class AppRiseNotifyConfig:
+class ResolvedAppriseConfig:
     """
     Convenience class to hold apprise notification configuration
 
@@ -14,7 +14,7 @@ class AppRiseNotifyConfig:
         :config: <models.AppRiseNotifyConfig> = user input configuration
 
     Returns:
-        AppRiseNotifyConfig instance for holding configuration
+        ResolvedAppriseConfig instance for holding configuration
     """
     def __init__(self, config: models.AppRiseNotifyConfig):
         # env (JSON array string) wins over the config-file list; resolved +

--- a/bookstack_file_exporter/notify/handler.py
+++ b/bookstack_file_exporter/notify/handler.py
@@ -19,32 +19,20 @@ class NotifyHandler:
         NotifyHandler instance to help handle notification integrations.
     """
     def __init__(self, config: models.Notifications):
-        self.targets = self._get_targets(config)
-        self._supported_notifiers={
-            "apprise": self._handle_apprise
-        }
-
-    def _get_targets(self, config: models.Notifications):
-        targets = {}
-
-        if config.apprise:
-            targets["apprise"] = config.apprise
-
-        return targets
+        self.apprise_config = config.apprise
 
     def do_notify(self, excep: None | Exception = None, result: NotifyResult | None = None) -> None:
         """handle notification sending for all configured targets"""
-        if len(self.targets) == 0:
+        if not self.apprise_config:
             log.debug("No notification targets found")
             return
-        for target, config in self.targets.items():
-            log.debug("Starting notification handling for: %s", target)
-            self._supported_notifiers[target](config, excep, result)
+        log.debug("Starting notification handling for: apprise")
+        self._handle_apprise(self.apprise_config, excep, result)
 
     def _handle_apprise(self, config: models.AppRiseNotifyConfig,
                         excep: None | Exception = None,
                         result: NotifyResult | None = None):
-        a_config = notifications.AppRiseNotifyConfig(config)
+        a_config = notifications.ResolvedAppriseConfig(config)
         a_config.validate()
         apprise = notifiers.AppRiseNotify(a_config)
         # PARTIAL is a degraded run: treat it like a failure for gating so on_failure

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -87,7 +87,10 @@ class AppRiseNotify:
         client = Apprise(asset=asset)
 
         if self.config.config_path:
-            app_config = AppriseConfig()
+            # same asset must be threaded into AppriseConfig too -- otherwise
+            # config-file-loaded plugins get AppriseConfig's own default asset
+            # instead of the storage_path/plugin_paths built above.
+            app_config = AppriseConfig(asset=asset)
             app_config.add(self.config.config_path)
             client.add(app_config)
         else:

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -62,13 +62,13 @@ class AppRiseNotify:
     AppRiseNotify helps send notifications via apprise for failed export runs
 
     Args:
-        :config: <notifications.AppRiseNotifyConfig> = Configuration with user inputs and
+        :config: <notifications.ResolvedAppriseConfig> = Configuration with user inputs and
                                                        general options
 
     Returns:
         AppRiseNotify instance to help handle apprise notification integration.
     """
-    def __init__(self, config: notifications.AppRiseNotifyConfig):
+    def __init__(self, config: notifications.ResolvedAppriseConfig):
         self.config = config
         self._client = self._create_client()
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
-# set log level default
-if [[ -z "${LOG_LEVEL}" ]]; then
-    RUN_LOG_LEVEL="info"
-else
-    # if user supplied log level as env var, use that
-    RUN_LOG_LEVEL=$LOG_LEVEL
-fi
-
-python -m bookstack_file_exporter -c $DOCKER_CONFIG_DIR/config.yml -o $DOCKER_EXPORT_DIR -v $RUN_LOG_LEVEL
+# LOG_LEVEL is not forwarded via -v: the app reads the env var itself and
+# falls back gracefully on an invalid value, while argparse's `choices` would
+# hard-exit (SystemExit 2) instead.
+exec python -m bookstack_file_exporter -c "$DOCKER_CONFIG_DIR/config.yml" -o "$DOCKER_EXPORT_DIR"

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -228,7 +228,14 @@ class TestBuildArchiver:
 
 @pytest.fixture
 def five_files():
-    return ["oldest.tgz", "old.tgz", "mid.tgz", "new.tgz", "newest.tgz"]
+    # filenames embed the run timestamp, chronological order == basename sort order
+    return [
+        "bkps_2024-01-01_00-00-00.tgz",
+        "bkps_2024-01-02_00-00-00.tgz",
+        "bkps_2024-01-03_00-00-00.tgz",
+        "bkps_2024-01-04_00-00-00.tgz",
+        "bkps_2024-01-05_00-00-00.tgz",
+    ]
 
 
 @pytest.fixture
@@ -262,15 +269,13 @@ def test_filter_archives_5_files_keep_2(
 ):
     keep_last = 2
     expected_len = 3
-    expected_oldest = ["oldest.tgz", "old.tgz", "mid.tgz"]
+    expected_oldest = five_files[:3]
     mock_config.user_inputs.keep_last = keep_last
-    fake_ctimes = {
-        "oldest.tgz": 100,
-        "old.tgz": 150,
-        "mid.tgz": 200,
-        "new.tgz": 250,
-        "newest.tgz": 300,
-    }
+    # ctimes are deliberately reversed (newest-first): a chmod/chown -R or volume
+    # restore can reset ctime, so prune order must follow the filename timestamp,
+    # not stat times. If _filter_archives ever regresses to sorting by ctime,
+    # this assertion flips to the wrong 3 files and fails.
+    fake_ctimes = dict(zip(five_files, [500, 400, 300, 200, 100]))
     monkeypatch.setattr(os, "stat", _make_stat_patcher(fake_ctimes))
     result = archiver_instance._filter_archives(five_files)
     assert len(result) == expected_len
@@ -681,15 +686,22 @@ def test_clean_up_keep_last_positive_returns_only_old_archives(
 ):
     """keep_last > 0 with more archives than cap: only the excess (old) ones returned."""
     mock_config.user_inputs.keep_last = 1
-    # Three archives; keep_last=1 → 2 oldest should be deleted, newest kept
-    file_list = ["old1.tgz", "old2.tgz", "current.tgz"]
+    # Three archives, filenames carry the run timestamp; keep_last=1 -> the 2
+    # oldest by filename should be deleted, newest kept.
+    file_list = [
+        "bkps_2024-01-01_00-00-00.tgz",
+        "bkps_2024-01-02_00-00-00.tgz",
+        "bkps_2024-01-03_00-00-00.tgz",
+    ]
     patch_scan_archives(file_list)
-    fake_ctimes = {"old1.tgz": 100, "old2.tgz": 200, "current.tgz": 300}
+    # ctimes are deliberately reversed to prove prune order follows the filename
+    # timestamp, not stat times (which chmod/chown -R or a volume restore can reset).
+    fake_ctimes = dict(zip(file_list, [300, 200, 100]))
     monkeypatch.setattr(os, "stat", _make_stat_patcher(fake_ctimes))
     archiver_instance._delete_files = MagicMock()
     result = archiver_instance.clean_up()
-    assert result == ["old1.tgz", "old2.tgz"]
-    assert "current.tgz" not in result
+    assert result == file_list[:2]
+    assert file_list[2] not in result
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -49,7 +49,7 @@ class TestSetStop:
     def test_set_stop_forwards_to_node_archiver(self, archiver_instance):
         ev = threading.Event()
         archiver_instance.set_stop(ev)
-        assert archiver_instance._archiver._stop is ev
+        archiver_instance._archiver.set_stop.assert_called_once_with(ev)
 
 
 class TestDiscardPartial:

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -1,5 +1,5 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
-"""Unit tests for AppRiseNotifyConfig env/JSON resolution and validate() purity."""
+"""Unit tests for ResolvedAppriseConfig env/JSON resolution and validate() purity."""
 import json
 
 import pytest
@@ -7,7 +7,7 @@ from pydantic import ValidationError
 
 from bookstack_file_exporter.config_helper import models
 from bookstack_file_exporter.config_helper.notifications import (
-    AppRiseNotifyConfig,
+    ResolvedAppriseConfig,
     _APPRISE_FIELDS,
 )
 
@@ -23,68 +23,68 @@ def _make_config(**overrides) -> models.AppRiseNotifyConfig:
 class TestServiceUrlResolution:
     def test_env_json_string_parsed_to_list_at_construction(self, monkeypatch):
         monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://a", "mailto://b"]))
-        cfg = AppRiseNotifyConfig(_make_config())
+        cfg = ResolvedAppriseConfig(_make_config())
         # __init__ resolves the raw env JSON string into a validated list
         assert cfg.service_urls == ["mailto://a", "mailto://b"]
 
     def test_config_file_urls_untouched_when_env_unset(self, monkeypatch):
         monkeypatch.delenv(_ENV_KEY, raising=False)
-        cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://from-file"]))
+        cfg = ResolvedAppriseConfig(_make_config(service_urls=["mailto://from-file"]))
         assert cfg.service_urls == ["mailto://from-file"]
 
     def test_none_config_urls_resolve_to_empty_list(self, monkeypatch):
         # caller's `or []` keeps the []-not-None guarantee the helper dropped
         monkeypatch.delenv(_ENV_KEY, raising=False)
-        cfg = AppRiseNotifyConfig(_make_config(service_urls=None))
+        cfg = ResolvedAppriseConfig(_make_config(service_urls=None))
         assert cfg.service_urls == []
 
     def test_env_parsed_even_with_config_path(self, monkeypatch):
         # env is resolved unconditionally now; config_path no longer suppresses it
         monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://x"]))
-        cfg = AppRiseNotifyConfig(_make_config(config_path="/etc/apprise.yml"))
+        cfg = ResolvedAppriseConfig(_make_config(config_path="/etc/apprise.yml"))
         assert cfg.service_urls == ["mailto://x"]
 
     def test_invalid_env_json_raises_at_construction(self, monkeypatch):
         monkeypatch.setenv(_ENV_KEY, "{not valid json")
         with pytest.raises(ValidationError):
-            AppRiseNotifyConfig(_make_config())
+            ResolvedAppriseConfig(_make_config())
 
     def test_non_list_env_json_raises_at_construction(self, monkeypatch):
         # valid JSON but a bare str: must fail loud, not reach apprise as a str
         monkeypatch.setenv(_ENV_KEY, '"mailto://a"')
         with pytest.raises(ValidationError):
-            AppRiseNotifyConfig(_make_config())
+            ResolvedAppriseConfig(_make_config())
 
     def test_empty_env_falls_back_to_config_list(self, monkeypatch):
         # APPRISE_URLS="" (set but empty) falls back to the config list instead
         # of crashing with TypeError (the old double-env-probe bug).
         monkeypatch.setenv(_ENV_KEY, "")
-        cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://x"]))
+        cfg = ResolvedAppriseConfig(_make_config(service_urls=["mailto://x"]))
         assert cfg.service_urls == ["mailto://x"]
 
 
 class TestValidate:
     def test_missing_both_raises(self, monkeypatch):
         monkeypatch.delenv(_ENV_KEY, raising=False)
-        cfg = AppRiseNotifyConfig(_make_config(service_urls=[], config_path=""))
+        cfg = ResolvedAppriseConfig(_make_config(service_urls=[], config_path=""))
         with pytest.raises(ValueError):
             cfg.validate()
 
     def test_config_path_only_passes(self, monkeypatch):
         monkeypatch.delenv(_ENV_KEY, raising=False)
-        cfg = AppRiseNotifyConfig(_make_config(config_path="/etc/apprise.yml"))
+        cfg = ResolvedAppriseConfig(_make_config(config_path="/etc/apprise.yml"))
         cfg.validate()  # no raise
 
     def test_service_urls_only_passes(self, monkeypatch):
         monkeypatch.delenv(_ENV_KEY, raising=False)
-        cfg = AppRiseNotifyConfig(_make_config(service_urls=["mailto://x"]))
+        cfg = ResolvedAppriseConfig(_make_config(service_urls=["mailto://x"]))
         cfg.validate()  # no raise
 
     def test_validate_is_pure_no_env_read_no_mutation(self, monkeypatch):
         # resolve from env at construction, then change the env: validate() must
         # not re-read it or mutate state. Idempotent across repeated calls.
         monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://a"]))
-        cfg = AppRiseNotifyConfig(_make_config())
+        cfg = ResolvedAppriseConfig(_make_config())
         assert cfg.service_urls == ["mailto://a"]
         monkeypatch.setenv(_ENV_KEY, json.dumps(["mailto://changed"]))
         cfg.validate()

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -2,9 +2,9 @@
 # pylint: disable=protected-access
 """Unit tests for AppRiseNotify._get_message_text success-branch formatting."""
 import os
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
-from apprise import NotifyFormat
+from apprise import AppriseConfig, NotifyFormat
 
 from bookstack_file_exporter.config_helper import models as config_models
 from bookstack_file_exporter.config_helper import notifications
@@ -63,6 +63,17 @@ class TestCreateClientAssetWiring:
         notifier = AppRiseNotify(config)
         assert notifier._client.asset.plugin_paths == [plugin_dir]
         assert notifier._client[0].asset.plugin_paths == [plugin_dir]
+
+    def test_config_path_branch_constructs_appriseconfig_with_asset(self, tmp_path):
+        # AppriseConfig carries its own default AppriseAsset -- the asset built
+        # above (storage_path/plugin_paths) must be threaded into it explicitly,
+        # or config-file-loaded plugins silently get apprise's stock asset.
+        config = _apprise_notify_config(
+            config_path=str(tmp_path / "missing.yml"), storage_path=str(tmp_path))
+        with patch("bookstack_file_exporter.notify.notifiers.AppriseConfig",
+                   wraps=AppriseConfig) as spy:
+            AppRiseNotify(config)
+        assert spy.call_args.kwargs["asset"].storage_path == str(tmp_path)
 
 
 class TestGetMessageTextSuccessBranch:

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -30,11 +30,11 @@ def _make_notifier(body_format="text"):
 
 
 def _apprise_notify_config(**overrides):
-    """Build a real notifications.AppRiseNotifyConfig via the pydantic model,
+    """Build a real notifications.ResolvedAppriseConfig via the pydantic model,
     so _create_client() runs against production config wiring."""
     base = {"service_urls": ["json://localhost"]}
     base.update(overrides)
-    return notifications.AppRiseNotifyConfig(config_models.AppRiseNotifyConfig(**base))
+    return notifications.ResolvedAppriseConfig(config_models.AppRiseNotifyConfig(**base))
 
 
 class TestCreateClientAssetWiring:

--- a/tests/unit/test_notify_handler.py
+++ b/tests/unit/test_notify_handler.py
@@ -15,7 +15,7 @@ def _run_gate(excep, result, on_success, on_failure):
     a_config = MagicMock(on_success=on_success, on_failure=on_failure)
     with patch("bookstack_file_exporter.notify.handler.notifications") as notif_mod, \
          patch("bookstack_file_exporter.notify.handler.notifiers") as notif_pkg:
-        notif_mod.AppRiseNotifyConfig.return_value = a_config
+        notif_mod.ResolvedAppriseConfig.return_value = a_config
         sender = MagicMock()
         notif_pkg.AppRiseNotify.return_value = sender
         h._handle_apprise(MagicMock(), excep, result)

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -40,20 +40,17 @@ def page_archiver(tmp_path):
 # ---------------------------------------------------------------------------
 
 class TestStopFlag:
-    def test_stop_defaults_to_none(self, page_archiver):
-        assert page_archiver._stop is None
-
     def test_stop_requested_false_when_unset(self, page_archiver):
         assert page_archiver._stop_requested() is False
 
     def test_stop_requested_false_when_event_clear(self, page_archiver):
-        page_archiver._stop = threading.Event()
+        page_archiver.set_stop(threading.Event())
         assert page_archiver._stop_requested() is False
 
     def test_stop_requested_true_when_event_set(self, page_archiver):
         ev = threading.Event()
         ev.set()
-        page_archiver._stop = ev
+        page_archiver.set_stop(ev)
         assert page_archiver._stop_requested() is True
 
 
@@ -61,7 +58,7 @@ class TestCooperativeCancellation:
     def test_export_nodes_bails_before_first_node_when_stopped(self, page_archiver):
         ev = threading.Event()
         ev.set()
-        page_archiver._stop = ev
+        page_archiver.set_stop(ev)
         page_archiver._download_node_assets = MagicMock()
         page_archiver._get_node_data = MagicMock()
 
@@ -73,7 +70,7 @@ class TestCooperativeCancellation:
 
     def test_export_nodes_stops_between_nodes(self, page_archiver):
         ev = threading.Event()
-        page_archiver._stop = ev
+        page_archiver.set_stop(ev)
         page_archiver._download_node_assets = MagicMock(return_value=({}, []))
         # set the flag the moment the first node's data is fetched
         page_archiver._get_node_data = MagicMock(side_effect=lambda url: ev.set() or b"data")
@@ -92,7 +89,7 @@ class TestCooperativeCancellation:
     def test_download_node_assets_breaks_asset_type_loop_when_stopped(self, page_archiver):
         ev = threading.Event()
         ev.set()
-        page_archiver._stop = ev
+        page_archiver.set_stop(ev)
         page_archiver._archive_node_assets = MagicMock(return_value=set())
         page_archiver._asset_page_map = MagicMock(return_value={1: "page-1"})
 
@@ -107,7 +104,7 @@ class TestCooperativeCancellation:
     def test_archive_node_assets_breaks_asset_loop_when_stopped(self, page_archiver):
         ev = threading.Event()
         ev.set()
-        page_archiver._stop = ev
+        page_archiver.set_stop(ev)
         # asset nodes present; the per-asset guard must break before the first one.
         page_archiver.asset_archiver = MagicMock()
         failed = page_archiver._archive_node_assets(
@@ -725,7 +722,7 @@ class TestParallelExport:
                                 asset_archiver=MagicMock())
         archiver.asset_archiver.get_asset_nodes.return_value = {}
         ev = threading.Event()
-        archiver._stop = ev
+        archiver.set_stop(ev)
         parent = build_node(id=1, name="bk", slug="bk")
         pages = {i: build_node(id=i, name=f"p{i}", slug=f"p{i}", parent=parent)
                  for i in range(2, 22)}  # 20 pages
@@ -752,7 +749,7 @@ class TestParallelExport:
         archiver.asset_archiver.get_asset_nodes.return_value = {}
         ev = threading.Event()
         ev.set()  # stop requested up front
-        archiver._stop = ev
+        archiver.set_stop(ev)
         parent = build_node(id=1, name="bk", slug="bk")
         pages = {i: build_node(id=i, name=f"p{i}", slug=f"p{i}", parent=parent)
                  for i in range(2, 12)}  # 10 pages


### PR DESCRIPTION
## Changes

Batch of small, independent fixes and cleanups from a codebase review pass:

- **Local retention now sorts archives by filename timestamp instead of `st_ctime`.** ctime is inode-*change* time, not creation time — `chmod`/`chown -R` or a volume restore resets it, making prune order among old archives arbitrary (it could keep older content and delete newer). Archive filenames already embed the run timestamp (`bookstack_export_%Y-%m-%d_%H-%M-%S`), which sorts lexicographically in chronological order, so sorting on `os.path.basename` is deterministic and free. Remote retention already uses `LastModified` and is unchanged.
- **`entrypoint.sh` now `exec`s python directly and stops forwarding `LOG_LEVEL` via `-v`.** The app reads the `LOG_LEVEL` env var itself (with warn-and-fallback on invalid values), while forwarding through `-v` made argparse's `choices` hard-exit the container (`SystemExit(2)`) on something like `LOG_LEVEL=verbose`. `exec` also removes the bash shim between dumb-init and python, and the config/export dir vars are now quoted.
- **Apprise asset now propagates to config-file loaded plugins.** The `config_path` branch constructed a bare `AppriseConfig()`, whose plugins carry apprise's default asset instead of the tmp-dir `storage_path`/`plugin_paths` asset built for the run. Now passes `AppriseConfig(asset=...)`.
- **Dockerfile: `apt install dumb-init` → `apt-get install -y dumb-init`.** The missing `-y` only worked because dumb-init has no transitive deps to prompt about; the day one appears, the non-interactive build aborts.
- **Renamed the resolved apprise view class to `ResolvedAppriseConfig`.** Two classes were both named `AppRiseNotifyConfig` (the pydantic schema in `config_helper/models.py` and the resolved convenience view in `config_helper/notifications.py`), with one converted into the other on every notify call. Also replaced `NotifyHandler`'s one-entry dispatch dict with a plain `if` — behavior identical.
- **`NodeArchiver` gains a public `set_stop`; `Archiver.set_stop` delegates to it** instead of assigning the protected `_stop` attribute (drops a `pylint: disable=protected-access`). Tests updated to use the public setter as well.

## Motivation

None of these are new features; they remove latent failure modes (wrong-file deletion under metadata changes, container crash on an invalid `LOG_LEVEL`, notification plugins silently missing their asset config, a build that only works by luck) and two readability hazards (duplicate class name, protected-member poke).

## Test plan

- `pytest tests/` — 706 passed (retention tests rewritten to prove filename ordering wins over deliberately misleading ctimes; new test asserts `AppriseConfig` receives the shared asset; one redundant internal-state test removed).
- `pylint bookstack_file_exporter tests` — 10.00 on both.
- `bash -n entrypoint.sh` — clean.

## In-depth

- The retention sort change assumes archive filenames keep embedding the run timestamp; that format is also what keeps per-level retention scoped (`bkps` vs `bkps_books` globs), so it is stable.
- `LOG_LEVEL` handling in docker is now entirely the app's responsibility — the entrypoint is a single `exec` line. Documented behavior (`docs/`) already describes the env var generically, so no doc changes were needed.
