### PR TITLE
fix!: reject explicit YAML null for config fields with defaults

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -215,8 +215,7 @@ class Archiver:
         n_ok = sum(1 for o in outcomes if o.dest is not None)
         if n_ok == len(outcomes) and not any(o.warning for o in outcomes):
             return ExportStatus.SUCCESS
-        if n_ok == 0 and self.config.user_inputs.keep_last is not None \
-                and self.config.user_inputs.keep_last < 0:
+        if n_ok == 0 and self.config.user_inputs.keep_last < 0:
             failed = ", ".join(o.label for o in outcomes)
             raise AggregateUploadError(
                 f"all upload targets failed and no local copy is kept "

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -52,14 +52,14 @@ class S3StorageConfig(StrictModel):
     name: str
     endpoint: str | None = None
     bucket: str
-    prefix: str | None = ""
+    prefix: str = ""
     region: str | None = None
     secure: bool = True
     addressing_style: Literal["path", "virtual", "auto"] | None = None  # None => inferred
     ambient_auth: bool = False
-    keep_last: int | None = 0
-    access_key: str | None = ""
-    secret_key: str | None = ""
+    keep_last: int = 0
+    access_key: str = ""
+    secret_key: str = ""
     access_key_env: str | None = None
     secret_key_env: str | None = None
 
@@ -137,16 +137,16 @@ class S3StorageConfig(StrictModel):
 # pylint: disable=too-few-public-methods
 class BookstackAccess(StrictModel):
     """YAML schema for bookstack access credentials"""
-    token_id: str | None = ""
-    token_secret: str | None = ""
+    token_id: str = ""
+    token_secret: str = ""
 
 # pylint: disable=too-few-public-methods
 class Assets(StrictModel):
     """YAML schema for bookstack markdown asset(pages/images/attachments) configuration"""
-    export_images: bool | None = False
-    export_attachments: bool | None = False
-    modify_links: bool | None = False
-    export_meta: bool | None = False
+    export_images: bool = False
+    export_attachments: bool = False
+    modify_links: bool = False
+    export_meta: bool = False
 
     @model_validator(mode="before")
     @classmethod
@@ -162,23 +162,23 @@ class Assets(StrictModel):
 
 class HttpConfig(StrictModel):
     """YAML schema for user provided http settings"""
-    verify_ssl: bool | None = False
-    timeout: int | None = 30
-    backoff_factor: float | None = 2.5
-    retry_codes: list[int] | None = [413, 429, 500, 502, 503, 504]
-    retry_count: int | None = 5
-    additional_headers: dict[str, str] | None = {}
+    verify_ssl: bool = False
+    timeout: int = 30
+    backoff_factor: float = 2.5
+    retry_codes: list[int] = [413, 429, 500, 502, 503, 504]
+    retry_count: int = 5
+    additional_headers: dict[str, str] = {}
 
 class AppRiseNotifyConfig(StrictModel):
     """YAML schema for user provided app rise settings"""
-    service_urls: list[str] | None = []
-    config_path: str | None = ""
-    plugin_paths: list[str] | None = []
-    storage_path: str | None = ""
-    custom_title: str | None = ""
-    custom_attachment_path: str | None = ""
-    on_success: bool | None = False
-    on_failure: bool | None = True
+    service_urls: list[str] = []
+    config_path: str = ""
+    plugin_paths: list[str] = []
+    storage_path: str = ""
+    custom_title: str = ""
+    custom_attachment_path: str = ""
+    on_success: bool = False
+    on_failure: bool = True
     body_format: Literal["text", "markdown"] = "text"
 
 class Notifications(StrictModel):
@@ -232,18 +232,18 @@ class Filters(StrictModel):
 class UserInput(StrictModel):
     """YAML schema for user provided configuration file"""
     host: str
-    credentials: BookstackAccess | None = BookstackAccess()
+    credentials: BookstackAccess = BookstackAccess()
     formats: list[Literal["markdown", "html", "pdf", "plaintext", "zip"]]
-    output_path: str | None = ""
+    output_path: str = ""
     # Export granularity: "pages" = one file per page (default),
     # "books" = one combined file per book, "chapters" = one combined file per chapter.
     # Note: assets.export_images/attachments/modify_links apply at all levels;
     # for book/chapter, modify_links localizes assets in markdown exports
     # (html/pdf embed assets server-side and are not rewritten at these levels).
     export_level: Literal["pages", "books", "chapters"] = "pages"
-    assets: Assets | None = Assets()
+    assets: Assets = Assets()
     object_storage: list[S3StorageConfig] | None = None
-    keep_last: int | None = 0
+    keep_last: int = 0
     # Opt-in node-level parallel fetch. Default 1 = today's exact serial behavior.
     # ge=1 because ThreadPoolExecutor(max_workers=0) raises ValueError — reject
     # nonsense at config-parse time, not mid-run. No hard upper bound: huge values
@@ -251,12 +251,12 @@ class UserInput(StrictModel):
     # concurrent API requests; BookStack rate-limits (API_REQUESTS_PER_MIN, default
     # 180/min/user -> HTTP 429). If you raise it and see 429s, raise that .env value.
     export_workers: int = Field(default=1, ge=1)
-    run_interval: int | None = 0
+    run_interval: int = 0
     run_schedule: str | None = None
     # opt-in scheduled-mode health endpoint; no server unless health_port is set
     health_port: int | None = None
-    health_host: str | None = "0.0.0.0"
-    http_config: HttpConfig | None = HttpConfig()
+    health_host: str = "0.0.0.0"
+    http_config: HttpConfig = HttpConfig()
     notifications: Notifications | None = None
     filters: Filters | None = None
 
@@ -276,12 +276,13 @@ class UserInput(StrictModel):
     @classmethod
     def _null_composite_to_default(cls, value):
         """A key present with an explicit YAML null (e.g. children commented out
-        under 'credentials:') validates straight to None, and downstream code
-        unconditionally dereferences these three (.credentials.token_id,
-        .http_config.additional_headers, assets usage in node_archiver) -- so a
-        null here must become the default instance, not None. '{}' re-validates
-        into that default since BookstackAccess/Assets/HttpConfig all have
-        defaults for every field."""
+        under 'credentials:') is otherwise rejected by these three fields' now
+        non-Optional annotations, but downstream code unconditionally dereferences
+        them (.credentials.token_id, .http_config.additional_headers, assets usage
+        in node_archiver) -- so a null here must become the default instance
+        instead of failing validation. This before-validator runs ahead of type
+        validation and rewrites null to '{}', which re-validates into that default
+        since BookstackAccess/Assets/HttpConfig all have defaults for every field."""
         return {} if value is None else value
 
     @model_validator(mode="after")

--- a/bookstack_file_exporter/config_helper/notifications.py
+++ b/bookstack_file_exporter/config_helper/notifications.py
@@ -18,9 +18,9 @@ class ResolvedAppriseConfig:
     """
     def __init__(self, config: models.AppRiseNotifyConfig):
         # env (JSON array string) wins over the config-file list; resolved +
