### PR TITLE
fix: honor shutdown signals promptly in one-shot parallel export

### DIFF
--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -92,9 +92,9 @@ class NodeArchiver:
             else self._default_asset_archiver(api_urls, http_client)
         )
         self.modify_links: bool = self._check_links_modify()
-        # Cooperative-shutdown flag, injected by Archiver.set_stop() in scheduled
-        # mode (stays None in one-shot mode). Polled at export checkpoints below;
-        # the signal handler only SETS this flag (it cannot safely raise across
+        # Cooperative-shutdown flag, injected by Archiver.set_stop() in both
+        # one-shot and scheduled mode. Polled at export checkpoints below; the
+        # signal handler only SETS this flag (it cannot safely raise across
         # arbitrary code), so the export must poll it to cancel.
         self._stop = None
         # Content-loss ledger: paths this run failed to produce (node exports,

--- a/bookstack_file_exporter/exporter/exporter.py
+++ b/bookstack_file_exporter/exporter/exporter.py
@@ -26,10 +26,11 @@ class NodeExporter():
         self.api_urls = api_urls
         self.http_client = http_client
         self._node_filter = node_filter
-        # Cooperative-cancel flag (threading.Event). None in one-shot mode so the
-        # checks below are no-ops. Scheduled mode injects its shutdown Event so a
-        # signal mid-fetch halts the tree walk at the next node boundary instead of
-        # fetching the entire tree first. Twin of NodeArchiver._stop (archive phase).
+        # Cooperative-cancel flag (threading.Event), injected by both one-shot and
+        # scheduled mode so a signal mid-fetch halts the tree walk at the next node
+        # boundary instead of fetching the entire tree first. None (checks below are
+        # no-ops) only when run()/exporter() are called directly (tests/library use).
+        # Twin of NodeArchiver._stop (archive phase).
         self._stop = stop
         # Tracks book IDs belonging to dropped shelves; consumed in get_unassigned_books.
         # Populated in get_all_shelves, pruned in get_all_books before unassigned check.

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -47,38 +47,45 @@ def entrypoint(args: argparse.Namespace) -> int:
 def _run_once(config: ConfigNode) -> int:
     """Run the export exactly once and return an exit code.
 
-    A SIGTERM/SIGINT mid-run raises KeyboardInterrupt so the export's finally
-    block discards any partial archive before exiting. This matters for ephemeral
-    one-shot containers (`docker run --rm`, a k8s Job) where no later run exists
-    to sweep a stranded `.tgz.partial` off the output volume. Raising mid-write is
-    safe here because the only local artifacts are the tar/.partial, which
-    discard_partial removes (a signal during a remote upload may still leave a
-    partial object on the remote — same as any interrupted upload, not specific to
-    this path). The first signal also restores the default
-    disposition for both signals so a second signal force-kills via the kernel.
-    Exit code is 128+signum (SIGINT->130, SIGTERM->143).
+    Cancellation is cooperative via a shared threading.Event -- the same
+    mechanism scheduled mode uses. The export polls it at checkpoints (fetch,
+    node, per-format, per-asset boundaries) and bails; the exporter's `finally`
+    still runs discard_partial, which matters for ephemeral one-shot containers
+    (`docker run --rm`, a k8s Job) where no later run exists to sweep a
+    stranded `.tgz.partial` off the output volume. The first signal restores
+    the default disposition for both signals so a second signal force-kills
+    via the kernel. Exit code is 128+signum (SIGINT->130, SIGTERM->143).
+
+    A signal that lands after archiving (during gzip/upload/cleanup, which have
+    no checkpoints) lets the run finish, and the exit code reflects the run's
+    actual outcome -- matching scheduled mode finishing its cycle instead of
+    force-stopping mid-upload.
     """
     received = {}
+    stop = threading.Event()
 
     def _handle_signal(signum, _frame):
         received["signum"] = signum
+        log.info("Received signal %s, shutting down (signal again to force)", signum)
+        stop.set()
         signal.signal(signal.SIGTERM, signal.SIG_DFL)
         signal.signal(signal.SIGINT, signal.SIG_DFL)
-        raise KeyboardInterrupt
 
     signal.signal(signal.SIGTERM, _handle_signal)
     signal.signal(signal.SIGINT, _handle_signal)
 
     try:
-        result = run(config)
+        result = run(config, stop)
         if result is None:
