### PR TITLE
feat: stream exports directly into the final gzipped archive

### DIFF
--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -110,17 +110,19 @@ class Archiver:
         self._archiver.set_stop(stop)
 
     def discard_partial(self):
-        """Remove this run's intermediate tar and any .tgz.partial; never the final .tgz.
+        """Abort the archive stream and remove this run's .tgz.partial; never the final .tgz.
 
-        Idempotent and missing-file tolerant: an all-empty cycle writes no tar, and
-        a successful run has already consumed the tar and renamed the .partial away,
-        so this is a no-op on the success path.
+        Abort-then-unlink: the stream handle is closed (best-effort) before the
+        file is removed, and abort poisons the stream so no straggler write can
+        recreate the .partial after cleanup. Idempotent and missing-file
+        tolerant: on the success path finalize() already detached the handle and
+        renamed the .partial away, so this is a no-op.
         """
-        partial = f"{self._archiver.archive_file}.partial"
-        for path in (self._archiver.tar_file, partial):
-            if os.path.exists(path):
-                log.info("Cleaning up partial archive: %s", path)
-                util.remove_file(path)
+        self._archiver.abort_archive()
+        partial = self._archiver.partial_file
+        if os.path.exists(partial):
+            log.info("Cleaning up partial archive: %s", partial)
+            util.remove_file(partial)
 
     def sweep_orphans(self):
         """Delete prior-run .tar / .tgz.partial orphans (SIGKILL backstop).
@@ -136,7 +138,8 @@ class Archiver:
         level, so `bkps_*` clears partials stranded by prior runs at any level. The
         `bkps_` prefix still anchors the scan so unrelated files are never touched.
         (keep_last retention deliberately stays level-scoped — those are deliverables.)
-        Also retro-cleans .tar orphans from past failed cycles.
+        Also retro-cleans .tar orphans stranded by pre-v3 versions (which staged
+        an intermediate .tar before gzipping) and by past failed cycles.
         """
         tgz_ext = self._archiver.file_extension_map['tgz']
         for ext in (self._archiver.file_extension_map['tar'], f"{tgz_ext}.partial"):
@@ -150,16 +153,18 @@ class Archiver:
 
     @property
     def has_exported_content(self) -> bool:
-        """True if the intermediate tar exists, i.e. at least one file was written.
+        """True if the streaming .partial exists, i.e. at least one file was written.
 
-        Checked against the tar on disk (ground truth) rather than a flag threaded
-        up from the archivers, so it cannot drift from what was actually archived.
+        Checked against the archive on disk (ground truth) rather than a flag
+        threaded up from the archivers, so it cannot drift from what was actually
+        archived. The stream opens lazily on the first write, so mere Archiver
+        construction never creates the file.
         """
-        return os.path.exists(self._archiver.tar_file)
+        return os.path.exists(self._archiver.partial_file)
 
     def create_archive(self):
-        """create tgz archive"""
-        self._archiver.gzip_archive()
+        """finalize the streaming archive: close and atomically rename to .tgz"""
+        self._archiver.finalize_archive()
 
     # send to remote systems
     def archive_remote(self) -> list[UploadOutcome]:

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -81,8 +81,9 @@ class NodeArchiver:
         self.export_meta = export_meta
         # full path with .tgz extension
         self.archive_file = f"{archive_dir}{_FILE_EXTENSION_MAP['tgz']}"
-        # intermediate tar before gzip
-        self.tar_file = f"{archive_dir}{_FILE_EXTENSION_MAP['tar']}"
+        # streaming archive target; renamed to archive_file on finalize
+        self.partial_file = f"{self.archive_file}.partial"
+        self._tar_stream = archiver_util.TarStream(self.partial_file)
         # base folder name inside the tgz archive
         self.archive_base_path = os.path.basename(archive_dir)
         # asset handling (shared by page/book/chapter); None => disabled
@@ -302,7 +303,7 @@ class NodeArchiver:
     def _export_nodes_parallel(self, nodes: dict[int, Node], resource_type: str,
                                image_map: dict[int, list],
                                attachment_map: dict[int, list]):
-        """Fan node fetches across a thread pool; writes serialize in write_tar.
+        """Fan node fetches across a thread pool; writes serialize inside TarStream.
 
         Memory stays ~= export_workers x fattest-node: only max_workers tasks run
         at once, and _export_node returns only the tiny ContentFailures ledger,
@@ -364,7 +365,7 @@ class NodeArchiver:
 
         Self-contained per node (no shared mutable state): safe to run in a
         worker thread when export_workers > 1. Writes go through write_data ->
-        write_tar, which serializes appends under a module lock. Returns only the
+        TarStream, which serializes appends under its internal lock. Returns only the
         tiny ContentFailures ledger, so completed pool futures retain no bulky
         payload (peak RAM ~= workers x fattest-node).
         """
@@ -442,24 +443,32 @@ class NodeArchiver:
                                       self.asset_archiver.update_asset_links_html)
 
     def write_data(self, file_path: str, data: bytes):
-        """Write data to a tar file.
+        """Write data into the streaming archive.
 
         Args:
-            :file_path: <str> path of file relative to tar file inner directory
-            :data: <bytes> data to write to that file_path within the tar
+            :file_path: <str> path of file relative to archive inner directory
+            :data: <bytes> data to write to that file_path within the archive
         """
-        archiver_util.write_tar(self.tar_file, file_path, data)
+        self._tar_stream.write(file_path, data)
 
-    def gzip_archive(self):
-        """Gzip the tar atomically: write to a .partial then rename to the final .tgz.
+    def finalize_archive(self):
+        """Close the stream and atomically publish .tgz.partial as the final .tgz.
 
