### PR TITLE
feat: silence cancelled runs and report nothing-to-archive runs honestly

### DIFF
--- a/bookstack_file_exporter/notify/handler.py
+++ b/bookstack_file_exporter/notify/handler.py
@@ -37,6 +37,8 @@ class NotifyHandler:
         apprise = notifiers.AppRiseNotify(a_config)
         # PARTIAL is a degraded run: treat it like a failure for gating so on_failure
         # subscribers are alerted (a copy survived, but a target did not receive it).
+        # EMPTY is success-toned (nothing to archive is not a degradation) and falls
+        # through to the on_success branch below like SUCCESS.
         is_partial = result is not None and result.status is ExportStatus.PARTIAL
         fire_failure = excep is not None or is_partial
         if (not fire_failure and a_config.on_success) or (fire_failure and a_config.on_failure):

--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -3,9 +3,17 @@ from enum import Enum
 
 
 class ExportStatus(Enum):
-    """Terminal run outcome. Hard failure is a raised exception, never a value here."""
+    """Terminal run outcome. Hard failure is a raised exception, never a value here.
+
+    SUCCESS: archive produced and durable copies exist.
+    PARTIAL: run finished but degraded (content loss, a failed upload, or a
+        failed retention cleanup).
+    EMPTY: run completed but found nothing to archive (empty instance / filters
+        matched nothing) -- not a failure, not cancelled.
+    """
     SUCCESS = "success"
     PARTIAL = "partial"
+    EMPTY = "empty"
 
 
 @dataclass(frozen=True)
@@ -26,6 +34,10 @@ STATUS_EFFECTS: dict[ExportStatus, StatusEffects] = {
         exit_code=0, health_degraded=False, title_suffix="Success"),
     ExportStatus.PARTIAL: StatusEffects(
         exit_code=3, health_degraded=True, title_suffix="Partial"),
+    # title stays "Success": operators' alerting rules match on title, and the
+    # body carries the nothing-to-archive detail instead.
+    ExportStatus.EMPTY: StatusEffects(
+        exit_code=0, health_degraded=False, title_suffix="Success"),
 }
 
 

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -128,6 +128,17 @@ class AppRiseNotify:
                 "",
                 f"Error message: {str(error_msg)}",
             ])
+        if result is not None and result.status is ExportStatus.EMPTY:
+            # Archive-less run: no Archive/Uploaded/Pruned/Failed sections make
+            # sense when nothing was ever written.
+            return "\n".join([
+                "",
+                "Bookstack File Exporter completed - nothing to archive.",
+                "",
+                f"Completed At: {timestamp}",
+                "",
+                f"No {result.export_level} content was found to export.",
+            ])
         partial = result is not None and result.status is ExportStatus.PARTIAL
         headline = ("Bookstack File Exporter completed with errors."
                     if partial else
@@ -186,6 +197,15 @@ class AppRiseNotify:
                 f"Occurred At: {timestamp}",
                 "",
                 f"Error message: {_md_code(str(error_msg))}",
+            ])
+        if result is not None and result.status is ExportStatus.EMPTY:
+            return "\n".join([
+                "",
+                "**Bookstack File Exporter completed - nothing to archive.**",
+                "",
+                f"Completed At: {timestamp}",
+                "",
+                f"No {result.export_level} content was found to export.",
             ])
         partial = result is not None and result.status is ExportStatus.PARTIAL
         headline = ("**Bookstack File Exporter completed with errors.**"

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -72,7 +72,10 @@ def _run_once(config: ConfigNode) -> int:
     try:
         result = run(config)
         if result is None:
-            # nothing to archive (empty instance) is a clean no-op, not a failure
+            # Defensive/unreachable: None only comes from run.py's shutdown
+            # paths, which require a stop flag -- one-shot mode never passes
+            # one, so run() can't return None here. Kept as a safe default (0)
+            # rather than a KeyError if that ever changes.
             return 0
         return STATUS_EFFECTS[result.status].exit_code
     except KeyboardInterrupt:
@@ -121,8 +124,11 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
             status.mark_running()
         try:
             result = run(config, stop)
-            if status:
-                if result is not None and STATUS_EFFECTS[result.status].health_degraded:
+            # None = cycle cancelled by shutdown; the loop breaks right after
+            # anyway (stop.is_set() below), so health keeps its last real
+            # state instead of being marked for a cycle that never finished.
+            if status and result is not None:
+                if STATUS_EFFECTS[result.status].health_degraded:
                     status.mark_degraded(result)
                 else:
                     status.mark_success(result)
@@ -154,7 +160,11 @@ def run(config: ConfigNode, stop=None):
     """run export process with error handling and notification support"""
     try:
         result = exporter(config, stop)
-        if config.user_inputs.notifications:
+        # None = cancelled by shutdown (run.py's shutdown-during-fetch /
+        # shutdown-mid-cycle paths); notifying would report an outcome that
+        # never happened, so skip notification entirely. Any real outcome
+        # (including EMPTY) still notifies below.
+        if result is not None and config.user_inputs.notifications:
             try:
                 notif = NotifyHandler(config.user_inputs.notifications)
                 notif.do_notify(result=result)
@@ -231,7 +241,7 @@ def exporter(config: ConfigNode, stop=None):
             "No %s data available from given Bookstack instance. Nothing to archive",
             export_level,
         )