-        # validated once here. `or []` keeps the []-not-None guarantee.
+        # validated once here.
         self.service_urls = resolve_env_json(_APPRISE_FIELDS["urls"], list[str],
-                                             config.service_urls or [])
+                                             config.service_urls)
         self.config_path = config.config_path
         self.plugin_paths = config.plugin_paths
         self.storage_path = config.storage_path

--- a/tests/unit/test_asset_archiver_config.py
+++ b/tests/unit/test_asset_archiver_config.py
@@ -34,6 +34,15 @@ class TestPhase2AssetsModel:
         with pytest.raises(ValidationError, match="modify_links"):
             Assets(modify_markdown=True)
 
+    @pytest.mark.parametrize("field", [
+        "export_images", "export_attachments", "modify_links", "export_meta",
+    ])
+    def test_assets_rejects_explicit_null(self, field):
+        # bools are no longer Optional; explicit null must fail, not fall through
+        # to a falsy default that silently disables the toggle.
+        with pytest.raises(ValidationError):
+            Assets(**{field: None})
+
     def test_assets_rejects_modify_markdown_even_with_modify_links(self):
         # both keys present is still an error — the removed key must never be silently ignored
         with pytest.raises(ValidationError, match="modify_markdown"):

--- a/tests/unit/test_models_notify.py
+++ b/tests/unit/test_models_notify.py
@@ -19,3 +19,10 @@ def test_body_format_accepts_markdown():
 def test_body_format_rejects_unknown():
     with pytest.raises(ValidationError):
         AppRiseNotifyConfig(service_urls=["json://localhost"], body_format="html")
