### PR TITLE
feat: UTC timestamps, fail-fast archive errors, and per-target TLS options for object storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ What it does:
 
 - Discover and build relationships between Bookstack `Shelves/Books/Chapters/Pages` to create a relational parent-child layout
 - Export Bookstack pages and their content to a `.tgz` archive
-- Additional content for pages like their images, attachments, and metadata and can be exported
+- Additional page content — images, attachments, and metadata — can also be exported
 - The exporter can also [Modify Links](docs/backup-behavior.md#modify-links) to replace image and/or attachment links with local exported paths for a more portable backup
 - Fine grained filtering and selectable export levels.
 - YAML configuration file for repeatable and easy runs
@@ -35,9 +35,8 @@ What it does:
 
 Supported backup targets are:
 
-1. local
-2. minio
-3. s3
+1. local filesystem
+2. S3-compatible object storage — AWS S3, MinIO, Ceph, Cloudflare R2, Backblaze B2, Wasabi, DigitalOcean Spaces, etc. There is no `type` field; a target is treated as a custom store or AWS S3 based on whether an `endpoint` is set. See [Remote Storage](docs/remote-storage.md#object-storage-upload).
 
 Supported backup formats are based on Bookstack API and shown [here](https://demo.bookstackapp.com/api/docs#pages-exportHtml) and below:
 
@@ -74,6 +73,7 @@ Below are versions that have major changes to the way configuration or exporter 
 | `< 1.4.X` | `1.5.0` | `assets.verify_ssl` has been moved to `http_config.verify_ssl` and the default value has been updated to `false`. `additional_headers` has been moved to `http_config.additional_headers` |
 | `1.6.X` | `3.0.0` | `assets.modify_markdown` is deprecated — HTML image and attachment link rewrites are now supported, so the markdown-specific name no longer fits. Use `assets.modify_links` instead. The legacy `modify_markdown` key was removed in `3.0.0`. |
 | `< 3.0.0` | `3.0.0` | The top-level `minio:` config block is removed. Replace it with an `object_storage:` list entry using the flat schema (`name`, `endpoint`, `prefix`, `ambient_auth`, etc — no `type` field). See [Migrating from v2](docs/remote-storage.md#migrating-from-v2) for the exact mapping. |
+| `< 3.0.0` | `3.0.0` | `http_config.verify_ssl` now defaults to `true` (was `false`) — the exporter verifies the BookStack server's TLS certificate by default. If your BookStack uses a self-signed or internal-CA certificate, set `http_config.verify_ssl: false`, or point the `REQUESTS_CA_BUNDLE` environment variable at your CA bundle. |
 
 ## Future Items
 1. ~~Be able to pull images locally and place in their respective page folders for a more complete file level backup.~~

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import os
 
@@ -311,4 +311,4 @@ class Archiver:
     @staticmethod
     def _generate_root_folder(base_folder_name: str) -> str:
         """return base archive name"""
-        return base_folder_name + "_" + datetime.now().strftime(_DATE_STR_FORMAT)
+        return base_folder_name + "_" + datetime.now(timezone.utc).strftime(_DATE_STR_FORMAT)

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -92,14 +92,21 @@ class Archiver:
             return
         log.info("Creating base directory for archive: %s",
                  self.config.user_inputs.output_path)
-        # in docker, this may fail if the user id is not the same as the host
         try:
             util.create_dir(self.config.user_inputs.output_path)
         except PermissionError as perm_err:
-            log.warning("Failed to create base directory: %s", perm_err)
-            log.warning("This usually occurs in docker environments " \
-                        "attempting to skip this step")
-            return
+            # create_dir uses mkdir(exist_ok=True), which never raises for an
+            # existing directory (writable or not) — the docker mounted-volume
+            # case is tolerated there, not here. Reaching this catch means
+            # output_path is missing AND creating it was denied: a real
+            # misconfig, so fail now with a pointed message instead of dying
+            # later at the first archive write.
+            log.error(
+                "Cannot create export directory '%s': %s - the path does not "
+                "exist and creation was denied; fix output_path or its "
+                "parent directory permissions",
+                self.config.user_inputs.output_path, perm_err)
+            raise
 
     def set_stop(self, stop):
         """Inject the shutdown flag into the node archiver for cooperative cancel.

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -318,7 +318,9 @@ class NodeArchiver:
         runs WITHOUT cancel_futures, so without this call queued work would all run.
         A worker raising a non-HTTP error (HTTPError/RetryError are already swallowed
         per-format inside _export_node) is logged and skipped so one bad node never
-        aborts the run.
+        aborts the run - EXCEPT ArchiveWriteError: that means the shared tar stream
+        is poisoned and no later node can be written, so the run aborts promptly
+        instead of fetching the rest for nothing.
         """
         # Threads (not processes) because the work is I/O-bound: each node spends
         # almost all its time waiting on a network round-trip to BookStack, and
@@ -351,6 +353,16 @@ class NodeArchiver:
                 # and skipped rather than aborting every other node's export.
                 try:
                     self._merge_failures(future.result())
+                except archiver_util.ArchiveWriteError:
+                    # The stream is poisoned: no later node can write, so
+                    # continuing only burns API fetches. Drop queued futures and
+                    # propagate; in-flight workers finish their fetch and die
+                    # cheaply on the poisoned write. (Fail-fast is scoped to
+                    # ArchiveWriteError deliberately - requests exceptions
+                    # subclass OSError, so a broader class would abort the run
+                    # on one flaky page.)
+                    executor.shutdown(cancel_futures=True)
+                    raise
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     log.error("Node export worker failed, skipping node: %s", exc)
                     # formats already exported before the crash are unknown here,

--- a/bookstack_file_exporter/archiver/s3_archiver.py
+++ b/bookstack_file_exporter/archiver/s3_archiver.py
@@ -3,6 +3,7 @@ import os
 
 # pylint: disable=import-error
 import boto3
+import urllib3
 from botocore.config import Config
 from botocore.exceptions import ClientError, BotoCoreError
 
@@ -32,6 +33,11 @@ class S3CompatibleArchiver:
     (env / shared config / IRSA / IMDS / assume-role) — used only when ambient_auth is set.
     """
     def __init__(self, provider_config: S3ProviderConfig):
+        if provider_config.verify is False:
+            # botocore emits a urllib3 InsecureRequestWarning on every request when
+            # verification is off; silence globally, matching HttpHelper's behavior
+            # for verify_ssl: false on the BookStack side.
+            urllib3.disable_warnings()
         session = boto3.session.Session(
             aws_access_key_id=provider_config.access_key,
             aws_secret_access_key=provider_config.secret_key,
@@ -40,6 +46,7 @@ class S3CompatibleArchiver:
         self._client = session.client(
             "s3",
             endpoint_url=provider_config.endpoint_url,
+            verify=provider_config.verify,
             config=Config(s3={"addressing_style": provider_config.addressing_style}),
         )
         self.bucket = provider_config.bucket

--- a/bookstack_file_exporter/archiver/util.py
+++ b/bookstack_file_exporter/archiver/util.py
@@ -45,13 +45,15 @@ class TarStream:
         self._lock = threading.Lock()
         self._tar: tarfile.TarFile | None = None
         self._poisoned = False
+        self._first_error: str | None = None
 
     def write(self, file_path: str, data: bytes):
         """Append one member; thread-safe. Raises ArchiveWriteError on failure."""
         with self._lock:
             if self._poisoned:
                 raise ArchiveWriteError(
-                    f"archive stream already failed; dropping write of {file_path}")
+                    f"archive stream already failed{self._first_error_detail()}; "
+                    f"dropping write of {file_path}")
             try:
                 if self._tar is None:
                     # Handle is intentionally kept open across calls (not a
@@ -65,6 +67,7 @@ class TarStream:
                 self._tar.addfile(tar_info, fileobj=data_obj)
             except Exception as err:  # pylint: disable=broad-exception-caught
                 self._poisoned = True
+                self._first_error = str(err)
                 raise ArchiveWriteError(
                     f"archive write failed for {file_path}: {err}") from err
 
@@ -78,7 +81,9 @@ class TarStream:
         """
         with self._lock:
             if self._poisoned:
-                raise ArchiveWriteError("archive stream failed mid-run; not publishing")
+                raise ArchiveWriteError(
+                    f"archive stream failed mid-run{self._first_error_detail()}; "
+                    "not publishing")
             if self._tar is None:
                 return
             tar = self._tar
@@ -87,6 +92,7 @@ class TarStream:
                 tar.close()
             except Exception as err:  # pylint: disable=broad-exception-caught
                 self._poisoned = True
+                self._first_error = str(err)
                 raise ArchiveWriteError(
                     f"archive close failed; not publishing: {err}") from err
 
@@ -107,6 +113,13 @@ class TarStream:
                 except Exception:  # pylint: disable=broad-exception-caught
                     log.debug("Ignoring close error while discarding archive stream",
                               exc_info=True)
+
+    def _first_error_detail(self) -> str:
+        """' (first error: ...)' suffix, or '' when poisoned without a recorded
+        cause (abort() poisons deliberately during discard)."""
+        if self._first_error is None:
+            return ""
+        return f" (first error: {self._first_error})"
 
 def get_json_bytes(data: dict[str, str | int]) -> bytes:
     """dump dict to json file"""

--- a/bookstack_file_exporter/common/logging.py
+++ b/bookstack_file_exporter/common/logging.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from datetime import datetime, timezone
 
 # Standard LogRecord attributes; anything else on a record is a user-supplied
@@ -35,7 +36,7 @@ class JsonFormatter(logging.Formatter):
         return json.dumps(out, default=str)
 
 
-_TEXT_FMT = "%(asctime)s [%(levelname)s] %(message)s"
+_TEXT_FMT = "%(asctime)s UTC [%(levelname)s] %(message)s"
 _DATE_FMT = "%Y-%m-%d %H:%M:%S"
 
 
@@ -45,5 +46,10 @@ def build_handler(log_format: str) -> logging.StreamHandler:
     if log_format == "json":
         handler.setFormatter(JsonFormatter())
     else:
-        handler.setFormatter(logging.Formatter(_TEXT_FMT, datefmt=_DATE_FMT))
+        formatter = logging.Formatter(_TEXT_FMT, datefmt=_DATE_FMT)
+        # %(asctime)s renders via time.localtime by default; pin to UTC so the
+        # text format shares one clock with every other surface (JSON logs,
+        # health endpoint, notification bodies, archive filenames).
+        formatter.converter = time.gmtime
+        handler.setFormatter(formatter)
     return handler

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -87,12 +87,11 @@ class HttpHelper:
     # more details on options: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
     def http_get_request(self, url: str) -> requests.Response:
         """make http requests and return response object"""
-        try:
-            response = self._session.get(url, headers=self._headers,
-                                         verify=self.verify_ssl, timeout=self.http_timeout)
-        except Exception as req_err:
-            log.error("Failed to make request for %s", url)
-            raise req_err
+        # verify stays per-call: an explicit verify=False must keep suppressing
+        # REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE overrides, which session-level verify
+        # cannot (requests merges call-level None with the env bundle first).
+        response = self._session.get(url, headers=self._headers,
+                                     verify=self.verify_ssl, timeout=self.http_timeout)
         try:
             #raise_for_status() throws an exception on codes 400-599
             response.raise_for_status()

--- a/bookstack_file_exporter/common/util.py
+++ b/bookstack_file_exporter/common/util.py
@@ -87,9 +87,9 @@ class HttpHelper:
     # more details on options: https://urllib3.readthedocs.io/en/stable/reference/urllib3.util.html
     def http_get_request(self, url: str) -> requests.Response:
         """make http requests and return response object"""
-        # verify stays per-call: an explicit verify=False must keep suppressing
-        # REQUESTS_CA_BUNDLE/CURL_CA_BUNDLE overrides, which session-level verify
-        # cannot (requests merges call-level None with the env bundle first).
+        # verify is passed per-call because requests gives env vars precedence
+        # over session.verify: with no call-level value, REQUESTS_CA_BUNDLE/
+        # CURL_CA_BUNDLE would override an explicit verify_ssl: false config.
         response = self._session.get(url, headers=self._headers,
                                      verify=self.verify_ssl, timeout=self.http_timeout)
         try:

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -174,7 +174,11 @@ class Assets(StrictModel):
 
 class HttpConfig(StrictModel):
     """YAML schema for user provided http settings"""
-    verify_ssl: bool = False
+    # verifies the BookStack server's TLS cert by default -- the API token rides
+    # this connection, so an unverified default would expose it to MITM. Users with
+    # a self-signed/internal-CA BookStack opt out with verify_ssl: false (or point
+    # REQUESTS_CA_BUNDLE at their CA).
+    verify_ssl: bool = True
     timeout: int = 30
     backoff_factor: float = 2.5
     retry_codes: list[int] = [413, 429, 500, 502, 503, 504]

--- a/bookstack_file_exporter/config_helper/models.py
+++ b/bookstack_file_exporter/config_helper/models.py
@@ -55,6 +55,8 @@ class S3StorageConfig(StrictModel):
     prefix: str = ""
     region: str | None = None
     secure: bool = True
+    verify_ssl: bool = True
+    ca_bundle: str = ""
     addressing_style: Literal["path", "virtual", "auto"] | None = None  # None => inferred
     ambient_auth: bool = False
     keep_last: int = 0
@@ -132,6 +134,16 @@ class S3StorageConfig(StrictModel):
             raise ValueError(
                 f"object_storage target {self.name!r}: 'region' is required for AWS S3 "
                 "targets (no 'endpoint') unless ambient_auth resolves it.")
+        return self
+
+    @model_validator(mode="after")
+    def _check_tls_verify_options(self):
+        """'ca_bundle' means "verify against this CA"; 'verify_ssl: false' means "do not
+        verify at all" — both together is a contradiction, not a precedence question."""
+        if self.ca_bundle and not self.verify_ssl:
+            raise ValueError(
+                f"object_storage target {self.name!r}: 'ca_bundle' and 'verify_ssl: false' "
+                "are mutually exclusive - a custom CA bundle implies verification is on.")
         return self
 
 # pylint: disable=too-few-public-methods

--- a/bookstack_file_exporter/config_helper/remote.py
+++ b/bookstack_file_exporter/config_helper/remote.py
@@ -23,6 +23,7 @@ class S3ProviderConfig:
         self.endpoint_url = self._resolve_endpoint_url(entry)
         self.region = self._resolve_region(entry)
         self.addressing_style = self._resolve_addressing(entry)
+        self.verify = self._resolve_verify(entry)
         self.access_key, self.secret_key = self._resolve_credentials(entry)
 
     @staticmethod
@@ -73,3 +74,19 @@ class S3ProviderConfig:
         if entry.addressing_style:
             return entry.addressing_style
         return "auto" if entry.is_aws else "path"
+
+    @staticmethod
+    def _resolve_verify(entry: S3StorageConfig) -> bool | str | None:
+        """boto3 client 'verify': explicit per-target setting pinned, SDK defaults otherwise.
+
+        ca_bundle path -> verify against that CA; verify_ssl false -> disable verification;
+        neither set -> None, which lets botocore fall through its own chain (AWS_CA_BUNDLE
+        env / config-file ca_bundle, then REQUESTS_CA_BUNDLE, then verify-on) — so a target
+        without explicit TLS settings still honors standard SDK env vars. botocore gives an
+        explicit non-None verify precedence over those env vars, which is what makes this
+        per-target-safe when multiple targets need different CAs."""
+        if entry.ca_bundle:
+            return entry.ca_bundle
+        if not entry.verify_ssl:
+            return False
+        return None

--- a/bookstack_file_exporter/health/server.py
+++ b/bookstack_file_exporter/health/server.py
@@ -13,7 +13,7 @@ class HealthHandler(BaseHTTPRequestHandler):
 
     The bound RunStatus is injected as a class attribute on a per-server
     subclass (see start_health_server)."""
-    status: RunStatus = None  # set on the per-server subclass
+    status: RunStatus | None = None  # set on the per-server subclass
 
     # do_GET name is mandated by BaseHTTPRequestHandler
     def do_GET(self):  # pylint: disable=invalid-name

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from apprise import Apprise, AppriseAsset, AppriseConfig, NotifyFormat
 
 from bookstack_file_exporter.config_helper import notifications
@@ -118,7 +118,7 @@ class AppRiseNotify:
 
     def _text_body(self, error_msg: None | Exception,
                    result: NotifyResult | None = None) -> str:
-        timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
         if error_msg:
             return "\n".join([
                 "",
@@ -188,7 +188,7 @@ class AppRiseNotify:
         # markdown emphasis on headline/group headers and every interpolated
         # untrusted value wrapped in _md_code(). See _md_code for why the wrapping
         # is mandatory (apprise's MARKDOWN->HTML conversion does not escape HTML).
-        timestamp = datetime.today().strftime('%Y-%m-%d %H:%M:%S')
+        timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')
         if error_msg:
             return "\n".join([
                 "",

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -36,7 +36,7 @@ def entrypoint(args: argparse.Namespace) -> int:
         return 1
 
     inputs = config.user_inputs
-    if getattr(args, "run_once", False) or (not inputs.run_interval and not inputs.run_schedule):
+    if args.run_once or (not inputs.run_interval and not inputs.run_schedule):
         return _run_once(config)
     if inputs.run_schedule:
         return _run_scheduled(
@@ -163,6 +163,7 @@ def _run_scheduled(config: ConfigNode, next_wait: Callable[[], float]) -> int:
 
     if server:
         server.shutdown()
+        server.server_close()
     log.info("Shutdown complete")
     return 0
 
@@ -234,8 +235,9 @@ def exporter(config: ConfigNode, stop: threading.Event | None = None) -> NotifyR
 
     ## Select nodes by export level
     export_level = config.user_inputs.export_level
+    nodes: dict[int, Node]
     if export_level == "books":
-        nodes: dict[int, Node] = book_nodes
+        nodes = book_nodes
     elif export_level == "chapters":
         nodes = export_helper.get_chapter_nodes(book_nodes)
     else:

--- a/docs/backup-behavior.md
+++ b/docs/backup-behavior.md
@@ -14,12 +14,12 @@
   - [Known limitations](#known-limitations)
 
 ## General
-Backups are exported in `.tgz` format and generated based off timestamp. Export names will be in the format: `%Y-%m-%d_%H-%M-%S` (Year-Month-Day_Hour-Minute-Second). *Files are first pulled locally to create the tarball and then can be sent to object storage if needed*. Example file name: `bookstack_export_2023-09-22_07-19-54.tgz`.
+Backups are exported in `.tgz` format and generated based off timestamp. Export names will be in the format: `%Y-%m-%d_%H-%M-%S` (Year-Month-Day_Hour-Minute-Second). The timestamp is **UTC** as of v3.0.0 (earlier versions used the host's local time); notification bodies use the same UTC clock. *Files are first pulled locally to create the tarball and then can be sent to object storage if needed*. Example file name: `bookstack_export_2023-09-22_07-19-54.tgz`.
 
 The exporter can also do housekeeping duties and keep a configured number of archives and delete older ones. See `keep_last` property in the [Configuration](configuration.md#options-and-descriptions) section. Object storage provider configurations include their own `keep_last` property for flexibility. 
 
 ### File Naming
-For file names, `slug` names (from Bookstack API) are used, as such certain characters like `!`, `/` will be ignored and spaces replaced from page names/titles. If your page has an empty `slug` value for some reason (draft that was never fully saved), the exporter will use page name with the `slugify` function from Django to generate a valid slug. Example: `My Page.bin Name!` will be converted to `my-page-bin-name`.
+For file names, `slug` names (from Bookstack API) are used, as such certain characters like `!`, `/` will be ignored and spaces replaced in page names/titles. If your page has an empty `slug` value for some reason (draft that was never fully saved), the exporter will use page name with the `slugify` function from Django to generate a valid slug. Example: `My Page.bin Name!` will be converted to `my-page-bin-name`.
 
 You may also notice some directories (books) and/or files (pages) in the archive have a random string at the end, example - `nKA`: `user-and-group-management-nKA`. This is expected and is because there were resources with the same name created in another shelve and bookstack adds a string at the end to ensure uniqueness.
 
@@ -143,7 +143,7 @@ If an API call to get an attachment or its metadata fails, the exporter will ski
 
 The configuration item, `assets.modify_links`, can be set to `true` to rewrite image and attachment URL links in exported files to local relative paths. This feature makes your `markdown` and `html` exports fully portable — assets resolve locally without a network connection to the Bookstack instance.
 
-- **Eligible formats**: `markdown` and `html` only. PDF, plaintext, and zip exports are not yet requested/implemented.
+- **Eligible formats**: `markdown` and `html` only. PDF, plaintext, and zip are not eligible for link rewriting.
 - **Scope**: rewrites image `src` attributes and their outer anchor `href` wrappers; rewrites attachment `<a href>` links. Does **not** rewrite inter-page, inter-book, inter-chapter, or inter-shelf links (deferred to a future issue).
 - **Removed key**: the legacy `modify_markdown` key was removed in v3.0.0. Rename it to `modify_links` in your configuration.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ formats:
   - plaintext
   - zip
 http_config:
-  verify_ssl: false
+  verify_ssl: true      # verify the BookStack TLS cert (default); false for self-signed
   timeout: 30
   backoff_factor: 2.5
   retry_codes: [413, 429, 500, 502, 503, 504]
@@ -52,6 +52,9 @@ object_storage:
     bucket: "mybucket"
     prefix: "bookstack/file_backups"
     secure: false
+    # https targets only (ignored when secure: false):
+    # verify_ssl: true              # verify the target's TLS cert (default true)
+    # ca_bundle: "/certs/ca.pem"    # verify against a private CA (excludes verify_ssl: false)
     keep_last: 5
     access_key_env: "MINIO_ACCESS_KEY"
     secret_key_env: "MINIO_SECRET_KEY"
@@ -103,7 +106,7 @@ More descriptions can be found for each section below:
 | `assets.modify_links` | `bool` | `false` | Optional (default: `false`). Rewrites image and attachment URLs in markdown AND html exports to local relative paths. Requires `assets.export_images` and/or `assets.export_attachments` to be `true`. Controls link *rewriting* only — assets are downloaded whenever their export flag is set, regardless of `modify_links`. Only applies to `markdown` and `html` formats; pdf, plaintext, and zip are not eligible. The legacy `modify_markdown` key was removed in v3.0.0 — rename it to `modify_links`. See [Modify Links](backup-behavior.md#modify-links) for more information. |
 | `assets.export_meta` | `bool` | `false` | Optional (default: `false`), export metadata about each archived page, book, or chapter in a json file. |
 | `http_config` | `object` | `false` | Optional section to override default http configuration. |
-| `http_config.verify_ssl` | `bool` | `false` | Optional (default: `false`), whether or not to verify ssl certificates if using https. |
+| `http_config.verify_ssl` | `bool` | `false` | Optional (default: `true`). Verify the BookStack server's TLS certificate when using https — on by default so the API token is not exposed to interception. Set `false` for a self-signed/internal-CA BookStack, or point the `REQUESTS_CA_BUNDLE` env var at your CA bundle. **The default flipped from `false` to `true` in v3.0.0** — see [Potential Breaking Upgrades](../README.md#potential-breaking-upgrades). |
 | `http_config.timeout` | `int` | `false` | Optional (default: `30`), set the timeout, in seconds, for http requests. |
 | `http_config.retry_count` | `int` | `false` | Optional (default: `5`), the number of http retries after initial failure. |
 | `http_config.retry_codes` | `List[int]` | `false` | Optional (default: `[413, 429, 500, 502, 503, 504]`), which http response status codes trigger a retry. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -222,7 +222,7 @@ health_host: "0.0.0.0"     # optional bind address (default 0.0.0.0)
     "started_at": "2026-06-21T02:00:00Z",
     "finished_at": "2026-06-21T02:03:11Z",
     "duration_seconds": 191,
-    "archive_file": "bookstack_export_2026-06-21.tgz",
+    "archive_file": "bookstack_export_2026-06-21_02-00-00.tgz",
     "error": null
   },
   "next_run": "2026-06-22T02:00:00Z",

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -30,11 +30,11 @@ Error message: 401 Client Error: Unauthorized for url: https://test.bookstack/ap
 Bookstack File Exporter completed successfully.
 
 Completed At: 2025-09-06 01:05:27 UTC
-Archive: bkps/bookstack_export_2025-09-06_010527.tgz (removed locally after upload)
+Archive: bkps/bookstack_export_2025-09-06_01-05-27.tgz (removed locally after upload)
 
 Uploaded to:
-- minio-main: my-bucket/bookstack/bookstack_export_2025-09-06_010527.tgz
-- aws-s3: my-bucket-s3/bookstack/bookstack_export_2025-09-06_010527.tgz
+- minio-main: my-bucket/bookstack/bookstack_export_2025-09-06_01-05-27.tgz
+- aws-s3: my-bucket-s3/bookstack/bookstack_export_2025-09-06_01-05-27.tgz
 
 Pruned:
 - local: 2 archive(s)
@@ -57,10 +57,10 @@ No pages content was found to export.
 Bookstack File Exporter completed with errors.
 
 Completed At: 2025-09-06 01:05:27 UTC
-Archive: bkps/bookstack_export_2025-09-06_010527.tgz (removed locally after upload)
+Archive: bkps/bookstack_export_2025-09-06_01-05-27.tgz (removed locally after upload)
 
 Uploaded to:
-- minio-main: my-bucket/bookstack/bookstack_export_2025-09-06_010527.tgz
+- minio-main: my-bucket/bookstack/bookstack_export_2025-09-06_01-05-27.tgz
 
 Failed:
 - content: 2 page export(s) failed

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -19,7 +19,7 @@ The title for notifications is configurable but if not specified, a default will
 {BODY}:
 Bookstack File Exporter encountered an unrecoverable error.
 
-Occurred At: 2025-09-06 01:02:47
+Occurred At: 2025-09-06 01:02:47 UTC
 
 Error message: 401 Client Error: Unauthorized for url: https://test.bookstack/api/shelve
 
@@ -29,7 +29,7 @@ Error message: 401 Client Error: Unauthorized for url: https://test.bookstack/ap
 {BODY}:
 Bookstack File Exporter completed successfully.
 
-Completed At: 2025-09-06 01:05:27
+Completed At: 2025-09-06 01:05:27 UTC
 Archive: bkps/bookstack_export_2025-09-06_010527.tgz (removed locally after upload)
 
 Uploaded to:
@@ -46,7 +46,7 @@ Pruned:
 {BODY}:
 Bookstack File Exporter completed - nothing to archive.
 
-Completed At: 2025-09-06 01:05:27
+Completed At: 2025-09-06 01:05:27 UTC
 
 No pages content was found to export.
 
@@ -56,7 +56,7 @@ No pages content was found to export.
 {BODY}:
 Bookstack File Exporter completed with errors.
 
-Completed At: 2025-09-06 01:05:27
+Completed At: 2025-09-06 01:05:27 UTC
 Archive: bkps/bookstack_export_2025-09-06_010527.tgz (removed locally after upload)
 
 Uploaded to:

--- a/docs/remote-storage.md
+++ b/docs/remote-storage.md
@@ -82,6 +82,8 @@ object_storage:
 | `bucket` | `str` | `true` | — | Bucket to upload to. |
 | `region` | `str` | conditionally | `None` | Explicit value always wins. If omitted and `endpoint` is set, defaults to `us-east-1`. If omitted and no `endpoint` (AWS), required unless `ambient_auth: true` (botocore can then resolve it from env/profile). |
 | `secure` | `bool` | `false` | `true` | TLS toggle; selects the `https://`/`http://` scheme used when building the endpoint URL. Set `false` for plain-HTTP local MinIO. |
+| `verify_ssl` | `bool` | `false` | `true` | TLS certificate verification for this target. Set `false` to accept an untrusted/self-signed certificate without verification (quick fix — prefer `ca_bundle`). Irrelevant for plain-HTTP endpoints (`secure: false`). |
+| `ca_bundle` | `str` | `false` | `""` | Path to a PEM CA bundle used to verify this target's certificate — the clean fix for a private-CA/self-signed HTTPS store (e.g. MinIO behind your own CA). Mutually exclusive with `verify_ssl: false`. When neither is set, the standard AWS SDK variables (`AWS_CA_BUNDLE`, etc.) still apply. |
 | `prefix` | `str` | `false` | `""` | Optional object key prefix. Empty means bucket root. |
 | `addressing_style` | `str` | `false` | `None` (inferred) | Passed straight to boto3: `path`, `virtual`, or `auto`. Left unset, `path` is inferred when `endpoint` is set (MinIO/Ceph work out of the box) and `auto` (virtual-hosted) for AWS. Use `virtual` for compat stores that require virtual-hosted addressing (e.g. DigitalOcean Spaces, Backblaze B2) — note boto3 treats `auto` the same as `path` when a custom `endpoint` is set, so `virtual` is the only way to get virtual-hosted there. |
 | `ambient_auth` | `bool` | `false` | `false` | Opt in to the boto3 SDK's own ambient credential chain: environment variables, shared config/profile, **IRSA or Pod Identity (EKS/Kubernetes)**, IMDS instance profile (EC2), or assume-role. Required whenever no `access_key(_env)` pair is configured on the entry — there is no silent fallback to ambient credentials. |
@@ -183,6 +185,22 @@ a hard **Failure** (exit `1`), not Partial.
 
 In scheduled mode the `/healthz` endpoint reports `last_run.status` as `degraded` for a partial
 run (distinct from `success` and `failed`).
+
+### Self-signed or private-CA HTTPS targets
+
+For an HTTPS store whose certificate is not publicly trusted (typical for self-hosted
+MinIO), pick one per target:
+
+- `ca_bundle: /path/to/ca.pem` — verify against your own CA. The clean option: TLS
+  protection stays on, and other targets are unaffected.
+- `verify_ssl: false` — disable certificate verification for this target only.
+- `secure: false` — plain HTTP, no TLS at all (LAN-only setups).
+
+Prefer a per-target `ca_bundle` over the `AWS_CA_BUNDLE` environment variable when you
+have more than one target: the environment variable is process-wide and *replaces* the
+trust store, so pointing it at a private CA breaks verification for targets using
+publicly-trusted certificates (e.g. AWS S3). A per-target setting always wins over these
+environment variables.
 
 ### Interrupted uploads and orphaned multipart parts
 

--- a/docs/remote-storage.md
+++ b/docs/remote-storage.md
@@ -184,6 +184,24 @@ a hard **Failure** (exit `1`), not Partial.
 In scheduled mode the `/healthz` endpoint reports `last_run.status` as `degraded` for a partial
 run (distinct from `success` and `failed`).
 
+### Interrupted uploads and orphaned multipart parts
+
+A failed or interrupted upload never leaves a partial archive visible in the
+bucket: small archives upload as a single atomic `PutObject`, and larger ones
+use multipart uploads that only materialize as an object on completion. If an
+upload fails while the exporter is still running, boto3 aborts the multipart
+session itself.
+
+The one gap is a hard kill (SIGKILL, power loss, OOM) in the middle of a large
+multipart upload: the already-uploaded parts stay in the bucket — invisible in
+normal listings but still billed — until they are removed. The standard fix is
+a provider-side rule rather than application-side cleanup:
+
+- **AWS S3**: add an `AbortIncompleteMultipartUpload` lifecycle rule to the
+  bucket (for example, abort anything incomplete after 1 day).
+- **MinIO**: set an equivalent ILM expiry rule for incomplete uploads, or clean
+  up manually with `mc rm --incomplete --recursive <alias>/<bucket>`.
+
 ## Migrating from v2
 
 v3.0.0 removes the single top-level `minio:` block entirely — its presence is now a hard

--- a/docs/remote-storage.md
+++ b/docs/remote-storage.md
@@ -5,8 +5,12 @@
 - [Object Storage Upload](#object-storage-upload)
   - [Entry fields](#entry-fields)
   - [Credential resolution (per entry, fail-closed)](#credential-resolution-per-entry-fail-closed)
+- [Bucket validation](#bucket-validation)
 - [Multi-target upload behavior](#multi-target-upload-behavior)
+  - [Self-signed or private-CA HTTPS targets](#self-signed-or-private-ca-https-targets)
+  - [Interrupted uploads and orphaned multipart parts](#interrupted-uploads-and-orphaned-multipart-parts)
 - [Migrating from v2](#migrating-from-v2)
+  - [Other v3 key changes (outside object_storage)](#other-v3-key-changes-outside-object_storage)
 
 ## Object Storage Upload
 _Currently, S3-compatible object storage providers are supported. Feel free to create a github issue to request something else_.

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -412,10 +412,10 @@ def test_create_export_dir_with_path_calls_create_dir(
     assert calls == ["x/y"]
 
 
-def test_create_export_dir_permission_error_logs_warning(
+def test_create_export_dir_permission_error_fails_fast(
     monkeypatch, archiver_instance, mock_config, caplog
 ):
-    """util.create_dir raises PermissionError → warning logged, no exception raised."""
+    """util.create_dir raises PermissionError → pointed error logged, exception propagates."""
     mock_config.user_inputs.output_path = "some/path"
 
     def _raise_perm(path):
@@ -425,10 +425,11 @@ def test_create_export_dir_permission_error_logs_warning(
         "bookstack_file_exporter.archiver.archiver.util.create_dir",
         _raise_perm,
     )
-    caplog.set_level(logging.WARNING, logger="bookstack_file_exporter.archiver.archiver")
-    archiver_instance.create_export_dir()  # must not raise
-    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("Failed to create base directory" in msg for msg in warning_messages)
+    caplog.set_level(logging.ERROR, logger="bookstack_file_exporter.archiver.archiver")
+    with pytest.raises(PermissionError):
+        archiver_instance.create_export_dir()
+    error_messages = [r.message for r in caplog.records if r.levelno == logging.ERROR]
+    assert any("Cannot create export directory" in msg for msg in error_messages)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_archiver.py
+++ b/tests/unit/test_archiver.py
@@ -4,7 +4,7 @@ import logging
 import os
 import re
 import threading
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import List
 from unittest.mock import MagicMock
 
@@ -157,13 +157,15 @@ class TestLevelBaseDir:
 @pytest.mark.parametrize("base_name", ["bkps", "my_export", "abc-123"])
 def test_generate_root_folder_format(monkeypatch, base_name):
     fixed_dt = datetime(2024, 3, 15, 10, 30, 45)
+    fake_now = MagicMock(return_value=fixed_dt)
     monkeypatch.setattr(
         "bookstack_file_exporter.archiver.archiver.datetime",
-        type("_FakeDT", (), {"now": staticmethod(lambda: fixed_dt)})(),
+        type("_FakeDT", (), {"now": staticmethod(fake_now)})(),
     )
     result = Archiver._generate_root_folder(base_name)
     expected = f"{base_name}_2024-03-15_10-30-45"
     assert result == expected
+    fake_now.assert_called_once_with(timezone.utc)
 
 
 def test_archive_dir_has_timestamp_suffix(archiver_instance):

--- a/tests/unit/test_archiver_util.py
+++ b/tests/unit/test_archiver_util.py
@@ -204,6 +204,17 @@ class TestTarStreamPoison:
         with pytest.raises(ArchiveWriteError):
             stream.finalize()
 
+    def test_subsequent_write_carries_first_error(self, tmp_path, monkeypatch):
+        """Poisoned-stream raises must name the ROOT cause, not just 'already failed'."""
+        stream = self._poisoned_stream(tmp_path, monkeypatch)
+        with pytest.raises(ArchiveWriteError, match="disk full"):
+            stream.write("later.txt", b"payload")
+
+    def test_finalize_carries_first_error(self, tmp_path, monkeypatch):
+        stream = self._poisoned_stream(tmp_path, monkeypatch)
+        with pytest.raises(ArchiveWriteError, match="disk full"):
+            stream.finalize()
+
     def test_open_failure_poisons(self, tmp_path):
         # Unwritable target: first write fails, second fails fast as poisoned.
         stream = TarStream(str(tmp_path / "no_such_dir" / "bkps.tgz.partial"))

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -96,5 +96,13 @@ class TestBuildHandler:
         rendered = handler.formatter.format(_record(msg="done", args=()))
         assert rendered.endswith("[INFO] done")
 
+    def test_text_handler_timestamps_in_utc(self):
+        """Text asctime must render in UTC with the label, not host-local time."""
+        handler = build_handler("text")
+        rec = _record(msg="done", args=())
+        rec.created = 0  # 1970-01-01 00:00:00 UTC; a local-time render differs
+        rendered = handler.formatter.format(rec)
+        assert rendered.startswith("1970-01-01 00:00:00 UTC [INFO]")
+
     def test_returns_stream_handler(self):
         assert isinstance(build_handler("text"), logging.StreamHandler)

--- a/tests/unit/test_logging.py
+++ b/tests/unit/test_logging.py
@@ -4,6 +4,7 @@ import json
 import logging
 import re
 import sys
+import time
 
 from bookstack_file_exporter.common.logging import JsonFormatter, build_handler
 
@@ -96,12 +97,20 @@ class TestBuildHandler:
         rendered = handler.formatter.format(_record(msg="done", args=()))
         assert rendered.endswith("[INFO] done")
 
-    def test_text_handler_timestamps_in_utc(self):
+    def test_text_handler_timestamps_in_utc(self, monkeypatch):
         """Text asctime must render in UTC with the label, not host-local time."""
-        handler = build_handler("text")
-        rec = _record(msg="done", args=())
-        rec.created = 0  # 1970-01-01 00:00:00 UTC; a local-time render differs
-        rendered = handler.formatter.format(rec)
+        # Force a non-UTC local zone: on a UTC-configured host, a localtime render
+        # of epoch 0 is identical to the UTC one and a converter revert would pass.
+        monkeypatch.setenv("TZ", "America/New_York")
+        time.tzset()
+        try:
+            handler = build_handler("text")
+            rec = _record(msg="done", args=())
+            rec.created = 0  # 1970-01-01 00:00:00 UTC; EST renders 1969-12-31 19:00:00
+            rendered = handler.formatter.format(rec)
+        finally:
+            monkeypatch.undo()
+            time.tzset()
         assert rendered.startswith("1970-01-01 00:00:00 UTC [INFO]")
 
     def test_returns_stream_handler(self):

--- a/tests/unit/test_models_null_validation.py
+++ b/tests/unit/test_models_null_validation.py
@@ -29,6 +29,7 @@ def test_http_config_rejects_explicit_null(field):
 
 def test_http_config_omitted_keys_still_default():
     cfg = HttpConfig()
+    assert cfg.verify_ssl is True  # secure-by-default: verify the BookStack TLS cert
     assert cfg.timeout == 30
     assert cfg.retry_codes == [413, 429, 500, 502, 503, 504]
 

--- a/tests/unit/test_models_object_storage.py
+++ b/tests/unit/test_models_object_storage.py
@@ -29,13 +29,25 @@ def test_keep_last_rejects_explicit_null():
         S3StorageConfig(**_entry(access_key="a", secret_key="s", keep_last=None))
 
 
-@pytest.mark.parametrize("field", ["prefix", "access_key", "secret_key"])
+@pytest.mark.parametrize("field", ["prefix", "access_key", "secret_key", "ca_bundle"])
 def test_s3_string_fields_reject_explicit_null(field):
     # non-Optional strings: explicit null must fail instead of flowing downstream
     entry = _entry(access_key="a", secret_key="s")
     entry[field] = None
     with pytest.raises(ValidationError):
         S3StorageConfig(**entry)
+
+
+def test_tls_defaults():
+    cfg = S3StorageConfig(**_entry(access_key="a", secret_key="s"))
+    assert cfg.verify_ssl is True
+    assert cfg.ca_bundle == ""
+
+
+def test_ca_bundle_with_verify_off_rejected():
+    with pytest.raises(ValidationError, match="mutually exclusive"):
+        S3StorageConfig(**_entry(access_key="a", secret_key="s",
+                                 verify_ssl=False, ca_bundle="/certs/ca.pem"))
 
 
 def test_is_aws_discriminant():

--- a/tests/unit/test_notifiers.py
+++ b/tests/unit/test_notifiers.py
@@ -2,6 +2,7 @@
 # pylint: disable=protected-access
 """Unit tests for AppRiseNotify._get_message_text success-branch formatting."""
 import os
+import re
 from unittest.mock import MagicMock, patch
 
 from apprise import AppriseConfig, NotifyFormat
@@ -416,6 +417,7 @@ class TestEmptyStatusBody:
         body = notifier._text_body(None, result)
         assert "nothing to archive" in body
         assert "Completed At:" in body
+        assert re.search(r"Completed At: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC", body)
         assert "No pages content was found to export." in body
         assert "Archive:" not in body
         assert "Uploaded to:" not in body
@@ -434,6 +436,7 @@ class TestEmptyStatusBody:
         body = notifier._markdown_body(None, result)
         assert "**Bookstack File Exporter completed - nothing to archive.**" in body
         assert "Completed At:" in body
+        assert re.search(r"Completed At: \d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} UTC", body)
         assert "No pages content was found to export." in body
         assert "Archive:" not in body
         assert "Uploaded to:" not in body

--- a/tests/unit/test_page_archiver.py
+++ b/tests/unit/test_page_archiver.py
@@ -718,6 +718,45 @@ class TestParallelExport:
         expected = {f"{archiver.archive_base_path}/bk/p{i}.md" for i in (2, 3, 5, 6)}
         assert set(collected) == expected
 
+    def test_parallel_archive_write_error_aborts_run(self, tmp_path, build_node):
+        """ArchiveWriteError from a worker aborts the export: the stream is
+        poisoned, so remaining nodes can't be written - cancel queued futures
+        and propagate instead of logging N per-node failures."""
+        config = _make_config(formats=["markdown"], export_workers=2)
+        archiver = PageArchiver(str(tmp_path / "bs"), config, MagicMock(),
+                                asset_archiver=MagicMock())
+        archiver.asset_archiver.get_asset_nodes.return_value = {}
+        parent = build_node(id=1, name="bk", slug="bk")
+        pages = {i: build_node(id=i, name=f"p{i}", slug=f"p{i}", parent=parent)
+                 for i in range(2, 22)}  # 20 pages
+
+        def _boom(path, data):
+            raise ArchiveWriteError("archive write failed for x: disk full")
+        archiver.write_data = _boom
+
+        cancel_calls = []
+
+        class SpyExecutor(ThreadPoolExecutor):
+            def shutdown(self, wait=True, *, cancel_futures=False):
+                cancel_calls.append(cancel_futures)
+                super().shutdown(wait, cancel_futures=cancel_futures)
+
+        with patch(
+            "bookstack_file_exporter.archiver.node_archiver.ThreadPoolExecutor",
+            SpyExecutor,
+        ), patch(
+            "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+            return_value=b"data",
+        ):
+            with pytest.raises(ArchiveWriteError):
+                archiver.archive(pages)
+
+        # The abort path must cancel queued futures (True), not just the
+        # with-exit shutdown (False).
+        assert True in cancel_calls
+        # The aborting error is propagated, not folded into the per-node ledger.
+        assert not archiver.failed_node_exports
+
     def test_parallel_stop_mid_run_does_not_crash(self, tmp_path, build_node):
         """Stop Event set mid-run: no crash, run exits cleanly (partial discarded upstream)."""
         config = _make_config(formats=["markdown"], export_workers=2)

--- a/tests/unit/test_remote_config.py
+++ b/tests/unit/test_remote_config.py
@@ -38,3 +38,16 @@ def test_none_prefix_rejected_at_construction(make_storage_entry):
     # instead of resolving to "" at S3ProviderConfig.
     with pytest.raises(ValidationError):
         make_storage_entry(prefix=None)
+
+
+def test_verify_defaults_to_none_for_sdk_chain(make_storage_entry):
+    # None (not True) so botocore's own AWS_CA_BUNDLE/REQUESTS_CA_BUNDLE chain still applies
+    assert S3ProviderConfig(make_storage_entry()).verify is None
+
+
+def test_verify_ssl_false_resolves_to_false(make_storage_entry):
+    assert S3ProviderConfig(make_storage_entry(verify_ssl=False)).verify is False
+
+
+def test_ca_bundle_resolves_to_path(make_storage_entry):
+    assert S3ProviderConfig(make_storage_entry(ca_bundle="/certs/ca.pem")).verify == "/certs/ca.pem"

--- a/tests/unit/test_s3_archiver.py
+++ b/tests/unit/test_s3_archiver.py
@@ -60,6 +60,16 @@ def test_validate_bucket_raises_when_missing(aws, provider):
         S3CompatibleArchiver(provider(bucket="nope"))
 
 
+def test_client_built_with_per_target_verify(monkeypatch, make_provider):
+    captured = {}
+    def fake_client(self, *args, **kwargs):
+        captured.update(kwargs)
+        return MagicMock()
+    monkeypatch.setattr("boto3.session.Session.client", fake_client)
+    S3CompatibleArchiver(make_provider(ca_bundle="/certs/ca.pem"))
+    assert captured["verify"] == "/certs/ca.pem"
+
+
 def test_validate_bucket_wraps_endpoint_connection_error(monkeypatch, provider):
     fake = MagicMock()
     fake.head_bucket.side_effect = EndpointConnectionError(endpoint_url="http://unreachable:9000")

--- a/tests/unit/test_s3_archiver.py
+++ b/tests/unit/test_s3_archiver.py
@@ -70,6 +70,21 @@ def test_client_built_with_per_target_verify(monkeypatch, make_provider):
     assert captured["verify"] == "/certs/ca.pem"
 
 
+@pytest.mark.parametrize("overrides,expect_disabled", [
+    ({"verify_ssl": False}, True),
+    ({"ca_bundle": "/certs/ca.pem"}, False),  # truthy path must NOT disable warnings
+    ({}, False),                              # default (verify=None) must NOT disable
+])
+def test_urllib3_warnings_disabled_only_when_verify_off(
+        monkeypatch, make_provider, overrides, expect_disabled):
+    monkeypatch.setattr("boto3.session.Session.client", lambda self, *a, **k: MagicMock())
+    disabled = MagicMock()
+    monkeypatch.setattr(
+        "bookstack_file_exporter.archiver.s3_archiver.urllib3.disable_warnings", disabled)
+    S3CompatibleArchiver(make_provider(**overrides))
+    assert disabled.called is expect_disabled
+
+
 def test_validate_bucket_wraps_endpoint_connection_error(monkeypatch, provider):
     fake = MagicMock()
     fake.head_bucket.side_effect = EndpointConnectionError(endpoint_url="http://unreachable:9000")


### PR DESCRIPTION
## Changes

**UTC timestamps on every display surface.** Notification bodies, archive filenames, and text-format log lines (labeled ` UTC`, via a `time.gmtime` converter) now use UTC, joining the JSON logs and health endpoint which already did. Archive filename sorting also becomes immune to DST fall-back non-monotonicity, which filename-sort retention relies on. Cron scheduling deliberately stays container-local wall clock (TZ-driven, documented behavior).

**BookStack API TLS verification on by default (breaking).** `http_config.verify_ssl` now defaults to `true` instead of `false`. The BookStack API token rides this connection, so an unverified default exposes it to interception; verify-by-default matches standard HTTP client behavior and removes the confusing split with `object_storage[].verify_ssl`, which already defaults `true`. A self-signed or internal-CA BookStack now fails with a TLS error on first run — opt out with `http_config.verify_ssl: false` or point `REQUESTS_CA_BUNDLE` at the CA bundle. Documented as a Breaking Upgrade in the README.

**Fail-fast on archive write errors.**
- `TarStream` records its first write/finalize failure and embeds it in subsequent poisoned-stream errors, so the root cause survives even when a secondary error surfaces first from `as_completed`.
- The parallel export loop now aborts promptly on `ArchiveWriteError` (`shutdown(cancel_futures=True)` + raise) instead of logging each queued node as a per-node failure against a dead archive. Scoped to `ArchiveWriteError` only: `requests` exceptions subclass `OSError`, so a broader catch would abort whole runs on transient network errors.
- `create_export_dir` no longer tolerates `PermissionError`: `mkdir(parents=True, exist_ok=True)` never raises for an existing directory (writable or not), so the mounted-volume case the old tolerate-branch targeted never reached it. Reaching it means the path is missing and creation was denied — now a pointed error and hard fail instead of a doomed export.

**Per-target TLS verification for object storage.** New `verify_ssl` (default `true`) and `ca_bundle` per `object_storage` target, passed as boto3's per-client `verify` value: a `ca_bundle` path verifies against that CA, `verify_ssl: false` disables verification, and when neither is set the SDK's own resolution (`AWS_CA_BUNDLE` etc.) applies unchanged. A per-target setting avoids the process-wide `AWS_CA_BUNDLE` trade-off, which replaces the trust store for every target at once and breaks mixed private-CA/public-CA configurations. Setting both is rejected as contradictory.

**http helper.** Removed a log-and-reraise wrapper that double-logged request errors. BookStack-side TLS `verify` intentionally stays per-call: requests gives `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` precedence over `session.verify`, so a session-level setting would let an env var silently override an explicit `verify_ssl: false`.

**Docs.** New guidance on orphaned multipart parts after hard kills (provider-side lifecycle cleanup, e.g. `AbortIncompleteMultipartUpload`), a self-signed/private-CA section for object storage, and notification samples updated to UTC. A pre-release correctness pass also fixed several stale/ambiguous references for v3.0.0: the README's `local/minio/s3` target list replaced with `local` + generic S3-compatible storage (no `type` field); filename timestamps documented as UTC in Backup Behavior; the Remote Storage table of contents rebuilt to include its later sections; and example archive filenames corrected to the real `%Y-%m-%d_%H-%M-%S` format.

**Mechanical tidies.** `args.run_once` direct attribute access, health server `server_close()` after shutdown, hoisted `nodes` annotation, `RunStatus | None` annotation.

## Motivation

Final pre-v3.0.0 batch. UTC, the object-storage TLS knobs, and the `http_config.verify_ssl` default flip land now because v3.0.0 is a breaking release: object storage has not shipped in a tagged release yet (so its knobs are original behavior, not a migration), and the verify_ssl flip is the correct window to harden a security-sensitive default rather than deferring it to a second major later. The fail-fast changes complete the archive-error semantics introduced by the streaming tar writer (#158): one clear root-cause failure instead of a cascade of misleading per-node errors.

## Test plan

- 764 unit tests pass (was 750 at branch point), 95% coverage; `task lint` 10.00/10 for package and tests.
- Read-only-directory smoke: first `ArchiveWriteError` names `Permission denied`; subsequent poisoned errors embed it as `(first error: ...)`.
- UTC pins: text-log test forces `TZ=America/New_York` so a converter revert fails on any host; notification/filename tests assert `now(timezone.utc)` is actually requested and bodies match an anchored `... UTC` pattern.
- boto3 wiring: tests assert the resolved `verify` value reaches `session.client` and that urllib3 warnings are disabled only for `verify_ssl: false` (not for a CA path or default).
- verify_ssl default: a model test locks `HttpConfig().verify_ssl is True`; existing http-helper tests set the value explicitly and are unaffected.

## In-depth

- Timestamp note for operators is queued for the v3.0.0 release notes: east-of-UTC installs may see one transient retention-ordering window at the switch, harmless unless runs are spaced closer than the UTC offset.
- The http side has no `ca_bundle` knob yet (object storage does); a matching `http_config.ca_bundle` is a reasonable post-release follow-up for private-CA BookStack installs that prefer verification over disabling it.
- A follow-up comment-density cleanup (`chore:`) is planned post-release; deliberately excluded here to keep this reviewable.