-        Same-filesystem os.rename is atomic, so a consumer or the next run never
-        observes a half-written .tgz (a SIGKILL/crash mid-gzip leaves only the
-        .partial, which the run-start sweep removes).
+        Close-before-rename is load-bearing: a consumer or the next run never
+        observes a half-written .tgz (a SIGKILL/crash mid-run leaves only the
+        .partial, which the run-start sweep removes). finalize() raises if the
+        stream is poisoned or the closing flush fails, so a corrupt archive is
+        never renamed into place. The unconditional os.rename never sees a
+        missing .partial: run.py only calls create_archive() after its
+        has_exported_content / content_written gates proved a write happened —
+        do not call this on an empty run.
         """
-        partial = f"{self.archive_file}.partial"
-        archiver_util.create_gzip(self.tar_file, partial)
-        os.rename(partial, self.archive_file)
+        self._tar_stream.finalize()
+        os.rename(self.partial_file, self.archive_file)
+
+    def abort_archive(self):
+        """Close the stream best-effort so the discard path can unlink the .partial."""
+        self._tar_stream.abort()
 
     @property
     def file_extension_map(self) -> dict[str, str]:

--- a/bookstack_file_exporter/archiver/util.py
+++ b/bookstack_file_exporter/archiver/util.py
@@ -32,9 +32,8 @@ class TarStream:
     .tgz.partial path), so an empty run never creates a file. All writes
     serialize under an internal lock — single-writer safety is structural,
     not a convention callers must remember. Compression runs inside the
-    lock: concurrent WRITERS serialize
-    on compress time, but fetching threads are unaffected (zlib releases the
-    GIL during compression).
+    lock: concurrent WRITERS serialize on compress time, but fetching
+    threads are unaffected (zlib releases the GIL during compression).
 
     Poisoning: a gzip stream, unlike an append-mode tar, is corrupted for all
     later members by one failed addfile. The first write error therefore

--- a/bookstack_file_exporter/archiver/util.py
+++ b/bookstack_file_exporter/archiver/util.py
@@ -3,24 +3,13 @@ import os
 import logging
 import tarfile
 import threading
-import shutil
 from io import BytesIO
-import gzip
 import glob
 from pathlib import Path
 
 from bookstack_file_exporter.common.util import HttpHelper
 
 log = logging.getLogger(__name__)
-
-# Serializes tar appends across threads. write_tar opens the archive in append
-# mode ("a") per call; two concurrent opens both seek to EOF and corrupt it.
-# The lock lives HERE (inside the writer) so single-writer safety is structural,
-# not a convention every caller must remember. Used by the export_workers pool.
-# threading.Lock is a plain non-reentrant mutex; `with _tar_write_lock:` acquires
-# on entry and releases on block exit (even if the body raises) — so only one
-# thread is ever inside the append below at a time.
-_tar_write_lock = threading.Lock()
 
 def get_byte_response(url: str, http_client: HttpHelper) -> bytes:
     """get byte response from http request"""
@@ -42,8 +31,8 @@ class TarStream:
     Opens the target lazily on the first write ("w:gz" straight onto the
     .tgz.partial path), so an empty run never creates a file. All writes
     serialize under an internal lock — single-writer safety is structural,
-    not a convention callers must remember (same contract the old write_tar
-    provided). Compression runs inside the lock: concurrent WRITERS serialize
+    not a convention callers must remember. Compression runs inside the
+    lock: concurrent WRITERS serialize
     on compress time, but fetching threads are unaffected (zlib releases the
     GIL during compression).
 
@@ -120,18 +109,6 @@ class TarStream:
                     log.debug("Ignoring close error while discarding archive stream",
                               exc_info=True)
 
-# append to a tar file instead of creating files locally and then tar'ing after
-def write_tar(base_tar_dir: str, file_path: str, data: bytes):
-    """append byte data to tar file (thread-safe via _tar_write_lock)"""
-    with _tar_write_lock:
-        with tarfile.open(base_tar_dir, "a") as tar:
-            data_obj = BytesIO(data)
-            tar_info = tarfile.TarInfo(name=file_path)
-            tar_info.size = data_obj.getbuffer().nbytes
-            log.debug("Adding file: %s with size: %d bytes to tar file",
-                      tar_info.name, tar_info.size)
-            tar.addfile(tar_info, fileobj=data_obj)
-
 def get_json_bytes(data: dict[str, str | int]) -> bytes:
     """dump dict to json file"""
     return json.dumps(data, indent=4).encode('utf-8')
@@ -140,14 +117,6 @@ def get_json_bytes(data: dict[str, str | int]) -> bytes:
 def remove_file(file_path: str):
     """remove a file"""
     os.remove(file_path)
-
-def create_gzip(file_path: str, gzip_file: str, remove_old: bool = True):
-    """create a gzip of an existing file/dir and remove it"""
-    with open(file_path, 'rb') as f_in:
-        with gzip.open(gzip_file, 'wb') as f_out:
-            shutil.copyfileobj(f_in, f_out)
-    if remove_old:
-        remove_file(file_path)
 
 def scan_archives(base_dir: str, extension: str) -> list[str]:
     """scan export directory for archives"""

--- a/bookstack_file_exporter/archiver/util.py
+++ b/bookstack_file_exporter/archiver/util.py
@@ -27,6 +27,99 @@ def get_byte_response(url: str, http_client: HttpHelper) -> bytes:
     response = http_client.http_get_request(url=url)
     return response.content
 
+class ArchiveWriteError(Exception):
+    """The streaming archive is unusable and must be discarded.
+
+    Raised on the first failed member write (which poisons the stream), on any
+    later write against a poisoned stream, and by finalize() when the stream is
+    poisoned or the closing flush fails. Callers must never publish the
+    .partial once this has been raised.
+    """
+
+class TarStream:
+    """Single-owner streaming .tar.gz writer for one export run.
+
+    Opens the target lazily on the first write ("w:gz" straight onto the
+    .tgz.partial path), so an empty run never creates a file. All writes
+    serialize under an internal lock — single-writer safety is structural,
+    not a convention callers must remember (same contract the old write_tar
+    provided). Compression runs inside the lock: concurrent WRITERS serialize
+    on compress time, but fetching threads are unaffected (zlib releases the
+    GIL during compression).
+
+    Poisoning: a gzip stream, unlike an append-mode tar, is corrupted for all
+    later members by one failed addfile. The first write error therefore
+    poisons the stream — every subsequent write() and finalize() raises
+    ArchiveWriteError — so a corrupt archive can never be published.
+    """
+    def __init__(self, path: str):
+        self._path = path
+        self._lock = threading.Lock()
+        self._tar: tarfile.TarFile | None = None
+        self._poisoned = False
+
+    def write(self, file_path: str, data: bytes):
+        """Append one member; thread-safe. Raises ArchiveWriteError on failure."""
+        with self._lock:
+            if self._poisoned:
+                raise ArchiveWriteError(
+                    f"archive stream already failed; dropping write of {file_path}")
+            try:
+                if self._tar is None:
+                    # Handle is intentionally kept open across calls (not a
+                    # `with` block); it's closed later by finalize()/abort().
+                    self._tar = tarfile.open(self._path, "w:gz")  # pylint: disable=consider-using-with
+                data_obj = BytesIO(data)
+                tar_info = tarfile.TarInfo(name=file_path)
+                tar_info.size = data_obj.getbuffer().nbytes
+                log.debug("Adding file: %s with size: %d bytes to archive stream",
+                          tar_info.name, tar_info.size)
+                self._tar.addfile(tar_info, fileobj=data_obj)
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                self._poisoned = True
+                raise ArchiveWriteError(
+                    f"archive write failed for {file_path}: {err}") from err
+
+    def finalize(self):
+        """Close the stream so the .partial is complete and publishable.
+
+        Close-then-rename ordering is load-bearing: close() flushes the gzip
+        trailer, and a failure here (or a poisoned stream) raises so the caller
+        discards the .partial instead of renaming a truncated archive into place.
+        No-op if nothing was ever written.
+        """
+        with self._lock:
+            if self._poisoned:
+                raise ArchiveWriteError("archive stream failed mid-run; not publishing")
+            if self._tar is None:
+                return
+            tar = self._tar
+            self._tar = None
+            try:
+                tar.close()
+            except Exception as err:  # pylint: disable=broad-exception-caught
+                self._poisoned = True
+                raise ArchiveWriteError(
+                    f"archive close failed; not publishing: {err}") from err
+
+    def abort(self):
+        """Best-effort close for the discard path; idempotent, never raises.
+
+        Poisons the stream so no write can land after cleanup has started.
+        Safe after finalize(): the handle is already detached, so the
+        successfully published archive is untouched.
+        """
+        with self._lock:
+            tar = self._tar
+            self._tar = None
+            self._poisoned = True
+            if tar is not None:
+                try:
+                    tar.close()
+                except Exception:  # pylint: disable=broad-exception-caught
+                    log.debug("Ignoring close error while discarding archive stream",
+                              exc_info=True)
+
 # append to a tar file instead of creating files locally and then tar'ing after
 def write_tar(base_tar_dir: str, file_path: str, data: bytes):
     """append byte data to tar file (thread-safe via _tar_write_lock)"""

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -87,8 +87,8 @@ def _run_once(config: ConfigNode) -> int:
     the default disposition for both signals so a second signal force-kills
     via the kernel. Exit code is 128+signum (SIGINT->130, SIGTERM->143).
 
-    A signal that lands after archiving (during gzip/upload/cleanup, which have
-    no checkpoints) lets the run finish, and the exit code reflects the run's
+    A signal that lands after archiving (during archive finalize/upload/cleanup,
+    which have no checkpoints) lets the run finish, and the exit code reflects the run's
     actual outcome -- matching scheduled mode finishing its cycle instead of
     force-stopping mid-upload.
     """