-        return None
+        return NotifyResult(status=ExportStatus.EMPTY, export_level=export_level)
 
     log.info("Beginning archive")
     try:
@@ -256,7 +266,7 @@ def exporter(config: ConfigNode, stop=None):
                     f"{len(archive.failed_assets)} asset download(s) failed")
         elif not archive.has_exported_content:
             log.warning("No %s content was archived. Nothing to upload", export_level)
-            return None
+            return NotifyResult(status=ExportStatus.EMPTY, export_level=export_level)
 
         # create tar if needed and gzip tar
         archive.create_archive()

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -125,8 +125,8 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
         try:
             result = run(config, stop)
             # None = cycle cancelled by shutdown; the loop breaks right after
-            # anyway (stop.is_set() below), so health keeps its last real
-            # state instead of being marked for a cycle that never finished.
+            # (stop.is_set() below) and the server shuts down, so the cycle is
+            # never marked success/degraded for work that didn't finish.
             if status and result is not None:
                 if STATUS_EFFECTS[result.status].health_degraded:
                     status.mark_degraded(result)

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -41,6 +41,16 @@ Pruned:
 - aws-s3: 1 archive(s)
 
 
+##### Nothing To Archive Message #####
+{TITLE}: Bookstack File Exporter Success
+{BODY}:
+Bookstack File Exporter completed - nothing to archive.
+
+Completed At: 2025-09-06 01:05:27
+
+No pages content was found to export.
+
+
 ##### Partial Message #####
 {TITLE}: Bookstack File Exporter Partial
 {BODY}:
@@ -57,6 +67,8 @@ Failed:
 - assets: 115 asset download(s) failed
 ```
 The success body reports the archive details only when an archive is produced. `Archive:` shows the local `.tgz` path (with `(removed locally after upload)` when it was uploaded then deleted), `Uploaded to:` lists each successful target as a `- name: destination` bullet, and the `Pruned:` group shows how many old archives `keep_last` retention removed — `local` for the export directory plus one bullet per remote target that deleted objects (zero-count targets are omitted).
+
+When a run completes but finds nothing to archive (an empty Bookstack instance, or filters that matched nothing), the notification title still reads "Success" — this is not a failure — but the body says so plainly and omits the `Archive:`/`Uploaded to:`/`Pruned:` sections entirely, since no archive was ever produced. It is gated the same as any other success (`apprise.on_success`), not `on_failure`.
 
 The partial body adds a `Failed:` group. Content dropped during export (a page/book/chapter export or an asset download that failed after retries) is reported first as count-only bullets — `- content: N <level> export(s) failed` and `- assets: N asset download(s) failed` — followed by one bullet per failed upload target, if any. Full per-path detail is not included in the notification; it is in the run logs.
 

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -407,6 +407,51 @@ class TestNotifyBodyFormat:
         assert kwargs["body_format"] == NotifyFormat.MARKDOWN
 
 
+class TestEmptyStatusBody:
+    """EMPTY (nothing to archive) renders an archive-less body in both formats."""
+
+    def test_text_body_says_nothing_to_archive_no_sections(self):
+        notifier = _make_notifier()
+        result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+        body = notifier._text_body(None, result)
+        assert "nothing to archive" in body
+        assert "Completed At:" in body
+        assert "No pages content was found to export." in body
+        assert "Archive:" not in body
+        assert "Uploaded to:" not in body
+        assert "Pruned" not in body
+        assert "Failed:" not in body
+
+    def test_text_body_names_the_export_level(self):
+        notifier = _make_notifier()
+        result = NotifyResult(status=ExportStatus.EMPTY, export_level="books")
+        body = notifier._text_body(None, result)
+        assert "No books content was found to export." in body
+
+    def test_markdown_body_says_nothing_to_archive_no_sections(self):
+        notifier = _make_notifier(body_format="markdown")
+        result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+        body = notifier._markdown_body(None, result)
+        assert "**Bookstack File Exporter completed - nothing to archive.**" in body
+        assert "Completed At:" in body
+        assert "No pages content was found to export." in body
+        assert "Archive:" not in body
+        assert "Uploaded to:" not in body
+        assert "Pruned" not in body
+        assert "Failed:" not in body
+
+    def test_get_message_text_dispatches_empty_to_markdown(self):
+        notifier = _make_notifier(body_format="markdown")
+        result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+        body = notifier._get_message_text(None, result)
+        assert "**Bookstack File Exporter completed - nothing to archive.**" in body
+
+    def test_title_stays_success_for_empty(self):
+        inst = _notifier()
+        result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+        assert inst._get_title(None, result).endswith("Success")
+
+
 class TestContentFailureBullets:
     """Content-loss ledger renders as count-only Failed: bullets."""
 

--- a/tests/unit/test_notify_handler.py
+++ b/tests/unit/test_notify_handler.py
@@ -35,3 +35,15 @@ def test_partial_suppressed_when_on_failure_false():
 def test_success_fires_on_success():
     result = NotifyResult(status=ExportStatus.SUCCESS, local="/a/b.tgz")
     assert _run_gate(None, result, on_success=True, on_failure=False) is True
+
+
+def test_empty_fires_on_success():
+    """EMPTY is success-toned: it must route through the on_success gate,
+    same as SUCCESS, not the on_failure gate PARTIAL uses."""
+    result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+    assert _run_gate(None, result, on_success=True, on_failure=False) is True
+
+
+def test_empty_suppressed_when_on_success_false():
+    result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+    assert _run_gate(None, result, on_success=False, on_failure=True) is False

--- a/tests/unit/test_notify_models.py
+++ b/tests/unit/test_notify_models.py
@@ -50,6 +50,12 @@ class TestStatusEffects:
         assert effects.health_degraded is True
         assert effects.title_suffix == "Partial"
 
+    def test_empty_effects(self):
+        effects = STATUS_EFFECTS[ExportStatus.EMPTY]
+        assert effects.exit_code == 0
+        assert effects.health_degraded is False
+        assert effects.title_suffix == "Success"
+
     def test_every_status_has_effects(self):
         """Adding an ExportStatus without an effects row must fail loudly here,
         not KeyError at exit time."""

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -512,6 +512,32 @@ class TestScheduledHealthServer:
         fake_status.mark_success.assert_called_once_with(empty_result)
         fake_status.mark_degraded.assert_not_called()
 
+    def test_partial_cycle_marks_degraded(self):
+        """A PARTIAL cycle (content loss, archive survived) must degrade health,
+        never mark_success."""
+        cfg = _config(run_interval=5, health_port=8080)
+        stop_event = threading.Event()
+        partial_result = NotifyResult(status=ExportStatus.PARTIAL, local="bkps/a.tgz",
+                                      failed_assets=["images/a.png"], export_level="pages")
+
+        def _run_side_effect(_config, _stop=None):
+            stop_event.set()
+            return partial_result
+
+        fake_status = MagicMock()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.RunStatus", return_value=fake_status), \
+             patch("bookstack_file_exporter.run.start_health_server", return_value=MagicMock()), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        fake_status.mark_degraded.assert_called_once_with(partial_result)
+        fake_status.mark_success.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # _run_scheduled() — double-signal force-kill (SIG_DFL restore)

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -463,6 +463,55 @@ class TestScheduledHealthServer:
         assert snap["last_run"]["status"] == "success"
         assert snap["last_run"]["archive_file"] == "export.tgz"
 
+    def test_cancelled_cycle_marks_neither_success_nor_degraded(self):
+        """run() returning None means the cycle was cancelled by shutdown, not
+        that it finished -- health must keep its last real state rather than
+        being marked for a cycle that never completed."""
+        cfg = _config(run_interval=5, health_port=8080)
+        stop_event = threading.Event()
+
+        def _run_side_effect(_config, _stop=None):
+            stop_event.set()
+
+        fake_status = MagicMock()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.RunStatus", return_value=fake_status), \
+             patch("bookstack_file_exporter.run.start_health_server", return_value=MagicMock()), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        fake_status.mark_success.assert_not_called()
+        fake_status.mark_degraded.assert_not_called()
+
+    def test_empty_cycle_marks_success(self):
+        """An EMPTY-status cycle (nothing to archive) is a real outcome, not a
+        cancellation -- it must still be marked via mark_success."""
+        cfg = _config(run_interval=5, health_port=8080)
+        stop_event = threading.Event()
+        empty_result = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
+
+        def _run_side_effect(_config, _stop=None):
+            stop_event.set()
+            return empty_result
+
+        fake_status = MagicMock()
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch.object(run, "run", side_effect=_run_side_effect), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch("bookstack_file_exporter.run.RunStatus", return_value=fake_status), \
+             patch("bookstack_file_exporter.run.start_health_server", return_value=MagicMock()), \
+             patch("bookstack_file_exporter.run.threading.Event", return_value=stop_event):
+            result = run.entrypoint(args=_args(run_once=False))
+
+        assert result == 0
+        fake_status.mark_success.assert_called_once_with(empty_result)
+        fake_status.mark_degraded.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # _run_scheduled() — double-signal force-kill (SIG_DFL restore)
@@ -542,6 +591,18 @@ def test_run_once_returns_one_on_exception():
 
 
 def test_run_once_returns_zero_when_result_none():
+    """Defensive guard only: one-shot mode never passes a stop flag, so run()
+    cannot actually return None here (that path requires cooperative shutdown).
+    The guard exists purely to avoid a KeyError if that ever changes."""
     with patch("bookstack_file_exporter.run.signal.signal"), \
          patch.object(run, "run", return_value=None):
+        assert run._run_once(MagicMock()) == 0
+
+
+def test_run_once_returns_zero_on_empty():
+    """Nothing-to-archive is a clean outcome (exit 0), same as SUCCESS."""
+    with patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(run, "run",
+                      return_value=NotifyResult(status=ExportStatus.EMPTY,
+                                                export_level="pages")):
         assert run._run_once(MagicMock()) == 0

--- a/tests/unit/test_run_exporter.py
+++ b/tests/unit/test_run_exporter.py
@@ -256,7 +256,8 @@ class TestExporterNodeFilterWiring:
 class TestRunNotificationOnEarlyReturn:
     def test_empty_nodes_early_return_fires_success_notification(self, monkeypatch):
         """When notifications are configured and exporter() hits an empty-nodes
-        early return, run() must still call do_notify() with no error argument."""
+        early return, run() must still call do_notify() with an EMPTY result
+        (not None -- None is reserved for shutdown cancellation)."""
         config = _make_exporter_config("pages")
         config.user_inputs.notifications = {"apprise_urls": ["mock://notify"]}
 
@@ -271,12 +272,16 @@ class TestRunNotificationOnEarlyReturn:
 
         run.run(config)
 
-        mock_notif_instance.do_notify.assert_called_once_with(result=None)
+        mock_notif_instance.do_notify.assert_called_once()
+        result_arg = mock_notif_instance.do_notify.call_args.kwargs.get("result")
+        assert isinstance(result_arg, NotifyResult)
+        assert result_arg.status is ExportStatus.EMPTY
+        assert result_arg.export_level == "pages"
 
     def test_empty_archive_early_return_fires_success_notification(self, monkeypatch):
         """Second early-return site: nodes existed but nothing landed in the tar
-        (has_exported_content False). run() must still call do_notify() with no
-        error argument, and the downstream archive steps must be skipped."""
+        (has_exported_content False). run() must still call do_notify() with an
+        EMPTY result, and the downstream archive steps must be skipped."""
         config = _make_exporter_config("pages")
         config.user_inputs.notifications = {"apprise_urls": ["mock://notify"]}
 
@@ -293,26 +298,52 @@ class TestRunNotificationOnEarlyReturn:
         run.run(config)
 
         mock_archiver.create_archive.assert_not_called()
-        mock_notif_instance.do_notify.assert_called_once_with(result=None)
+        mock_notif_instance.do_notify.assert_called_once()
+        result_arg = mock_notif_instance.do_notify.call_args.kwargs.get("result")
+        assert isinstance(result_arg, NotifyResult)
+        assert result_arg.status is ExportStatus.EMPTY
+
+    def test_cancelled_run_does_not_notify(self, monkeypatch):
+        """exporter() returning None means the cycle was cancelled by shutdown,
+        not that it produced an outcome -- run() must skip notification
+        entirely rather than report a cancellation as a success."""
+        config = _make_exporter_config("pages")
+        config.user_inputs.notifications = {"apprise_urls": ["mock://notify"]}
+
+        monkeypatch.setattr("bookstack_file_exporter.run.exporter", lambda cfg, stop=None: None)
+
+        mock_notif_instance = MagicMock()
+        mock_notif_cls = MagicMock(return_value=mock_notif_instance)
+        monkeypatch.setattr("bookstack_file_exporter.run.NotifyHandler", mock_notif_cls)
+
+        result = run.run(config)
+
+        assert result is None
+        mock_notif_instance.do_notify.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
-# exporter() return value: None on early returns, NotifyResult on success
+# exporter() return value: EMPTY NotifyResult on nothing-to-archive early
+# returns, populated NotifyResult on success. None is reserved exclusively for
+# shutdown cancellation (see TestExporterStopWiring below).
 # ---------------------------------------------------------------------------
 
 class TestExporterReturnValue:
-    def test_empty_nodes_returns_none(self, monkeypatch):
-        """empty nodes early return → exporter() returns None."""
+    def test_empty_nodes_returns_empty_status(self, monkeypatch):
+        """empty nodes early return → exporter() returns an EMPTY NotifyResult."""
         config = _make_exporter_config("pages")
         _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
             chapter_nodes={}, page_nodes={}
         )
         result = run.exporter(config)
-        assert result is None
+        assert isinstance(result, NotifyResult)
+        assert result.status is ExportStatus.EMPTY
+        assert result.export_level == "pages"
 
-    def test_no_exported_content_returns_none(self, monkeypatch):
-        """has_exported_content=False early return → exporter() returns None."""
+    def test_no_exported_content_returns_empty_status(self, monkeypatch):
+        """has_exported_content=False early return → exporter() returns an
+        EMPTY NotifyResult."""
         config = _make_exporter_config("pages")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
@@ -320,7 +351,9 @@ class TestExporterReturnValue:
         )
         mock_archiver.has_exported_content = False
         result = run.exporter(config)
-        assert result is None
+        assert isinstance(result, NotifyResult)
+        assert result.status is ExportStatus.EMPTY
+        assert result.export_level == "pages"
 
     def test_success_returns_notify_result(self, monkeypatch):
         """Happy path → exporter() returns a populated NotifyResult."""
@@ -603,8 +636,8 @@ class TestExporterContentLoss:
         with pytest.raises(run.NoContentArchivedError):
             run.exporter(config)
 
-    def test_truly_empty_archive_still_returns_none(self, monkeypatch):
-        """Empty ledger + no tar = benign empty instance: behavior unchanged."""
+    def test_truly_empty_archive_still_returns_empty_status(self, monkeypatch):
+        """Empty ledger + no tar = benign empty instance: EMPTY status, not None."""
         config = _make_exporter_config("pages")
         mock_archiver, _ = _patch_exporter_collaborators(
             monkeypatch, config, book_nodes={1: MagicMock()},
@@ -614,4 +647,5 @@ class TestExporterContentLoss:
 
         result = run.exporter(config)
 
-        assert result is None
+        assert isinstance(result, NotifyResult)
+        assert result.status is ExportStatus.EMPTY


### PR DESCRIPTION
## Changes

Distinguishes two run outcomes that previously both returned `None` from the exporter and fired a bare "completed successfully" notification:

- **Cancelled by shutdown** (SIGTERM/SIGINT during fetch or mid-cycle, scheduled mode): now fully silent — no notification and no health mark. The exporter's `None` return now exclusively means "cancelled"; `run()` skips notification for it and the scheduled loop skips `mark_success`/`mark_degraded` (the loop exits immediately after, so the health endpoint keeps its last real state instead of reporting success for a cycle that never finished).
- **Nothing to archive** (no nodes from the instance, or nothing landed in the tar with no failures): new `ExportStatus.EMPTY` with an honest notification — title stays "Bookstack File Exporter Success" (so alerting rules that match titles see no new value), body says "completed - nothing to archive" plus "No {level} content was found to export", with no Archive/Uploaded/Pruned sections. Rendered in both `text` and `markdown` body formats. Sent under the `on_success` gate only.
- `EMPTY` is a full row in the `STATUS_EFFECTS` table: exit code 0 in one-shot mode, `mark_success` (not degraded) in scheduled mode.
- One-shot mode behavior is unchanged (it never passes a stop flag, so the cancelled paths are unreachable there; signals already exit 128+signum).

## Motivation

An operator running with `on_success: true` uses notifications as a backup heartbeat. Previously a run cancelled by `docker stop` and a run that found zero content both produced the same "completed successfully" message as a real backup — the worst case being a config whose filters match nothing, reported as a working backup indefinitely. Now a cancelled run says nothing (an interruption is not an outcome) and an empty run says explicitly that nothing was archived.

## Test plan

- `pytest tests/` — 740 passed (13 new: EMPTY status effects, both empty exporter paths, notification skip on cancelled runs, scheduled-loop health marking for cancelled/EMPTY/PARTIAL cycles, EMPTY body rendering in both formats, `on_success`/`on_failure` gating for EMPTY, one-shot exit 0).
- `pylint bookstack_file_exporter tests` — 10.00 on both.
- Live smoke against a real BookStack instance with filters matching nothing: exit code 0 and the captured apprise JSON payload shows title "Bookstack File Exporter Success" with the nothing-to-archive body.
- Independent review walked every exporter return path (confirmed `None` escapes only from the two stop-guarded paths, so no failure or partial outcome can be silenced), the gating logic, all `STATUS_EFFECTS` consumers, and the scheduled-loop ordering that guarantees a cancelled cycle always breaks before waiting.

## In-depth

- The review also noted this fixes a latent mis-report on main: a mid-cycle shutdown discarded the partial archive but still sent a success-toned notification.
- The empty-run notification deliberately keeps the "Success" title rather than introducing a new one; the distinction lives in the body. If a future need arises to alert on empty runs specifically, promoting it to its own title is a one-line change in the `STATUS_EFFECTS` table.