+
+
+def test_on_success_rejects_explicit_null():
+    # bools are no longer Optional; explicit null must fail, not fall through
+    # to a falsy default that silently disables success notifications.
+    with pytest.raises(ValidationError):
+        AppRiseNotifyConfig(service_urls=["json://localhost"], on_success=None)

--- a/tests/unit/test_models_null_validation.py
+++ b/tests/unit/test_models_null_validation.py
@@ -1,0 +1,55 @@
+# pylint: disable=missing-function-docstring
+"""Unit tests asserting explicit YAML null is rejected for config fields whose
+`| None` annotation was dropped: the field's default already covers "key
+omitted", so `| None` only ever let an explicit YAML `null` (e.g. `timeout:
+null`) validate straight to None and flow downstream unchecked. Composite
+fields (credentials/assets/http_config) are covered separately in
+test_models_null_composite.py -- they still accept null via a before-validator
+that coerces it to the field's default instance."""
+import pytest
+from pydantic import ValidationError
+
+from bookstack_file_exporter.config_helper.models import (
+    BookstackAccess,
+    HttpConfig,
+    UserInput,
+)
+
+_USER_BASE = {"host": "https://wiki.example", "formats": ["markdown"]}
+
+
+@pytest.mark.parametrize("field", [
+    "verify_ssl", "timeout", "backoff_factor", "retry_codes", "retry_count",
+    "additional_headers",
+])
+def test_http_config_rejects_explicit_null(field):
+    with pytest.raises(ValidationError):
+        HttpConfig(**{field: None})
+
+
+def test_http_config_omitted_keys_still_default():
+    cfg = HttpConfig()
+    assert cfg.timeout == 30
+    assert cfg.retry_codes == [413, 429, 500, 502, 503, 504]
+
+
+@pytest.mark.parametrize("field", ["token_id", "token_secret"])
+def test_bookstack_access_rejects_explicit_null(field):
+    with pytest.raises(ValidationError):
+        BookstackAccess(**{field: None})
+
+
+def test_user_input_rejects_null_keep_last():
+    with pytest.raises(ValidationError):
+        UserInput(**_USER_BASE, keep_last=None)
+
+
+def test_user_input_rejects_null_output_path():
+    with pytest.raises(ValidationError):
+        UserInput(**_USER_BASE, output_path=None)
+
+
+def test_user_input_omitted_keys_still_default():
+    cfg = UserInput(**_USER_BASE)
+    assert cfg.keep_last == 0
+    assert cfg.output_path == ""

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -22,6 +22,13 @@ def test_entry_defaults():
     assert cfg.keep_last == 0
 
 
+def test_keep_last_rejects_explicit_null():
+    # keep_last is no longer Optional; explicit null must fail, not fall through
+    # to a default retention value.
+    with pytest.raises(ValidationError):
+        S3StorageConfig(**_entry(access_key="a", secret_key="s", keep_last=None))
+
+
 def test_is_aws_discriminant():
     """Single source for 'no endpoint => AWS': validators and resolvers read this."""
     custom = S3StorageConfig(**_entry(access_key="a", secret_key="s"))

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -29,6 +29,15 @@ def test_keep_last_rejects_explicit_null():
         S3StorageConfig(**_entry(access_key="a", secret_key="s", keep_last=None))
 
 
+@pytest.mark.parametrize("field", ["prefix", "access_key", "secret_key"])
+def test_s3_string_fields_reject_explicit_null(field):
+    # non-Optional strings: explicit null must fail instead of flowing downstream
+    entry = _entry(access_key="a", secret_key="s")
+    entry[field] = None
+    with pytest.raises(ValidationError):
+        S3StorageConfig(**entry)
+
+
 def test_is_aws_discriminant():
     """Single source for 'no endpoint => AWS': validators and resolvers read this."""
     custom = S3StorageConfig(**_entry(access_key="a", secret_key="s"))

--- a/tests/unit/test_notifications.py
+++ b/tests/unit/test_notifications.py
@@ -32,11 +32,12 @@ class TestServiceUrlResolution:
         cfg = ResolvedAppriseConfig(_make_config(service_urls=["mailto://from-file"]))
         assert cfg.service_urls == ["mailto://from-file"]
 