@@ -260,13 +260,13 @@ def exporter(config: ConfigNode, stop: threading.Event | None = None) -> NotifyR
         # get all content for each node
         archive.get_bookstack_exports(nodes)
 
-        # Graceful shutdown requested mid-cycle: drop the partial tar and skip
-        # gzip/upload/cleanup so a cancelled cycle never produces an archive.
+        # Graceful shutdown requested mid-cycle: drop the partial archive and skip
+        # finalize/upload/cleanup so a cancelled cycle never produces an archive.
         if stop is not None and stop.is_set():
             log.info("Shutdown requested mid-cycle; discarding partial export")
             return None
 
-        # Gate on DOCUMENT content, not the tar file: assets/meta alone are not a
+        # Gate on DOCUMENT content, not the archive stream: assets/meta alone are not a
         # restorable backup. Failures recorded but zero node exports archived ->
         # hard failure, not Partial (Partial promises some of the backup
         # survived). Empty ledger + empty tar is a benign empty instance.
@@ -280,7 +280,7 @@ def exporter(config: ConfigNode, stop: threading.Event | None = None) -> NotifyR
             log.warning("No %s content was archived. Nothing to upload", export_level)
             return NotifyResult(status=ExportStatus.EMPTY, export_level=export_level)
 
-        # create tar if needed and gzip tar
+        # close the archive stream and publish the .tgz
         archive.create_archive()
 
         # attempt every remote target, then derive status (raises only when no copy survives)
@@ -315,7 +315,7 @@ def exporter(config: ConfigNode, stop: threading.Event | None = None) -> NotifyR
                             export_level=export_level)
     finally:
         # Eager cleanup of THIS cycle's partial on every terminal path (stop,
-        # exception). No-op on success: the tar is
-        # already consumed and the .partial renamed away. The run-start sweep is
-        # the backstop for SIGKILL, which kills the process before finally runs.
+        # exception). No-op on success: the stream is already closed and the
+        # .partial renamed away. The run-start sweep is the backstop for
+        # SIGKILL, which kills the process before finally runs.
         archive.discard_partial()

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -187,7 +187,7 @@ Where they differ is the exit code. Scheduled mode exits `0` on a clean shutdown
 means the process stopped cleanly, **not** that the last cycle succeeded; alert on
 notifications or `/healthz`, not on the exit code. One-shot mode has no next cycle to
 fall back on, so an interrupted run exits `130`/`143` (128+signal) instead. A signal that
-lands after archiving finishes, during gzip/upload/cleanup (no checkpoints there), lets
+lands after archiving finishes, during archive finalize/upload/cleanup (no checkpoints there), lets
 the run complete and the exit code reflects its actual outcome in either mode.
 
 A single in-flight export call (e.g. a large-book PDF render) cannot be interrupted

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -53,51 +53,35 @@ class TestSetStop:
 
 
 class TestDiscardPartial:
-    def test_removes_tar_and_partial_when_present(self, archiver_instance, tmp_path):
-        tar = tmp_path / "bkps_2026.tar"
+    """discard_partial aborts the stream and removes only this run's .partial."""
+
+    def test_removes_partial_and_leaves_final_tgz(self, archiver_instance, tmp_path):
         partial = tmp_path / "bkps_2026.tgz.partial"
-        tar.write_bytes(b"x")
-        partial.write_bytes(b"y")
-        archiver_instance._archiver.tar_file = str(tar)
-        archiver_instance._archiver.archive_file = str(tmp_path / "bkps_2026.tgz")
-
-        archiver_instance.discard_partial()
-
-        assert not tar.exists()
-        assert not partial.exists()
-
-    def test_logs_each_removed_path(self, archiver_instance, tmp_path, caplog):
-        tar = tmp_path / "bkps_2026.tar"
-        tar.write_bytes(b"x")
-        archiver_instance._archiver.tar_file = str(tar)
-        archiver_instance._archiver.archive_file = str(tmp_path / "bkps_2026.tgz")
-
-        with caplog.at_level(logging.INFO):
-            archiver_instance.discard_partial()
-
-        assert any(str(tar) in r.message and "partial" in r.message.lower()
-                   for r in caplog.records)
-
-    def test_no_log_when_nothing_to_discard(self, archiver_instance, tmp_path, caplog):
-        archiver_instance._archiver.tar_file = str(tmp_path / "absent.tar")
-        archiver_instance._archiver.archive_file = str(tmp_path / "absent.tgz")
-        with caplog.at_level(logging.INFO):
-            archiver_instance.discard_partial()
-        assert not any("partial" in r.message.lower() for r in caplog.records)
-
-    def test_no_error_when_nothing_to_discard(self, archiver_instance, tmp_path):
-        archiver_instance._archiver.tar_file = str(tmp_path / "absent.tar")
-        archiver_instance._archiver.archive_file = str(tmp_path / "absent.tgz")
-        # must not raise (all-empty cycle writes no tar)
-        archiver_instance.discard_partial()
-
-    def test_does_not_touch_final_tgz(self, archiver_instance, tmp_path):
         final = tmp_path / "bkps_2026.tgz"
-        final.write_bytes(b"done")
-        archiver_instance._archiver.tar_file = str(tmp_path / "bkps_2026.tar")
-        archiver_instance._archiver.archive_file = str(final)
+        partial.write_bytes(b"partial")
+        final.write_bytes(b"final")
+        archiver_instance._archiver.partial_file = str(partial)
         archiver_instance.discard_partial()
+        assert not partial.exists()
         assert final.exists()
+
+    def test_noop_when_nothing_on_disk(self, archiver_instance, tmp_path):
+        archiver_instance._archiver.partial_file = str(tmp_path / "absent.tgz.partial")
+        archiver_instance.discard_partial()  # no raise
+
+    def test_aborts_stream_before_unlink(self, archiver_instance, tmp_path):
+        # The archiver_instance fixture injects a MagicMock node archiver,
+        # so assert the ORDERING contract on the mock:
+        # abort_archive must run while the .partial is still on disk.
+        partial = tmp_path / "bkps_2026.tgz.partial"
+        partial.write_bytes(b"stream")
+        archiver_instance._archiver.partial_file = str(partial)
+        order = []
+        archiver_instance._archiver.abort_archive.side_effect = (
+            lambda: order.append(("abort", partial.exists())))
+        archiver_instance.discard_partial()
+        assert order == [("abort", True)]
+        assert not partial.exists()
 
 
 class TestSweepOrphans:
@@ -140,16 +124,16 @@ class TestSweepOrphans:
 
 
 class TestHasExportedContent:
-    """has_exported_content reflects whether the intermediate tar exists on disk."""
+    """has_exported_content reflects whether the streaming .partial exists on disk."""
 
-    def test_false_when_tar_missing(self, archiver_instance, tmp_path):
-        archiver_instance._archiver.tar_file = str(tmp_path / "absent.tar")
+    def test_false_when_no_partial(self, archiver_instance, tmp_path):
+        archiver_instance._archiver.partial_file = str(tmp_path / "absent.tgz.partial")
         assert archiver_instance.has_exported_content is False
 