-            # Defensive/unreachable: None only comes from run.py's shutdown
-            # paths, which require a stop flag -- one-shot mode never passes
-            # one, so run() can't return None here. Kept as a safe default (0)
-            # rather than a KeyError if that ever changes.
-            return 0
+            # Cycle cancelled by the shutdown signal (exporter's
+            # shutdown-during-fetch / shutdown-mid-cycle paths).
+            signum = int(received.get("signum", signal.SIGINT))
+            log.info("Interrupted by signal %s, exiting", signum)
+            return 128 + signum
         return STATUS_EFFECTS[result.status].exit_code
     except KeyboardInterrupt:
+        # Backstop only: a Ctrl-C landing in the brief window before the
+        # handlers above are installed still raises normally.
         signum = int(received.get("signum", signal.SIGINT))
         log.info("Interrupted by signal %s, exiting", signum)
         return 128 + signum
@@ -210,7 +217,8 @@ def exporter(config: ConfigNode, stop=None):
     ## Build archiver before the level branch (shared for all levels)
     archive: Archiver = Archiver(config, http_client)
 
-    # Inject the cooperative-shutdown flag (None in one-shot mode = no-op).
+    # Inject the cooperative-shutdown flag. Both modes pass a real Event now;
+    # stop is None only when run()/exporter() are called directly (tests/library use).
     archive.set_stop(stop)
 
     # create export directory if not exists
@@ -303,7 +311,7 @@ def exporter(config: ConfigNode, stop=None):
                             export_level=export_level)
     finally:
         # Eager cleanup of THIS cycle's partial on every terminal path (stop,
-        # exception, one-shot KeyboardInterrupt). No-op on success: the tar is
+        # exception). No-op on success: the tar is
         # already consumed and the .partial renamed away. The run-start sweep is
         # the backstop for SIGKILL, which kills the process before finally runs.
         archive.discard_partial()

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -44,6 +44,37 @@ def entrypoint(args: argparse.Namespace) -> int:
     return _run_scheduled(config, lambda: inputs.run_interval)
 
 
+def _install_signal_handlers(stop: threading.Event) -> dict:
+    """Install SIGTERM/SIGINT handlers for cooperative shutdown in both run modes.
+
+    Signal handlers run in the main thread between bytecodes, mid-anything;
+    raising across arbitrary code is unsafe and SIGTERM has no default
+    exception. So the handler only SETS the stop flag (which also breaks
+    scheduled mode's interruptible stop.wait()); the export polls it at
+    checkpoints to cancel. It also restores the default disposition for BOTH
+    catchable signals so that ANY second signal -- not only an identical
+    repeat -- force-kills via the kernel with its conventional exit code
+    (SIGINT->130, SIGTERM->143). This is an operator escape hatch if a slow
+    in-flight download won't drain inside the grace window (e.g. `docker stop`
+    then an impatient Ctrl-C).
+
+    Returns the dict the handler records the signal number into; one-shot mode
+    reads it to derive its 128+signum exit code (scheduled mode exits 0).
+    """
+    received = {}
+
+    def _handle_signal(signum, _frame):
+        received["signum"] = signum
+        log.info("Received signal %s, shutting down (signal again to force)", signum)
+        stop.set()
+        signal.signal(signal.SIGTERM, signal.SIG_DFL)
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+    signal.signal(signal.SIGTERM, _handle_signal)
+    signal.signal(signal.SIGINT, _handle_signal)
+    return received
+
+
 def _run_once(config: ConfigNode) -> int:
     """Run the export exactly once and return an exit code.
 
@@ -61,18 +92,8 @@ def _run_once(config: ConfigNode) -> int:
     actual outcome -- matching scheduled mode finishing its cycle instead of
     force-stopping mid-upload.
     """
-    received = {}
     stop = threading.Event()
-
-    def _handle_signal(signum, _frame):
-        received["signum"] = signum
-        log.info("Received signal %s, shutting down (signal again to force)", signum)
-        stop.set()
-        signal.signal(signal.SIGTERM, signal.SIG_DFL)
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    signal.signal(signal.SIGTERM, _handle_signal)
-    signal.signal(signal.SIGINT, _handle_signal)
+    received = _install_signal_handlers(stop)
 
     try:
         result = run(config, stop)
@@ -98,24 +119,7 @@ def _run_once(config: ConfigNode) -> int:
 def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
     """Run the export on a repeating schedule until a stop signal is received."""
     stop = threading.Event()