-    def test_none_config_urls_resolve_to_empty_list(self, monkeypatch):
-        # caller's `or []` keeps the []-not-None guarantee the helper dropped
+    def test_none_service_urls_rejected_at_construction(self, monkeypatch):
+        # service_urls is no longer Optional; explicit null now fails config
+        # validation instead of reaching ResolvedAppriseConfig's `or []` guard.
         monkeypatch.delenv(_ENV_KEY, raising=False)
-        cfg = ResolvedAppriseConfig(_make_config(service_urls=None))
-        assert cfg.service_urls == []
+        with pytest.raises(ValidationError):
+            _make_config(service_urls=None)
 
     def test_env_parsed_even_with_config_path(self, monkeypatch):
         # env is resolved unconditionally now; config_path no longer suppresses it

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -1,4 +1,7 @@
 # pylint: disable=missing-function-docstring,missing-class-docstring
+import pytest
+from pydantic import ValidationError
+
 from bookstack_file_exporter.config_helper.remote import S3ProviderConfig
 
 
@@ -30,6 +33,8 @@ def test_prefix_normalized_at_resolution(make_storage_entry):
     assert S3ProviderConfig(entry).prefix == "daily/exports"
 
 
-def test_none_prefix_resolves_empty(make_storage_entry):
-    entry = make_storage_entry(prefix=None)
-    assert S3ProviderConfig(entry).prefix == ""
+def test_none_prefix_rejected_at_construction(make_storage_entry):
+    # prefix is no longer Optional; explicit null now fails config validation
+    # instead of resolving to "" at S3ProviderConfig.
+    with pytest.raises(ValidationError):
+        make_storage_entry(prefix=None)


### PR DESCRIPTION
## Changes

Tightens the pydantic config schema so an explicit YAML `null` fails validation at startup instead of flowing downstream as `None`:

- Dropped `| None` from every config field where `None` has no meaning — all `HttpConfig` fields, all `Assets` bools, `BookstackAccess` tokens, the apprise settings, `S3StorageConfig.prefix`/`keep_last`/`access_key`/`secret_key`, and `UserInput.output_path`/`keep_last`/`run_interval`/`health_host`. Previously `timeout: null` made requests wait forever, `retry_codes: null` became `Retry(status_forcelist=None)` (retry everything), and `verify_ssl: null` disabled the warning without disabling verification.
- Kept `| None` only where `None` is a real, handled state: `endpoint` (absence selects AWS), `region`, `addressing_style` (inferred), `access_key_env`/`secret_key_env`, `object_storage`, `run_schedule`, `health_port`, `notifications`, `filters`, and the filter pattern lists.
- The three composites (`credentials`, `assets`, `http_config`) are now non-Optional but still accept an explicit `null` — the existing before-validator coerces it to the default instance, since commenting out all children under a key (common in docker setups) parses as `null`.
- Removed a now-dead `keep_last is not None` guard in `Archiver.resolve_remote_status` (the annotation guarantees `int`).
- Dropped a now-dead `or []` fallback on `service_urls` in the resolved apprise view.

**⚠ Behavior change:** configs that literally wrote `null` for one of the tightened fields now fail at startup with a ValidationError naming the field. Those configs were already misbehaving silently. Omitting a key is unchanged — every field keeps its previous default.

## Motivation

`T | None = default` is not needed for "key may be omitted" (the default covers that); its only effect was permitting explicit `null`, which then reached code that dereferences or compares these values unchecked. For a backup tool, failing loudly at config parse beats degraded behavior discovered later.

## Test plan

- `pytest tests/` — 727 passed (21 new: explicit-null rejection across all tightened models, omitted-key defaults unchanged, composite null coercion; 2 existing tests rewritten from None-passthrough to ValidationError assertions).
- `pylint bookstack_file_exporter tests` — 10.00 on both.
- Live config check: a real v3 config validates unchanged; the same config with `timeout: null` injected is rejected at startup.
- Independent review verified field-by-field against the keep-list, pydantic v2 before-validator ordering for the composite null coercion, per-instance mutable defaults, and that no construction path bypasses validation.

## In-depth

- `examples/config.yml` and `examples/docker-compose.yaml` contain no explicit `null`s, so shipped examples are unaffected.
- The commit is marked breaking (`fix!`) for honesty; it folds into the already-open v3.0.0 release, so it does not bump beyond that.