-    def test_true_when_tar_exists(self, archiver_instance, tmp_path):
-        tar_path = tmp_path / "present.tar"
-        tar_path.write_bytes(b"data")
-        archiver_instance._archiver.tar_file = str(tar_path)
+    def test_true_when_partial_exists(self, archiver_instance, tmp_path):
+        partial = tmp_path / "bkps_2026.tgz.partial"
+        partial.write_bytes(b"stream")
+        archiver_instance._archiver.partial_file = str(partial)
         assert archiver_instance.has_exported_content is True
 
 

--- a/tests/unit/test_archiver_util.py
+++ b/tests/unit/test_archiver_util.py
@@ -1,10 +1,7 @@
 # pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
 """Unit tests for archiver utility functions (scan, compress, delete)."""
-import gzip
 import json
-import os
 import tarfile
-import threading
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
@@ -82,109 +79,6 @@ def test_get_json_bytes_is_indented():
     result = util.get_json_bytes(data)
     text = result.decode("utf-8")
     assert "\n" in text  # indent=4 produces newlines
-
-
-# ---------------------------------------------------------------------------
-# write_tar
-# ---------------------------------------------------------------------------
-
-def test_write_tar_creates_tar_file(tmp_path):
-    tar_path = str(tmp_path / "archive.tar")
-    util.write_tar(tar_path, "hello.txt", b"hello world")
-    assert os.path.isfile(tar_path)
-
-
-def test_write_tar_appends_entry(tmp_path):
-    tar_path = str(tmp_path / "archive.tar")
-    util.write_tar(tar_path, "file1.txt", b"data1")
-    util.write_tar(tar_path, "file2.txt", b"data2")
-    with tarfile.open(tar_path, "r") as tar:
-        names = tar.getnames()
-    assert "file1.txt" in names
-    assert "file2.txt" in names
-
-
-def test_write_tar_correct_content(tmp_path):
-    tar_path = str(tmp_path / "archive.tar")
-    content = b"exact bytes"
-    util.write_tar(tar_path, "doc.txt", content)
-    with tarfile.open(tar_path, "r") as tar:
-        member = tar.getmember("doc.txt")
-        extracted = tar.extractfile(member).read()
-    assert extracted == content
-
-
-def test_write_tar_entry_size_matches(tmp_path):
-    tar_path = str(tmp_path / "archive.tar")
-    content = b"size check"
-    util.write_tar(tar_path, "check.txt", content)
-    with tarfile.open(tar_path, "r") as tar:
-        member = tar.getmember("check.txt")
-    assert member.size == len(content)
-
-
-def test_write_tar_concurrent_appends_all_present(tmp_path):
-    """Concurrent appends from many threads must all land in a valid tar.
-
-    Without serialization, two concurrent tarfile.open(path,"a") both seek to
-    EOF and corrupt the archive. A Barrier maximizes overlap to expose it.
-    """
-    tar_path = str(tmp_path / "concurrent.tar")
-    n = 50
-    barrier = threading.Barrier(n)
-
-    def worker(i):
-        barrier.wait()  # release all threads simultaneously
-        util.write_tar(tar_path, f"file{i}.txt", f"data{i}".encode())
-
-    threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
-    for t in threads:
-        t.start()
-    for t in threads:
-        t.join()
-
-    with tarfile.open(tar_path, "r") as tar:
-        names = set(tar.getnames())
-    assert names == {f"file{i}.txt" for i in range(n)}
-
-
-# ---------------------------------------------------------------------------
-# create_gzip
-# ---------------------------------------------------------------------------
-
-def test_create_gzip_produces_gzip_file(tmp_path):
-    src = tmp_path / "source.tar"
-    src.write_bytes(b"raw bytes")
-    gz = tmp_path / "source.tar.gz"
-    util.create_gzip(str(src), str(gz))
-    assert gz.is_file()
-
-
-def test_create_gzip_removes_original_by_default(tmp_path):
-    src = tmp_path / "source.tar"
-    src.write_bytes(b"raw bytes")
-    gz = tmp_path / "source.tar.gz"
-    util.create_gzip(str(src), str(gz))
-    assert not src.exists()
-
-
-def test_create_gzip_keeps_original_when_remove_old_false(tmp_path):
-    src = tmp_path / "source.tar"
-    src.write_bytes(b"raw bytes")
-    gz = tmp_path / "source.tar.gz"
-    util.create_gzip(str(src), str(gz), remove_old=False)
-    assert src.exists()
-
-
-def test_create_gzip_content_survives_round_trip(tmp_path):
-    original = b"important data"
-    src = tmp_path / "data.tar"
-    src.write_bytes(original)
-    gz = tmp_path / "data.tar.gz"
-    util.create_gzip(str(src), str(gz), remove_old=False)
-    with gzip.open(str(gz), "rb") as f:
-        recovered = f.read()
-    assert recovered == original
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_archiver_util.py
+++ b/tests/unit/test_archiver_util.py
@@ -1,15 +1,17 @@
-# pylint: disable=missing-class-docstring,missing-function-docstring
+# pylint: disable=missing-class-docstring,missing-function-docstring,protected-access
 """Unit tests for archiver utility functions (scan, compress, delete)."""
 import gzip
 import json
 import os
 import tarfile
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
 
 from bookstack_file_exporter.archiver import util
+from bookstack_file_exporter.archiver.util import ArchiveWriteError, TarStream
 
 
 # ---------------------------------------------------------------------------
@@ -220,3 +222,151 @@ def test_scan_archives_extension_filter(tmp_path):
     zip_results = util.scan_archives(base, ".zip")
     assert len(gz_results) == 1
     assert len(zip_results) == 1