-
-    def _handle_signal(signum, _frame):
-        # Signal handlers run in the main thread between bytecodes, mid-anything;
-        # raising across arbitrary code is unsafe and SIGTERM has no default
-        # exception. So we only SET a flag (also breaks the interruptible
-        # stop.wait() below); the export polls it at checkpoints to cancel.
-        log.info("Received signal %s, shutting down (signal again to force)", signum)
-        stop.set()
-        # Restore the default disposition for BOTH catchable signals so that ANY
-        # second signal — not only an identical repeat — force-kills via the
-        # kernel with its conventional exit code (SIGINT->130, SIGTERM->143). This
-        # is an operator escape hatch if a slow in-flight download won't drain
-        # inside the grace window (e.g. `docker stop` then an impatient Ctrl-C).
-        signal.signal(signal.SIGTERM, signal.SIG_DFL)
-        signal.signal(signal.SIGINT, signal.SIG_DFL)
-
-    signal.signal(signal.SIGTERM, _handle_signal)
-    signal.signal(signal.SIGINT, _handle_signal)
+    _install_signal_handlers(stop)
 
     status = None
     server = None

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -163,7 +163,7 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
     return 0
 
 
-def run(config: ConfigNode, stop=None):
+def run(config: ConfigNode, stop: threading.Event | None = None) -> NotifyResult | None:
     """run export process with error handling and notification support"""
     try:
         result = exporter(config, stop)
@@ -191,7 +191,7 @@ def run(config: ConfigNode, stop=None):
         # raise original error instead of notification error
         raise run_err
 