+
+
+# ---------------------------------------------------------------------------
+# TarStream
+# ---------------------------------------------------------------------------
+
+class TestTarStreamWrite:
+    """TarStream streams members into a gzip'd tar at the given path."""
+
+    def test_lazy_open_no_file_before_first_write(self, tmp_path):
+        partial = str(tmp_path / "bkps.tgz.partial")
+        TarStream(partial)
+        assert not (tmp_path / "bkps.tgz.partial").exists()
+
+    def test_first_write_creates_partial(self, tmp_path):
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        stream.write("hello.txt", b"hello world")
+        assert (tmp_path / "bkps.tgz.partial").exists()
+
+    def test_members_readable_after_finalize(self, tmp_path):
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        stream.write("file1.txt", b"data1")
+        stream.write("dir/file2.txt", b"data2")
+        stream.finalize()
+        with tarfile.open(partial, "r:gz") as tar:
+            names = tar.getnames()
+            assert names == ["file1.txt", "dir/file2.txt"]
+            member = tar.extractfile("dir/file2.txt")
+            assert member.read() == b"data2"
+
+    def test_member_size_matches_payload(self, tmp_path):
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        payload = b"x" * 4096
+        stream.write("big.bin", payload)
+        stream.finalize()
+        with tarfile.open(partial, "r:gz") as tar:
+            info = tar.getmember("big.bin")
+            assert info.size == len(payload)
+
+    def test_concurrent_writes_all_present(self, tmp_path):
+        """Writes from a pool serialize under the internal lock; nothing is lost."""
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        n = 32
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [
+                pool.submit(stream.write, f"file{i}.txt", f"data{i}".encode())
+                for i in range(n)
+            ]
+            for future in futures:
+                future.result()
+        stream.finalize()
+        with tarfile.open(partial, "r:gz") as tar:
+            assert sorted(tar.getnames()) == sorted(f"file{i}.txt" for i in range(n))
+
+
+class TestTarStreamPoison:
+    """First write failure poisons the stream: later writes and finalize fail fast."""
+
+    def _poisoned_stream(self, tmp_path, monkeypatch) -> TarStream:
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        stream.write("ok.txt", b"fine")
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+        # Poison via a failing member write on the underlying handle.
+        monkeypatch.setattr(stream._tar, "addfile", boom)
+        with pytest.raises(ArchiveWriteError):
+            stream.write("bad.txt", b"payload")
+        return stream
+
+    def test_failed_write_raises_archive_write_error(self, tmp_path, monkeypatch):
+        self._poisoned_stream(tmp_path, monkeypatch)
+
+    def test_subsequent_write_fails_fast(self, tmp_path, monkeypatch):
+        stream = self._poisoned_stream(tmp_path, monkeypatch)
+        with pytest.raises(ArchiveWriteError):
+            stream.write("later.txt", b"payload")
+
+    def test_finalize_refuses_poisoned_stream(self, tmp_path, monkeypatch):
+        stream = self._poisoned_stream(tmp_path, monkeypatch)
+        with pytest.raises(ArchiveWriteError):
+            stream.finalize()
+
+    def test_open_failure_poisons(self, tmp_path):
+        # Unwritable target: first write fails, second fails fast as poisoned.
+        stream = TarStream(str(tmp_path / "no_such_dir" / "bkps.tgz.partial"))
+        with pytest.raises(ArchiveWriteError):
+            stream.write("a.txt", b"a")
+        with pytest.raises(ArchiveWriteError):
+            stream.write("b.txt", b"b")
+
+
+class TestTarStreamLifecycle:
+    """finalize/abort close semantics: idempotent, safe on every terminal path."""
+
+    def test_finalize_without_writes_is_noop(self, tmp_path):
+        stream = TarStream(str(tmp_path / "bkps.tgz.partial"))
+        stream.finalize()  # nothing written, nothing to close, no error
+        assert not (tmp_path / "bkps.tgz.partial").exists()
+
+    def test_abort_never_raises_and_is_idempotent(self, tmp_path):
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        stream.write("a.txt", b"a")
+        stream.abort()
+        stream.abort()  # double-abort: no error
+
+    def test_abort_swallows_close_errors(self, tmp_path, monkeypatch):
+        stream = TarStream(str(tmp_path / "bkps.tgz.partial"))
+        stream.write("a.txt", b"a")
+
+        def boom():
+            raise OSError("flush failed")
+        monkeypatch.setattr(stream._tar, "close", boom)
+        stream.abort()  # never raises, even when close blows up
+
+    def test_finalize_close_failure_raises_archive_write_error(self, tmp_path, monkeypatch):
+        stream = TarStream(str(tmp_path / "bkps.tgz.partial"))
+        stream.write("a.txt", b"a")
+
+        def boom():
+            raise OSError("flush failed")
+        monkeypatch.setattr(stream._tar, "close", boom)
+        with pytest.raises(ArchiveWriteError):
+            stream.finalize()
+
+    def test_abort_after_finalize_is_noop(self, tmp_path):
+        """Success path: finalize() then the finally-block discard's abort()."""
+        partial = str(tmp_path / "bkps.tgz.partial")
+        stream = TarStream(partial)
+        stream.write("a.txt", b"a")
+        stream.finalize()
+        stream.abort()
+        # finalize's close already flushed a valid archive; abort didn't break it
+        with tarfile.open(partial, "r:gz") as tar:
+            assert tar.getnames() == ["a.txt"]
+
+    def test_write_after_abort_raises(self, tmp_path):
+        stream = TarStream(str(tmp_path / "bkps.tgz.partial"))
+        stream.write("a.txt", b"a")
+        stream.abort()
+        with pytest.raises(ArchiveWriteError):
+            stream.write("b.txt", b"b")

--- a/tests/unit/test_asset_archiver_modify_html.py
+++ b/tests/unit/test_asset_archiver_modify_html.py
@@ -119,7 +119,7 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"<html><body>content</body></html>",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({5: page})
 
@@ -149,7 +149,7 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"<html><body>test</body></html>",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({5: page})
 
@@ -184,7 +184,7 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"<html><body>content</body></html>",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({5: page})
 
@@ -233,7 +233,7 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"<html><body>content</body></html>",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({5: page})
 
@@ -316,7 +316,7 @@ class TestE2eHtmlRewrite:  # pylint: disable=too-few-public-methods
 
         written: dict = {}
 
-        def capture_write(_base_tar_dir: str, file_path: str, data: bytes) -> None:
+        def capture_write(file_path: str, data: bytes) -> None:
             written[file_path] = data
 
         parent = build_node(id=1, name="my-book", slug="my-book")
@@ -330,7 +330,7 @@ class TestE2eHtmlRewrite:  # pylint: disable=too-few-public-methods
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=self.PAGE_HTML.encode(),
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar",
+            "bookstack_file_exporter.archiver.util.TarStream.write",
             side_effect=capture_write,
         ):
             archiver.archive({self.PAGE_ID: page})

--- a/tests/unit/test_book_archiver.py
+++ b/tests/unit/test_book_archiver.py
@@ -59,9 +59,9 @@ class TestConstruction:
         archiver = _make_book_archiver(tmp_path)
         assert archiver.archive_file.endswith(".tgz")
 
-    def test_tar_file_ends_with_tar(self, tmp_path):
+    def test_partial_file_ends_with_tgz_partial(self, tmp_path):
         archiver = _make_book_archiver(tmp_path)
-        assert archiver.tar_file.endswith(".tar")
+        assert archiver.partial_file.endswith(".tgz.partial")
 
     def test_archive_base_path_is_last_segment(self, tmp_path):
         archiver = _make_book_archiver(tmp_path)
@@ -96,7 +96,7 @@ class TestArchiveMultipleBooksAndFormats:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"book content",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(book_nodes)
         assert mock_write_tar.call_count == expected_writes
@@ -116,7 +116,7 @@ class TestExportUrl:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"data",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({42: book_node})
 
@@ -144,7 +144,7 @@ class TestHTTPErrorHandling:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=side_effect,
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({10: book_node})
 
@@ -160,7 +160,7 @@ class TestHTTPErrorHandling:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=HTTPError("pdf failed"),
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({10: book_node})
 
@@ -183,7 +183,7 @@ class TestExportMeta:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"book data",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(book_nodes)
         # 2 books × 1 format + 2 meta files = 4 writes
@@ -196,7 +196,7 @@ class TestExportMeta:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"book data",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(book_nodes)
         # 1 book × 1 format only
@@ -217,7 +217,7 @@ class TestEmptyBook:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"data",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({99: empty_book, 100: non_empty_book})
 
@@ -235,7 +235,7 @@ class TestEmptyBook:
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(empty_books)
 
@@ -253,7 +253,7 @@ class TestEmptyInput:
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({})
         assert mock_get_bytes.call_count == 0

--- a/tests/unit/test_book_archiver.py
+++ b/tests/unit/test_book_archiver.py
@@ -77,7 +77,7 @@ class TestConstruction:
 
 
 # ---------------------------------------------------------------------------
-# 2. N books × N formats → N*M write_tar calls
+# 2. N books × N formats → N*M stream write calls
 # ---------------------------------------------------------------------------
 
 class TestArchiveMultipleBooksAndFormats:
@@ -87,7 +87,7 @@ class TestArchiveMultipleBooksAndFormats:
         (2, ["pdf", "html"], 4),
         (3, ["markdown", "html", "pdf"], 9),
     ])
-    def test_write_tar_call_count(self, tmp_path, n_books, formats, expected_writes):
+    def test_stream_write_call_count(self, tmp_path, n_books, formats, expected_writes):
         archiver = _make_book_archiver(tmp_path, formats=formats)
         book_nodes = {
             i: _make_book_node(i, f"book-{i}") for i in range(1, n_books + 1)
@@ -97,9 +97,9 @@ class TestArchiveMultipleBooksAndFormats:
             return_value=b"book content",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(book_nodes)
-        assert mock_write_tar.call_count == expected_writes
+        assert mock_stream_write.call_count == expected_writes
 
 
 # ---------------------------------------------------------------------------
@@ -145,11 +145,11 @@ class TestHTTPErrorHandling:
             side_effect=side_effect,
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({10: book_node})
 
         # pdf skipped, html written — 1 write
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
     def test_all_formats_fail_but_meta_still_written(self, tmp_path):
         """All format fetches fail, but export_meta still writes a meta file to the tar."""
@@ -161,11 +161,11 @@ class TestHTTPErrorHandling:
             side_effect=HTTPError("pdf failed"),
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({10: book_node})
 
         # pdf skipped, but meta still written → 1 write
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -184,10 +184,10 @@ class TestExportMeta:
             return_value=b"book data",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(book_nodes)
         # 2 books × 1 format + 2 meta files = 4 writes
-        assert mock_write_tar.call_count == 4
+        assert mock_stream_write.call_count == 4
 
     def test_meta_not_written_when_disabled(self, tmp_path):
         archiver = _make_book_archiver(tmp_path, formats=["pdf"], export_meta=False)
@@ -197,10 +197,10 @@ class TestExportMeta:
             return_value=b"book data",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(book_nodes)
         # 1 book × 1 format only
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -218,12 +218,12 @@ class TestEmptyBook:
             return_value=b"data",
         ) as mock_get_bytes, patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({99: empty_book, 100: non_empty_book})
 
         # empty book: no fetch, no write; full book: 1 fetch, 1 write
         assert mock_get_bytes.call_count == 1
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
     def test_all_empty_books_no_fetch_no_write(self, tmp_path):
         archiver = _make_book_archiver(tmp_path, formats=["pdf"])
@@ -236,11 +236,11 @@ class TestEmptyBook:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(empty_books)
 
         assert mock_get_bytes.call_count == 0
-        assert mock_write_tar.call_count == 0
+        assert mock_stream_write.call_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -254,10 +254,10 @@ class TestEmptyInput:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({})
         assert mock_get_bytes.call_count == 0
-        assert mock_write_tar.call_count == 0
+        assert mock_stream_write.call_count == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_chapter_archiver.py
+++ b/tests/unit/test_chapter_archiver.py
@@ -92,7 +92,7 @@ class TestArchiveMultipleChaptersAndFormats:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"chapter content",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(chapter_nodes)
         assert mock_write_tar.call_count == expected_writes
@@ -113,7 +113,7 @@ class TestExportUrl:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"data",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({55: chapter_node})
 
@@ -141,7 +141,7 @@ class TestHTTPErrorHandling:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=side_effect,
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({10: chapter_node})
 
@@ -157,7 +157,7 @@ class TestHTTPErrorHandling:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=HTTPError("pdf failed"),
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({10: chapter_node})
 
@@ -181,7 +181,7 @@ class TestExportMeta:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"chapter data",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(chapter_nodes)
         # 2 chapters × 1 format + 2 meta files = 4 writes
@@ -195,7 +195,7 @@ class TestExportMeta:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"chapter data",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(chapter_nodes)
         assert mock_write_tar.call_count == 1
@@ -216,7 +216,7 @@ class TestEmptyChapter:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"data",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({99: empty_chapter, 100: full_chapter})
 
@@ -234,7 +234,7 @@ class TestEmptyChapter:
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(empty_chapters)
 
@@ -252,7 +252,7 @@ class TestEmptyInput:
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({})
         assert mock_get_bytes.call_count == 0

--- a/tests/unit/test_chapter_archiver.py
+++ b/tests/unit/test_chapter_archiver.py
@@ -71,7 +71,7 @@ class TestConstruction:
 
 
 # ---------------------------------------------------------------------------
-# 2. N chapters × N formats → N*M write_tar calls
+# 2. N chapters × N formats → N*M stream write calls
 # ---------------------------------------------------------------------------
 
 class TestArchiveMultipleChaptersAndFormats:
@@ -81,7 +81,7 @@ class TestArchiveMultipleChaptersAndFormats:
         (2, ["pdf", "html"], 4),
         (3, ["markdown", "html", "pdf"], 9),
     ])
-    def test_write_tar_call_count(self, tmp_path, n_chapters, formats, expected_writes):
+    def test_stream_write_call_count(self, tmp_path, n_chapters, formats, expected_writes):
         archiver = _make_chapter_archiver(tmp_path, formats=formats)
         book = _make_book_node()
         chapter_nodes = {
@@ -93,9 +93,9 @@ class TestArchiveMultipleChaptersAndFormats:
             return_value=b"chapter content",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(chapter_nodes)
-        assert mock_write_tar.call_count == expected_writes
+        assert mock_stream_write.call_count == expected_writes
 
 
 # ---------------------------------------------------------------------------
@@ -142,10 +142,10 @@ class TestHTTPErrorHandling:
             side_effect=side_effect,
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({10: chapter_node})
 
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
     def test_all_formats_fail_but_meta_still_written(self, tmp_path):
         """All format fetches fail, but export_meta still writes a meta file to the tar."""
@@ -158,11 +158,11 @@ class TestHTTPErrorHandling:
             side_effect=HTTPError("pdf failed"),
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({10: chapter_node})
 
         # pdf skipped, but meta still written → 1 write
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -182,10 +182,10 @@ class TestExportMeta:
             return_value=b"chapter data",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(chapter_nodes)
         # 2 chapters × 1 format + 2 meta files = 4 writes
-        assert mock_write_tar.call_count == 4
+        assert mock_stream_write.call_count == 4
 
     def test_meta_not_written_when_disabled(self, tmp_path):
         archiver = _make_chapter_archiver(tmp_path, formats=["pdf"], export_meta=False)
@@ -196,9 +196,9 @@ class TestExportMeta:
             return_value=b"chapter data",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(chapter_nodes)
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -217,11 +217,11 @@ class TestEmptyChapter:
             return_value=b"data",
         ) as mock_get_bytes, patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({99: empty_chapter, 100: full_chapter})
 
         assert mock_get_bytes.call_count == 1
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
     def test_all_empty_chapters_no_fetch_no_write(self, tmp_path):
         archiver = _make_chapter_archiver(tmp_path, formats=["pdf"])
@@ -235,11 +235,11 @@ class TestEmptyChapter:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(empty_chapters)
 
         assert mock_get_bytes.call_count == 0
-        assert mock_write_tar.call_count == 0
+        assert mock_stream_write.call_count == 0
 
 
 # ---------------------------------------------------------------------------
@@ -253,10 +253,10 @@ class TestEmptyInput:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
         ) as mock_get_bytes, patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({})
         assert mock_get_bytes.call_count == 0
-        assert mock_write_tar.call_count == 0
+        assert mock_stream_write.call_count == 0
 
 
 

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -276,14 +276,14 @@ class TestArchivePages:
             return_value=b"page bytes",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(page_nodes)
 
-        # 2 pages × 1 format = 2 write_tar calls
-        assert mock_write_tar.call_count == 2
+        # 2 pages × 1 format = 2 stream write calls
+        assert mock_stream_write.call_count == 2
 
     def test_archive_respects_multiple_formats(self, tmp_path, build_node):
-        """archive should call write_tar once per page per format."""
+        """archive should write to the stream once per page per format."""
         mock_asset = MagicMock()
         config = _make_config(formats=["markdown", "html"], export_images=False,
                                export_attachments=False, export_meta=False)