-def exporter(config: ConfigNode, stop=None):
+def exporter(config: ConfigNode, stop: threading.Event | None = None) -> NotifyResult | None:
     """export bookstack nodes and archive locally and/or remotely"""
 
     #### Export Data #####

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -179,15 +179,16 @@ Pass `--run-once` to force a single run regardless of `run_interval` or `run_sch
 
 ## Graceful Shutdown And Grace Periods
 
-In scheduled mode `SIGTERM`/`SIGINT` shuts down gracefully: the exporter stops at the
-next asset/format/node boundary, discards any partial archive, and exits `0`. A second
-signal force-kills immediately (`130` for SIGINT, `143` for SIGTERM). Exit `0` means a
-clean shutdown, **not** that the last cycle succeeded — alert on notifications or
-`/healthz`, not on the exit code.
+Both modes handle `SIGTERM`/`SIGINT` the same cooperative way: the exporter stops at the
+next asset/format/node boundary and discards any partial archive. A second signal
+force-kills immediately (`130` for SIGINT, `143` for SIGTERM) in both modes.
 
-One-shot mode (`--run-once`, or no `run_interval`/`run_schedule`) aborts the current run
-on a signal rather than draining, but still discards any partial archive and exits
-`130`/`143`.
+Where they differ is the exit code. Scheduled mode exits `0` on a clean shutdown — that
+means the process stopped cleanly, **not** that the last cycle succeeded; alert on
+notifications or `/healthz`, not on the exit code. One-shot mode has no next cycle to
+fall back on, so an interrupted run exits `130`/`143` (128+signal) instead. A signal that
+lands after archiving finishes, during gzip/upload/cleanup (no checkpoints there), lets
+the run complete and the exit code reflects its actual outcome in either mode.
 
 A single in-flight export call (e.g. a large-book PDF render) cannot be interrupted
 mid-request, so give the container time to drain:

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -58,7 +58,7 @@ class TestRunOncePath:
         cfg = self._cfg_no_interval()
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal"), \
-             patch.object(run, "run", return_value=None):
+             patch.object(run, "run", return_value=NotifyResult(status=ExportStatus.SUCCESS)):
             result = run.entrypoint(args=_args())
         assert result == 0
 
@@ -92,7 +92,8 @@ class TestRunOncePath:
         assert result == 130
 
     def test_sigterm_during_run_cleans_up_and_returns_143(self):
-        """SIGTERM mid-run -> KeyboardInterrupt -> finally cleanup -> exit 143."""
+        """SIGTERM mid-run -> handler sets the stop event (no raise) -> run()
+        returns None (cycle cancelled) -> exit 143."""
         cfg = self._cfg_no_interval()
         captured = {}
 
@@ -102,6 +103,7 @@ class TestRunOncePath:
 
         def _signal_mid_run(_config, _stop=None):
             captured[signal.SIGTERM](signal.SIGTERM, None)
+            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
@@ -110,6 +112,8 @@ class TestRunOncePath:
         assert result == 143
 
     def test_sigint_during_run_returns_130(self):
+        """SIGINT mid-run -> handler sets the stop event (no raise) -> run()
+        returns None (cycle cancelled) -> exit 130."""
         cfg = self._cfg_no_interval()
         captured = {}
 
@@ -119,6 +123,7 @@ class TestRunOncePath:
 
         def _signal_mid_run(_config, _stop=None):
             captured[signal.SIGINT](signal.SIGINT, None)
+            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
@@ -139,6 +144,7 @@ class TestRunOncePath:
 
         def _signal_mid_run(_config, _stop=None):
             captured[signal.SIGTERM](signal.SIGTERM, None)
+            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
@@ -147,6 +153,67 @@ class TestRunOncePath:
 
         assert (signal.SIGTERM, signal.SIG_DFL) in calls
         assert (signal.SIGINT, signal.SIG_DFL) in calls
+
+    def test_stop_event_passed_to_run(self):
+        """_run_once must pass a real threading.Event to run(), same mechanism
+        as scheduled mode, so the cooperative checkpoints are live."""
+        cfg = self._cfg_no_interval()
+        captured_stop = {}
+
+        def _capture_stop(_config, _stop=None):
+            captured_stop["stop"] = _stop
+            return NotifyResult(status=ExportStatus.SUCCESS)
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal"), \
+             patch.object(run, "run", side_effect=_capture_stop):
+            run.entrypoint(args=_args())
+
+        assert isinstance(captured_stop["stop"], threading.Event)
+
+    def test_handler_sets_the_stop_event(self):
+        """The signal handler must actually flip the event it was given, not
+        just record the signum."""
+        cfg = self._cfg_no_interval()
+        captured = {}
+
+        def _capture(signum, handler):
+            if callable(handler):
+                captured[signum] = handler
+
+        captured_stop = {}
+
+        def _signal_mid_run(_config, _stop=None):
+            captured_stop["stop"] = _stop
+            captured[signal.SIGTERM](signal.SIGTERM, None)
+            return None
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
+             patch.object(run, "run", side_effect=_signal_mid_run):
+            run.entrypoint(args=_args())
+
+        assert captured_stop["stop"].is_set()
+
+    def test_signal_during_run_that_still_completes_returns_result_exit_code(self):
+        """A signal landing during a phase with no checkpoint (e.g. upload) lets
+        the run finish; the exit code reflects the run's outcome, not 128+signum."""
+        cfg = self._cfg_no_interval()
+        captured = {}
+
+        def _capture(signum, handler):
+            if callable(handler):
+                captured[signum] = handler
+
+        def _signal_then_finish(_config, _stop=None):
+            captured[signal.SIGTERM](signal.SIGTERM, None)
+            return NotifyResult(status=ExportStatus.SUCCESS)
+
+        with patch.object(run, "ConfigNode", return_value=cfg), \
+             patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
+             patch.object(run, "run", side_effect=_signal_then_finish):
+            result = run.entrypoint(args=_args())
+        assert result == 0
 
 
 # ---------------------------------------------------------------------------
@@ -158,7 +225,8 @@ class TestRunOnceFlag:
         cfg = _config(run_interval=60)
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal"), \
-             patch.object(run, "run", return_value=None) as mock_run:
+             patch.object(run, "run",
+                          return_value=NotifyResult(status=ExportStatus.SUCCESS)) as mock_run:
             result = run.entrypoint(args=_args(run_once=True))
         assert result == 0
         assert mock_run.call_count == 1
@@ -167,7 +235,8 @@ class TestRunOnceFlag:
         cfg = _config(run_interval=0)
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal"), \
-             patch.object(run, "run", return_value=None) as mock_run:
+             patch.object(run, "run",
+                          return_value=NotifyResult(status=ExportStatus.SUCCESS)) as mock_run:
             result = run.entrypoint(args=_args(run_once=False))
         assert result == 0
         assert mock_run.call_count == 1
@@ -310,7 +379,9 @@ class TestRunScheduledPath:
 def test_entrypoint_runs_once_when_no_interval():
     cfg = _config(run_interval=0)
     with patch.object(run, "ConfigNode", return_value=cfg), \
-         patch.object(run, "run", return_value=None) as mock_run:
+         patch("bookstack_file_exporter.run.signal.signal"), \
+         patch.object(run, "run",
+                      return_value=NotifyResult(status=ExportStatus.SUCCESS)) as mock_run:
         result = run.entrypoint(args=_args())
     assert result == 0
     assert mock_run.call_count == 1
@@ -616,13 +687,12 @@ def test_run_once_returns_one_on_exception():
         assert run._run_once(MagicMock()) == 1
 
 
-def test_run_once_returns_zero_when_result_none():
-    """Defensive guard only: one-shot mode never passes a stop flag, so run()
-    cannot actually return None here (that path requires cooperative shutdown).
-    The guard exists purely to avoid a KeyError if that ever changes."""
+def test_run_once_returns_130_when_result_none():
+    """None means the cycle was cancelled by the shutdown signal; with no
+    signum recorded, received.get falls back to SIGINT (130)."""
     with patch("bookstack_file_exporter.run.signal.signal"), \
          patch.object(run, "run", return_value=None):
-        assert run._run_once(MagicMock()) == 0
+        assert run._run_once(MagicMock()) == 130
 
 
 def test_run_once_returns_zero_on_empty():

--- a/tests/unit/test_run.py
+++ b/tests/unit/test_run.py
@@ -103,7 +103,6 @@ class TestRunOncePath:
 
         def _signal_mid_run(_config, _stop=None):
             captured[signal.SIGTERM](signal.SIGTERM, None)
-            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
@@ -123,7 +122,6 @@ class TestRunOncePath:
 
         def _signal_mid_run(_config, _stop=None):
             captured[signal.SIGINT](signal.SIGINT, None)
-            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
@@ -144,7 +142,6 @@ class TestRunOncePath:
 
         def _signal_mid_run(_config, _stop=None):
             captured[signal.SIGTERM](signal.SIGTERM, None)
-            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \
@@ -186,7 +183,6 @@ class TestRunOncePath:
         def _signal_mid_run(_config, _stop=None):
             captured_stop["stop"] = _stop
             captured[signal.SIGTERM](signal.SIGTERM, None)
-            return None
 
         with patch.object(run, "ConfigNode", return_value=cfg), \
              patch("bookstack_file_exporter.run.signal.signal", side_effect=_capture), \


### PR DESCRIPTION
## Changes

- One-shot mode (`_run_once`) now creates a `threading.Event` and passes it into `run()` — the same cooperative-shutdown mechanism scheduled mode uses. The signal handler records the signal number, sets the event, and restores default dispositions (second signal force-kills); it no longer raises `KeyboardInterrupt`.
- A `None` result from a cancelled cycle now exits `128+signum` (SIGINT→130, SIGTERM→143) instead of 0. The `except KeyboardInterrupt` block remains only as a backstop for a Ctrl-C landing before the handlers are installed.
- No executable changes to `_run_scheduled`, `node_archiver.py`, or `exporter.py` — comments there updated to stop claiming one-shot mode has no stop flag.
- Docs: the Graceful Shutdown section now describes both modes' identical cooperative behavior and the exit-code difference (scheduled exits 0 on clean shutdown, one-shot exits 128+signum for an interrupted run).
- Tests reworked/added in `test_run.py`: handler sets the event, a real Event reaches `run()`, cancelled-cycle exit codes, and the deliberate behavior that a signal landing after archiving (gzip/upload/cleanup have no checkpoints) lets the run finish with its real outcome.

## Motivation

One-shot mode passed no stop event into the export, so every cooperative cancellation checkpoint was dead code. With `export_workers > 1`, all nodes are submitted to the pool up-front; the `KeyboardInterrupt` raised by the old handler unwound through `as_completed` into `ThreadPoolExecutor.__exit__`, which runs `shutdown(wait=True)` without `cancel_futures` — so a SIGTERM to a one-shot container (e.g. `docker run --rm`, k8s Job) kept fetching every remaining node from the BookStack API until the queue drained or a second signal force-killed it.

With a real event, the existing checkpoints (fetch, per-node, per-format, per-asset) and the parallel path's `shutdown(cancel_futures=True)` all become live in one-shot mode with zero archiver changes, and signal handling is now one mechanism across both modes.

## Test plan / verification

- Full unit suite: 741 passed, coverage 94%, pylint 10.00.
- Live smoke against a real BookStack instance with `export_workers: 4`:
  - SIGTERM mid-archive: handler logs shutdown, in-flight workers drain at their checkpoints, queued nodes are cancelled, partial tar is discarded ("Cleaning up partial archive"), output dir left empty.
  - SIGTERM during the fetch phase: archive phase skipped, exit code `143` observed.

## In-depth

- Deliberate behavior: a signal that lands after archiving completes (during gzip/upload/cleanup, which have no checkpoints) lets the run finish, and the exit code reflects the run's actual outcome — matching scheduled mode finishing its cycle rather than aborting a finished backup mid-upload. Documented in the `_run_once` docstring and the docs page, and pinned by a test.
- Cancellation remains cooperative: a single in-flight export call (e.g. a large PDF render, or an asset download stuck in retry backoff) cannot be interrupted mid-request; the second-signal force-kill escape hatch is unchanged.
- Follow-up (separate, deferred): the parallel worker loop still converts environmental errors (`OSError`/`PermissionError`) into per-node failures instead of failing fast; deliberately left for after the tar-writer refactor, which changes write-failure semantics.