@@ -301,11 +301,11 @@ class TestArchivePages:
             return_value=b"content",
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive(page_nodes)
 
-        # 1 page × 2 formats = 2 write_tar calls
-        assert mock_write_tar.call_count == 2
+        # 1 page × 2 formats = 2 stream write calls
+        assert mock_stream_write.call_count == 2
 
     def test_failed_page_format_skipped_run_continues(self, tmp_path, build_node):
         """A 403/404 on one page-format export is skipped, not fatal; others still written."""
@@ -330,11 +330,11 @@ class TestArchivePages:
             side_effect=_byte_response,
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({30: good, 3: forbidden})  # must not raise
 
         # forbidden page skipped, good page written → 1 write
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -883,11 +883,11 @@ class TestFailureLedger:
             side_effect=HTTPError("500"),
         ), patch(
             "bookstack_file_exporter.archiver.util.TarStream.write"
-        ) as mock_write_tar:
+        ) as mock_stream_write:
             archiver.archive({60: page})
 
         # meta WAS written (tar exists) but no document content did
-        assert mock_write_tar.call_count == 1
+        assert mock_stream_write.call_count == 1
         assert archiver.content_written is False
         assert archiver.failed_node_exports == [f"{page.file_path}.md"]
 

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -234,6 +234,22 @@ class TestFinalizeArchive:
         page_archiver.abort_archive()
 
 
+class TestPoisonedStreamChain:
+    """Mid-run write failure poisons the stream; finalize refuses to publish."""
+
+    def test_poison_then_finalize_refuses_publish(self, page_archiver, monkeypatch):
+        page_archiver.write_data("book/page1.md", b"# ok")   # node 1 landed
+
+        def boom(*_args, **_kwargs):
+            raise OSError("disk full")
+        monkeypatch.setattr(page_archiver._tar_stream._tar, "addfile", boom)
+        with pytest.raises(ArchiveWriteError):
+            page_archiver.write_data("book/page2.md", b"# fails")   # node 2 poisons
+        with pytest.raises(ArchiveWriteError):
+            page_archiver.finalize_archive()                        # publish refused
+        assert not os.path.exists(page_archiver.archive_file)
+
+
 # ---------------------------------------------------------------------------
 # 5. write_data delegates to TarStream.write
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -2,6 +2,7 @@
 """Happy-path unit tests for PageArchiver."""
 import logging
 import os
+import tarfile
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Dict
@@ -11,7 +12,7 @@ import pytest
 from requests.exceptions import HTTPError
 
 from bookstack_file_exporter.archiver.node_archiver import NodeArchiver, PageArchiver
-from bookstack_file_exporter.archiver import util as archiver_util
+from bookstack_file_exporter.archiver.util import ArchiveWriteError
 from bookstack_file_exporter.exporter.node import Node
 from tests.fixtures.mock_config import make_mock_config as _make_config
 
@@ -127,11 +128,12 @@ class TestConstruction:
                                 asset_archiver=MagicMock())
         assert archiver.archive_file == f"{archive_dir}.tgz"
 
-    def test_tar_file_ends_with_tar(self, tmp_path):
+    def test_partial_file_is_tgz_partial(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
         archiver = PageArchiver(archive_dir, _make_config(), MagicMock(),
                                 asset_archiver=MagicMock())
-        assert archiver.tar_file == f"{archive_dir}.tar"
+        assert archiver.partial_file == f"{archiver.archive_file}.partial"
+        assert archiver.archive_file.endswith(".tgz")
 
     def test_archive_base_path_is_last_segment(self, tmp_path):
         archive_dir = str(tmp_path / "bookstack-20260514")
@@ -166,7 +168,7 @@ class TestExportUrl:
         with patch(
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response"
         ) as mock_get_bytes, patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             mock_get_bytes.return_value = b"page content"
             archiver.archive({42: page})
@@ -204,60 +206,45 @@ class TestFileExtensionMap:
 
 
 # ---------------------------------------------------------------------------
-# 4. gzip_archive delegates to archiver_util.create_gzip
+# 4. finalize_archive closes the stream then renames .tgz.partial -> .tgz
 # ---------------------------------------------------------------------------
+class TestFinalizeArchive:
 
-class TestGzipArchive:  # pylint: disable=too-few-public-methods  # test scaffolding stub
-    def test_create_gzip_called_with_tar_and_partial_then_renamed(self, page_archiver):
-        # gzip writes to the .partial path; os.rename promotes it to the final .tgz.
-        with patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.create_gzip"
-        ) as mock_create_gzip, patch(
-            "bookstack_file_exporter.archiver.node_archiver.os.rename"
-        ) as mock_rename:
-            page_archiver.gzip_archive()
-            partial = f"{page_archiver.archive_file}.partial"
-            mock_create_gzip.assert_called_once_with(page_archiver.tar_file, partial)
-            mock_rename.assert_called_once_with(partial, page_archiver.archive_file)
-
-
-class TestAtomicGzip:  # pylint: disable=too-few-public-methods
-    def test_gzip_writes_via_partial_then_renames(self, page_archiver, tmp_path, monkeypatch):
-
-        tar = tmp_path / "bkps_2026.tar"
-        tar.write_bytes(b"tar-bytes")
-        page_archiver.tar_file = str(tar)
-        page_archiver.archive_file = str(tmp_path / "bkps_2026.tgz")
-
-        seen_target = {}
-        real_create_gzip = archiver_util.create_gzip
-        def spy(file_path, gzip_file, remove_old=True):
-            seen_target["gzip_file"] = gzip_file
-            return real_create_gzip(file_path, gzip_file, remove_old)
-        monkeypatch.setattr(archiver_util, "create_gzip", spy)
-
-        page_archiver.gzip_archive()
-
-        # gzip was written to the .partial path, not the final name
-        assert seen_target["gzip_file"].endswith(".tgz.partial")
-        # final archive exists; no partial left behind
+    def test_finalize_renames_partial_to_final(self, page_archiver):
+        page_archiver.write_data("notes/page.md", b"# hi")
+        page_archiver.finalize_archive()
         assert os.path.exists(page_archiver.archive_file)
-        assert not os.path.exists(page_archiver.archive_file + ".partial")
+        assert not os.path.exists(page_archiver.partial_file)
+        with tarfile.open(page_archiver.archive_file, "r:gz") as tar:
+            assert tar.getnames() == ["notes/page.md"]
+
+    def test_finalize_close_failure_does_not_publish(self, page_archiver, monkeypatch):
+        page_archiver.write_data("notes/page.md", b"# hi")
+
+        def boom():
+            raise OSError("flush failed")
+        monkeypatch.setattr(page_archiver._tar_stream._tar, "close", boom)
+        with pytest.raises(ArchiveWriteError):
+            page_archiver.finalize_archive()
+        assert not os.path.exists(page_archiver.archive_file)
+
+    def test_abort_archive_never_raises(self, page_archiver):
+        page_archiver.write_data("notes/page.md", b"# hi")
+        page_archiver.abort_archive()
+        page_archiver.abort_archive()
 
 
 # ---------------------------------------------------------------------------
-# 5. write_data delegates to archiver_util.write_tar
+# 5. write_data delegates to TarStream.write
 # ---------------------------------------------------------------------------
 
 class TestWriteData:  # pylint: disable=too-few-public-methods  # test scaffolding stub
-    def test_write_tar_called_with_correct_args(self, page_archiver):
+    def test_write_data_delegates_to_stream(self, page_archiver):
         with patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
-        ) as mock_write_tar:
-            page_archiver.write_data("some/path/file.md", b"content")
-            mock_write_tar.assert_called_once_with(
-                page_archiver.tar_file, "some/path/file.md", b"content"
-            )
+            "bookstack_file_exporter.archiver.util.TarStream.write"
+        ) as mock_write:
+            page_archiver.write_data("some/file.md", b"content")
+        mock_write.assert_called_once_with("some/file.md", b"content")
 
 
 # ---------------------------------------------------------------------------
@@ -288,7 +275,7 @@ class TestArchivePages:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"page bytes",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(page_nodes)
 
@@ -313,7 +300,7 @@ class TestArchivePages:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"content",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive(page_nodes)
 
@@ -342,7 +329,7 @@ class TestArchivePages:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=_byte_response,
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({30: good, 3: forbidden})  # must not raise
 
@@ -802,7 +789,7 @@ class TestFailureLedger:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=_byte_response,
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({30: good, 3: forbidden})
 
@@ -843,7 +830,7 @@ class TestFailureLedger:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"page bytes",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({40: page})
 
@@ -872,7 +859,7 @@ class TestFailureLedger:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=_byte_response,
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({50: good, 51: crasher})
 
@@ -895,7 +882,7 @@ class TestFailureLedger:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             side_effect=HTTPError("500"),
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ) as mock_write_tar:
             archiver.archive({60: page})
 
@@ -918,7 +905,7 @@ class TestFailureLedger:
             "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
             return_value=b"page bytes",
         ), patch(
-            "bookstack_file_exporter.archiver.node_archiver.archiver_util.write_tar"
+            "bookstack_file_exporter.archiver.util.TarStream.write"
         ):
             archiver.archive({61: page})
 

--- a/tests/unit/test_run_exporter.py
+++ b/tests/unit/test_run_exporter.py
@@ -10,6 +10,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from bookstack_file_exporter import run
+from bookstack_file_exporter.archiver.util import ArchiveWriteError
 from bookstack_file_exporter.notify.models import ExportStatus, NotifyResult, UploadOutcome
 
 # ---------------------------------------------------------------------------
@@ -649,3 +650,33 @@ class TestExporterContentLoss:
 
         assert isinstance(result, NotifyResult)
         assert result.status is ExportStatus.EMPTY
+
+
+# ---------------------------------------------------------------------------
+# A poisoned archive stream must hard-fail the run, never publish as PARTIAL
+# ---------------------------------------------------------------------------
+
+class TestExporterPoisonedStream:  # pylint: disable=too-few-public-methods
+    def test_poisoned_stream_fails_run_even_with_partial_content(self, monkeypatch):
+        """A poisoned archive stream must hard-fail the run, never publish as PARTIAL.
+
+        Earlier nodes succeeded (content_written True, ledger non-empty), so run.py
+        would otherwise downgrade to PARTIAL -- but create_archive (finalize) raises
+        because the stream is poisoned, and the finally block discards the partial.
+        """
+        config = _make_exporter_config("pages")
+        mock_archiver, _ = _patch_exporter_collaborators(
+            monkeypatch, config, book_nodes={1: MagicMock()},
+            chapter_nodes={}, page_nodes={10: MagicMock()}
+        )
+        mock_archiver.failed_nodes = ["book/page.md (worker error)"]
+        mock_archiver.failed_assets = []
+        mock_archiver.content_written = True
+        mock_archiver.has_exported_content = True
+        mock_archiver.create_archive.side_effect = ArchiveWriteError("poisoned")
+
+        with pytest.raises(ArchiveWriteError):
+            run.exporter(config)
+
+        mock_archiver.discard_partial.assert_called_once()
+        mock_archiver.archive_remote.assert_not_called()


### PR DESCRIPTION
## Changes

- New `TarStream` class (`archiver/util.py`): one persistent `tarfile` handle opened `"w:gz"` lazily on the first write, streaming straight onto `{archive}.tgz.partial`. Writes serialize under an internal lock; a failed member write poisons the stream so every later write and the finalize step raise `ArchiveWriteError`.
- `NodeArchiver`: `tar_file` attribute replaced by `partial_file`; `write_data` delegates to the stream; `gzip_archive` replaced by `finalize_archive` (close stream, then atomically rename `.tgz.partial` → `.tgz`) plus a best-effort `abort_archive` for the discard path.
- `Archiver`: `discard_partial` now aborts the stream before unlinking the partial; `has_exported_content` re-anchors to `.tgz.partial` existence on disk (lazy open keeps disk as ground truth); `create_archive` finalizes the stream.
- Removed dead append-mode machinery: `write_tar`, `create_gzip`, module-level tar lock, and their tests. Orphan sweep still globs `.tar` deliberately, to retro-clean intermediates stranded by pre-v3 versions after upgrade.
- `run.py` untouched except comments; one wording fix in `docs/getting-started.md`.
- Tests: TarStream unit suite (lazy open, concurrency, poison, lifecycle), archiver finalize/abort/discard behavior tests, and two end-to-end tests pinning that a poisoned stream hard-fails the run and is never published — at the run gate (mocked) and through the real chain (live stream).

**Deliberate behavior change:** a mid-run archive write failure now fails the whole run and discards the partial archive. Previously the append-mode tar could lose one member and still publish; a gzip stream is corrupt for all members after a failed write, so publishing is never safe — all-or-nothing is the only honest outcome. Both end-to-end tests pin this.

## Motivation

The old design reopened the tar in append mode for every member (tarfile rescans all headers on open — O(n²) across a run), then re-read the entire tar in a separate gzip end-pass, briefly holding ~2× the archive size on disk. Streaming through one `w:gz` handle removes the rescans, removes the end-pass, and halves the transient disk footprint. This matches the standard single-writer shape used by `tar czf` itself; parallelism stays where it pays — in the API fetch workers. Compression now runs inside the write lock: concurrent writers serialize on compress time, while fetch threads are unaffected (zlib releases the GIL).

## Verification

- 748 unit tests pass; branch coverage 94%; pylint 10.00 on package and tests.
- Poison end-to-end tests passed unmodified on first run (guarantee already held by construction).
- Live smoke against a real BookStack instance, `export_workers: 4`, both modes:
  - clean one-shot: 417-member `.tgz` published and readable, S3 upload + retention prune, correct notification
  - SIGTERM mid-archive: graceful drain, partial discarded, nothing published, no notification
  - SIGTERM during fetch: exit 143, no files created (lazy open)
  - scheduled mode, SIGTERM mid-cycle: cycle cancelled silently, partial discarded, exit 0
  - scheduled mode, clean cycle then SIGTERM while idle: published + notified, exit 0
  - SIGKILL mid-archive: stranded `.tgz.partial` removed by the next run's startup sweep

## In-depth

- **Close-then-rename ordering is load-bearing.** `finalize()` flushes the gzip trailer before the rename; a close failure raises and the partial is discarded, so a truncated-but-valid-looking `.tgz` can never be published. This is the one new failure class a streaming design could add, and the ordering plus tests close it off.
- **`has_exported_content` stays disk-anchored** rather than becoming an in-memory counter: lazy open means the `.partial` exists iff at least one write landed, preserving the empty-run detection path without a flag that could drift.
- **Alternatives considered and rejected:** a queue + dedicated writer thread would detach write acknowledgement from the worker that produced the content, breaking the status-truthfulness guarantee that "content written" means bytes were accepted by the archive, and adds shutdown choreography for no measured gain (runs are fetch-bound; see prior worker benchmarks). Format-level parallelism (zip, chunk stores) changes the deliverable away from a single portable `.tgz`. A future `zstd` compression option can slot into this seam without further restructuring.