### PR TITLE
fix: fetch secure-storage images via authenticated API (issue #145)

### DIFF
--- a/bookstack_file_exporter/archiver/asset_archiver.py
+++ b/bookstack_file_exporter/archiver/asset_archiver.py
@@ -5,6 +5,7 @@ import re
 import base64
 import binascii
 from typing import Literal
+from urllib.parse import urlparse
 
 from markdown_it import MarkdownIt
 # pylint: disable=import-error
@@ -33,7 +34,8 @@ class AssetDecodeError(Exception):
     those builtins are ambiguous (they could equally be our own bug), while
     this type means specifically "the server sent something we cannot decode",
     so callers can treat it exactly like a failed download (skip the asset ->
-    PARTIAL) without a broad except masking real defects.
+    PARTIAL) without a broad except masking real defects. Also covers an image
+    fetch that returned login-page/HTML instead of image bytes (issue #145).
     """
 
 
@@ -294,18 +296,77 @@ class AssetArchiver:
             data_url)
         return asset_data_response.json()
 
-    def get_asset_bytes(self, asset_type: str, url: str) -> bytes:
-        """Get raw asset data"""
-        asset_response: Response = self.http_client.http_get_request(
-            url)
+    def get_asset_bytes(self, asset_type: str,
+            node: ImageNode | AttachmentNode) -> bytes:
+        """Get raw asset bytes for one node.
+
+        Images are fetched via their legacy /uploads/... URL first, falling back
+        to the authenticated image-data API only on a login/HTML response (see
+        _get_image_bytes); attachments use their base64-JSON API route.
+        """
         match asset_type:
             case "images":
-                asset_data = asset_response.content
+                return self._get_image_bytes(node)
             case "attachments":
-                asset_data = self._decode_attachment_response(asset_response)
+                response = self.http_client.http_get_request(node.download_url)
+                return self._decode_attachment_response(response)
             case _:
                 raise ValueError(f"unsupported asset type: {asset_type}")
-        return asset_data
+
+    def _get_image_bytes(self, node: ImageNode) -> bytes:
+        """Fetch image bytes: legacy web URL first, authenticated API as recovery.
+
+        The legacy /uploads/... URL is served directly by the web tier for public
+        images (STORAGE_IMAGE_TYPE local or s3) — fast, and the only route that
+        reaches an image stranded in the non-current storage dir on a migrated
+        instance. A SECURE image (local_secure / local_secure_restricted) instead
+        302-redirects that URL to /login and returns login HTML;
+        _validate_image_response catches that (AssetDecodeError) and we recover the
+        real bytes from the authenticated image-data API (GET .../{id}/data,
+        BookStack v25.11+).
+
+        The API fallback fires ONLY on that login/HTML signal, never on a legacy
+        HTTPError/RetryError: a missing image (404) or a transient legacy 5xx must
+        fail cleanly to a skipped asset (-> PARTIAL), not detour into /data and its
+        retry ladder. Secure images always surface as login HTML, so narrowing the
+        trigger loses no coverage. On a pre-v25.11 instance the /data recovery 404s
+        -> propagates -> PARTIAL (secure images are unfetchable there by any route).
+        """
+        try:
+            return self._validate_image_response(
+                self.http_client.http_get_request(node.download_url))
+        except AssetDecodeError:
+            api_url = f"{self.api_urls['images']}/{node.id_}/data"
+            return self._validate_image_response(
+                self.http_client.http_get_request(api_url))
+
+    @staticmethod
+    def _validate_image_response(response: Response) -> bytes:
+        """Return image bytes, or raise AssetDecodeError on login/HTML corruption.
+
+        Deny-list, NOT an image-magic allowlist: BookStack's accepted gallery
+        formats (jpeg/png/gif/webp/avif) change over time, so an allowlist would
+        flag healthy new formats. Reject only the specific #145 corruption — a
+        login page / HTML served instead of image bytes:
+          (a) body starts with <!doctype or <html (no image format starts '<');
+          (b) the request was redirected (response.history) to a URL whose path
+              ends /login — parsed via urlparse because BookStack redirects to
+              /login?intended=... and a naive endswith('/login') would miss it.
+        Content-Type is deliberately NOT a trigger: a proxy/CDN can mislabel
+        correct image bytes as text/html. Runs on both API and legacy paths.
+        """
+        content = response.content
+        # Strip a leading UTF-8 BOM before the marker check: bytes.lstrip() removes
+        # ASCII whitespace but not the BOM (\xef\xbb\xbf), and this HTML-body rule is
+        # now the primary signal that a secure image redirected to a login page.
+        head = content.removeprefix(b"\xef\xbb\xbf").lstrip()
+        if head[:9].lower().startswith((b"<!doctype", b"<html")):
+            raise AssetDecodeError(
+                "image response body is HTML (login page/error), not image bytes")
+        if response.history and urlparse(response.url).path.endswith("/login"):
+            raise AssetDecodeError(
+                "image request was redirected to a login page, not image bytes")
+        return content
 
     @staticmethod
     def _decode_attachment_response(response: Response) -> bytes:

--- a/bookstack_file_exporter/archiver/node_archiver.py
+++ b/bookstack_file_exporter/archiver/node_archiver.py
@@ -205,7 +205,7 @@ class NodeArchiver:
                 break
             try:
                 asset_data = self.asset_archiver.get_asset_bytes(
-                    asset_type, asset_node.download_url)
+                    asset_type, asset_node)
             except (HTTPError, RetryError, AssetDecodeError) as exc:
                 failed_assets.add(asset_node.id_)
                 log.error("Failed to get image or attachment data "

--- a/docs/backup-behavior.md
+++ b/docs/backup-behavior.md
@@ -128,6 +128,8 @@ bookstack_export_2023-11-28_06-24-25/programming/react/images/nextjs/tips.png
 
 If an API call to get an image or its metadata fails, the exporter will skip the image and log the error. If using `modify_links` option, the image links in the document will be untouched and in its original form. All API calls are retried 3 times after initial failure.
 
+Images stored with BookStack **secure image storage** (`STORAGE_IMAGE_TYPE=local_secure` or `local_secure_restricted`) are fetched through the authenticated image API, which requires **BookStack v25.11+**. On older BookStack a secure image cannot be exported and is skipped (the run is marked partial); public image storage (`local`, `s3`) works on all versions.
+
 ## Attachments
 Attachments will be dumped in a separate directory, `attachments` within the page parent (book/chapter) directory it belongs to. The relative path will be `{parent}/attachments/{page}/{attachment_name}`. As shown earlier:
 

--- a/docs/backup-behavior.md
+++ b/docs/backup-behavior.md
@@ -26,7 +26,7 @@ A few behaviors worth knowing about partial runs and pruning:
 - In-progress (mid-write) archives are written as `*.tgz.incomplete` and are swept automatically at the start of the next run.
 
 ### File Naming
-For file names, `slug` names (from Bookstack API) are used, as such certain characters like `!`, `/` will be ignored and spaces replaced in page names/titles. If your page has an empty `slug` value for some reason (draft that was never fully saved), the exporter will use page name with the `slugify` function from Django to generate a valid slug. Example: `My Page.bin Name!` will be converted to `my-page-bin-name`.
+For file names, `slug` names (from Bookstack API) are used, as such certain characters like `!`, `/` will be ignored and spaces replaced in page names/titles. If a page has an empty `slug` but is not an ignored draft (see [Empty/New Pages](#emptynew-pages)), the exporter falls back to the page name run through Django's `slugify` function to generate a valid slug. Example: `My Page.bin Name!` will be converted to `my-page-bin-name`.
 
 You may also notice some directories (books) and/or files (pages) in the archive have a random string at the end, example - `nKA`: `user-and-group-management-nKA`. This is expected and is because there were resources with the same name created in another shelve and bookstack adds a string at the end to ensure uniqueness.
 
@@ -112,7 +112,9 @@ bookstack_export_2023-11-28_06-24-25/programming/react/nextjs.pdf
 Books without a shelf will be put in a shelve folder named `unassigned`.
 
 ### Empty/New Pages
-Empty/New Pages are ignored: they have not been modified from creation, so they have no content and no valid slug. From the Bookstack API they appear as `"name": "New Page"` with an empty `"slug": ""`.
+Unsaved **draft** pages are ignored: a page created but never saved has no content and no slug, so the exporter skips it. BookStack returns these as `"name": "New Page"` with an empty `"slug": ""`, and the exporter recognizes them by that default *New Page* name — so a non-English instance whose default title differs is not matched.
+
+A **saved** page with a real slug but an empty body is *not* a draft and is *not* ignored: it is exported normally (title only). Empty containers behave symmetrically — a book or chapter with no pages produces no files, since only pages (leaves) yield output.
 
 ## Images
 Images will be dumped in a separate directory, `images` within the page parent (book/chapter) directory it belongs to. The relative path will be `{parent}/images/{page}/{image_name}`. As shown earlier:

--- a/tests/unit/test_asset_archiver_core.py
+++ b/tests/unit/test_asset_archiver_core.py
@@ -5,6 +5,7 @@ import logging
 from unittest.mock import MagicMock
 
 import pytest
+from requests.exceptions import HTTPError, RetryError
 
 from bookstack_file_exporter.archiver.asset_archiver import (
     AssetDecodeError,
@@ -273,8 +274,9 @@ class TestPhase1MdFixes:
 
 
 def test_get_asset_bytes_unknown_type_raises_valueerror(asset_archiver):
+    # ValueError fires before the node is touched, so any object works as arg 2.
     with pytest.raises(ValueError, match="unsupported asset type"):
-        asset_archiver.get_asset_bytes("widgets", "https://wiki.example.com/x")
+        asset_archiver.get_asset_bytes("widgets", MagicMock())
 
 
 def test_create_attachment_map_skips_external(asset_archiver):
@@ -308,6 +310,220 @@ def test_get_asset_bytes_attachment_decode_failure_raises_asset_decode_error(
     response = MagicMock()
     response.configure_mock(**response_setup)
     asset_archiver.http_client.http_get_request.return_value = response
+    node = MagicMock(spec=AttachmentNode)
+    node.download_url = "https://wiki.example.com/api/attachments/6"
     with pytest.raises(AssetDecodeError):
-        asset_archiver.get_asset_bytes(
-            "attachments", "https://wiki.example.com/api/attachments/6")
+        asset_archiver.get_asset_bytes("attachments", node)
+
+
+# ---------------------------------------------------------------------------
+# Issue #145 — legacy-first image fetch with authenticated image-data API
+# fallback + defense-in-depth login/HTML detection.
+# ---------------------------------------------------------------------------
+
+def _make_response(content: bytes, history=None, url: str = "") -> MagicMock:
+    """Build a minimal Response-like mock for image-fetch assertions."""
+    response = MagicMock()
+    response.content = content
+    response.history = history if history is not None else []
+    response.url = url
+    return response
+
+
+def _make_http_error(status_code: int) -> HTTPError:
+    """Build an HTTPError carrying a .response with the given status_code."""
+    error = HTTPError(f"{status_code} error")
+    error.response = MagicMock(status_code=status_code)
+    return error
+
+
+class TestGetImageBytesLegacyFirst:
+    """Legacy-first fetch with authenticated /data recovery on login/HTML."""
+
+    def test_saved_filename_derives_from_content_url_not_data_route(
+            self, asset_archiver, image_node):
+        """ImageNode.name/get_relative_path come from the gallery content URL
+        (set at construction) regardless of which URL bytes were fetched from
+        — the '/data' fetch route must never leak into the saved filename."""
+        asset_archiver.http_client.http_get_request.return_value = _make_response(
+            b"real_png_bytes")
+
+        asset_archiver.get_asset_bytes("images", image_node)
+
+        assert image_node.name == "screenshot.png"
+        relative_path = image_node.get_relative_path("my-page")
+        assert relative_path == "images/my-page/screenshot.png"
+        assert not relative_path.endswith("data")
+
+    def test_public_image_uses_legacy_url_only(self, asset_archiver, image_node):
+        """Public image (STORAGE_IMAGE_TYPE local/s3): legacy 200s with real
+        bytes, so the /data API is never requested."""
+        asset_archiver.http_client.http_get_request.return_value = _make_response(
+            b"real_png_bytes")
+
+        result = asset_archiver.get_asset_bytes("images", image_node)
+
+        assert result == b"real_png_bytes"
+        asset_archiver.http_client.http_get_request.assert_called_once_with(
+            image_node.download_url)
+
+    def test_secure_image_login_html_falls_back_to_data_api(
+            self, asset_archiver, image_node):
+        """The #145 fix: legacy redirects a secure image to a login page
+        (HTML body); the detector raises AssetDecodeError internally and the
+        authenticated /data API recovers the real bytes."""
+        login_response = _make_response(b"<!DOCTYPE html><html>login</html>")
+        api_response = _make_response(b"real_bytes_from_api")
+        asset_archiver.http_client.http_get_request.side_effect = [
+            login_response, api_response,
+        ]
+
+        result = asset_archiver.get_asset_bytes("images", image_node)
+
+        assert result == b"real_bytes_from_api"
+        calls = asset_archiver.http_client.http_get_request.call_args_list
+        assert calls[0].args[0] == image_node.download_url
+        assert calls[1].args[0] == f"{asset_archiver.api_urls['images']}/{image_node.id_}/data"
+
+    def test_secure_image_login_redirect_falls_back_to_data_api(
+            self, asset_archiver, image_node):
+        """Rule (b) path: legacy 200s with non-HTML-looking bytes but the
+        request was redirected to /login — still triggers the /data fallback."""
+        redirect_response = _make_response(
+            b"not html, not empty",
+            history=[MagicMock()],
+            url="https://wiki.example.com/login?intended=%2Fx",
+        )
+        api_response = _make_response(b"real_bytes_from_api")
+        asset_archiver.http_client.http_get_request.side_effect = [
+            redirect_response, api_response,
+        ]
+
+        result = asset_archiver.get_asset_bytes("images", image_node)
+
+        assert result == b"real_bytes_from_api"
+        calls = asset_archiver.http_client.http_get_request.call_args_list
+        assert calls[0].args[0] == image_node.download_url
+        assert calls[1].args[0] == f"{asset_archiver.api_urls['images']}/{image_node.id_}/data"
+
+    def test_missing_image_legacy_404_propagates_without_api_fallback(
+            self, asset_archiver, image_node):
+        """A deleted/missing image (legacy 404) must fail cleanly — no
+        wasteful detour into the /data API on a non-login error."""
+        asset_archiver.http_client.http_get_request.side_effect = _make_http_error(404)
+
+        with pytest.raises(HTTPError):
+            asset_archiver.get_asset_bytes("images", image_node)
+
+        asset_archiver.http_client.http_get_request.assert_called_once_with(
+            image_node.download_url)
+
+    def test_transient_legacy_5xx_propagates_without_api_fallback(
+            self, asset_archiver, image_node):
+        """A transient legacy RetryError must propagate — not trigger the
+        /data fallback (that's reserved for the login/HTML signal only)."""
+        asset_archiver.http_client.http_get_request.side_effect = RetryError("max retries")
+
+        with pytest.raises(RetryError):
+            asset_archiver.get_asset_bytes("images", image_node)
+
+        asset_archiver.http_client.http_get_request.assert_called_once_with(
+            image_node.download_url)
+
+    def test_secure_image_on_pre_v25_11_data_api_404s_and_propagates(
+            self, asset_archiver, image_node):
+        """Secure image on a pre-v25.11 instance: legacy login-HTML triggers
+        the fallback attempt, but /data 404s there too (route doesn't exist
+        yet) -> propagates -> caller marks the run PARTIAL."""
+        login_response = _make_response(b"<!DOCTYPE html><html>login</html>")
+        asset_archiver.http_client.http_get_request.side_effect = [
+            login_response, _make_http_error(404),
+        ]
+
+        with pytest.raises(HTTPError):
+            asset_archiver.get_asset_bytes("images", image_node)
+
+        calls = asset_archiver.http_client.http_get_request.call_args_list
+        assert len(calls) == 2
+        assert calls[1].args[0] == f"{asset_archiver.api_urls['images']}/{image_node.id_}/data"
+
+    def test_data_api_also_returns_login_html_raises_asset_decode_error(
+            self, asset_archiver, image_node):
+        """Defense-in-depth: if the /data recovery attempt also comes back as
+        login/HTML (e.g. an odd proxy), AssetDecodeError propagates -> PARTIAL."""
+        login_response = _make_response(b"<!DOCTYPE html><html>login</html>")
+        also_login_response = _make_response(b"<!DOCTYPE html><html>login2</html>")
+        asset_archiver.http_client.http_get_request.side_effect = [
+            login_response, also_login_response,
+        ]
+
+        with pytest.raises(AssetDecodeError):
+            asset_archiver.get_asset_bytes("images", image_node)
+
+
+class TestValidateImageResponse:
+    """C. Defense-in-depth detector."""
+
+    def test_ignores_mislabeled_content_type_header(self, asset_archiver):
+        """Content-Type is not a trigger: a proxy/CDN can mislabel correct
+        image bytes as text/html."""
+        response = _make_response(b"\x89PNG\r\n\x1a\nrest-of-real-png-bytes")
+        response.headers = {"Content-Type": "text/html"}
+
+        result = asset_archiver._validate_image_response(response)
+
+        assert result == response.content
+
+    @pytest.mark.parametrize("body", [
+        b"<!DOCTYPE html><html><body>login</body></html>",
+        b"<html><head></head><body>login</body></html>",
+        b"   <!DOCTYPE html><html></html>",
+        b"  <HTML><body>login</body></html>",
+    ])
+    def test_rejects_html_body(self, asset_archiver, body):
+        response = _make_response(body)
+        with pytest.raises(AssetDecodeError):
+            asset_archiver._validate_image_response(response)
+
+    def test_rejects_html_body_with_leading_utf8_bom(self, asset_archiver):
+        """bytes.lstrip() strips ASCII whitespace but not a leading UTF-8 BOM
+        (\\xef\\xbb\\xbf); the marker check must strip it first so a
+        BOM-prefixed login page is still detected as HTML."""
+        response = _make_response(b"\xef\xbb\xbf<!DOCTYPE html><html>login</html>")
+        with pytest.raises(AssetDecodeError):
+            asset_archiver._validate_image_response(response)
+
+    def test_rejects_redirect_to_login_path_with_query_string(self, asset_archiver):
+        """BookStack redirects to /login?intended=..., so the check must parse
+        the URL (urlparse) rather than naive endswith('/login')."""
+        response = _make_response(
+            b"not html, not empty",
+            history=[MagicMock()],
+            url="https://wiki.example.com/login?intended=%2Fx",
+        )
+        with pytest.raises(AssetDecodeError):
+            asset_archiver._validate_image_response(response)
+
+    def test_login_suffixed_url_without_redirect_history_is_not_flagged(
+            self, asset_archiver):
+        """Redirect evidence (response.history) is required — a URL that merely
+        ends in /login with no redirect history is not corruption."""
+        response = _make_response(
+            b"not html, not empty", history=[], url="https://wiki.example.com/login")
+
+        result = asset_archiver._validate_image_response(response)
+
+        assert result == response.content
+
+    @pytest.mark.parametrize("body", [
+        b"RIFF\x00\x00\x00\x00WEBPVP8 \x00\x00\x00\x00",
+        b"\x00\x00\x00\x20ftypavif\x00\x00\x00\x00",
+    ])
+    def test_accepts_non_png_jpeg_formats_deny_list_not_allow_list(self, asset_archiver, body):
+        """Deny-list, not an image-magic allowlist: newer gallery formats
+        (webp/avif) must pass through untouched."""
+        response = _make_response(body)
+
+        result = asset_archiver._validate_image_response(response)
+
+        assert result == body

--- a/tests/unit/test_asset_archiver_modify_html.py
+++ b/tests/unit/test_asset_archiver_modify_html.py
@@ -219,8 +219,8 @@ class TestPhase4PageArchiverDispatch:  # pylint: disable=too-few-public-methods
             {5: [good_node, bad_node]} if asset_type == "images" else {}
         )
 
-        def _fail_bad_node(_asset_type, url):
-            if "99" in url:
+        def _fail_bad_node(_asset_type, node):
+            if node.id_ == 99:
                 raise HTTPError("404")
             return b"img_bytes"
 
@@ -313,6 +313,10 @@ class TestE2eHtmlRewrite:  # pylint: disable=too-few-public-methods
             "url": self.IMAGE_URL,
         }]
         http_client.http_get_request.return_value.content = b"fake_png_bytes"
+        # _validate_image_response inspects response.history for a login redirect;
+        # a bare MagicMock is truthy, so an unrelated successful fetch must set it
+        # explicitly to [] (no redirect) or it would be misread as one.
+        http_client.http_get_request.return_value.history = []
 
         written: dict = {}
 

--- a/tests/unit/test_config_helper.py
+++ b/tests/unit/test_config_helper.py
@@ -62,6 +62,7 @@ def test_load_yaml_config_raises_value_error_on_empty_file(tmp_path, content):
 
 
 def test_non_mapping_yaml_root_raises_clear_error(tmp_path):
+    """load_yaml_config must reject a YAML root that is not a mapping."""
     cfg = tmp_path / "config.yml"
     cfg.write_text("- just\n- a\n- list\n", encoding="utf-8")
     with pytest.raises(ValueError, match="mapping"):

--- a/tests/unit/test_page_archiver_assets.py
+++ b/tests/unit/test_page_archiver_assets.py
@@ -249,3 +249,36 @@ def test_asset_decode_failure_skips_asset_and_keeps_page(tmp_path, build_node):
     assert archiver.failed_asset_downloads == ["attachments/gallery/broken.dat"]
     assert not archiver.failed_node_exports
     assert mock_write.call_count == 1  # the page export itself still landed
+
+
+def test_image_validation_failure_skips_asset_and_keeps_page(tmp_path, build_node):
+    """A _validate_image_response failure (issue #145 login-HTML detection)
+    raises AssetDecodeError, which _archive_node_assets' asset-level
+    `except (HTTPError, RetryError, AssetDecodeError)` catches exactly like a
+    failed download: the image is recorded as failed, but the page itself
+    still exports (-> PARTIAL, not abort)."""
+    config = _make_config(formats=["markdown"], export_images=True,
+                          export_attachments=False, export_meta=False)
+    mock_asset_archiver = MagicMock()
+    archiver = PageArchiver(str(tmp_path / "bookstack-image-decode"), config, MagicMock(),
+                            asset_archiver=mock_asset_archiver)
+
+    parent_node = build_node(id=1, name="a-book", slug="a-book")
+    page = build_node(id=41, name="gallery", slug="gallery", parent=parent_node)
+
+    bad = MagicMock()
+    bad.id_ = 200
+    bad.get_relative_path.return_value = "images/gallery/broken.png"
+    mock_asset_archiver.get_asset_nodes.return_value = {41: [bad]}
+    mock_asset_archiver.get_asset_bytes.side_effect = AssetDecodeError(
+        "image request was redirected to a login page, not image bytes")
+
+    with patch(
+        "bookstack_file_exporter.archiver.node_archiver.archiver_util.get_byte_response",
+        return_value=b"page bytes",
+    ), patch("bookstack_file_exporter.archiver.util.TarStream.write") as mock_write:
+        archiver.archive({41: page})  # must not raise
+
+    assert archiver.failed_asset_downloads == ["images/gallery/broken.png"]
+    assert not archiver.failed_node_exports
+    assert mock_write.call_count == 1  # the page export itself still landed

--- a/tests/unit/test_page_archiver_parallel.py
+++ b/tests/unit/test_page_archiver_parallel.py
@@ -389,8 +389,8 @@ class TestFailureLedger:
 
         mock_asset_archiver.get_asset_nodes.return_value = {40: [bad, ok]}
 
-        def _get_bytes(asset_type, url):
-            if url is bad.download_url:
+        def _get_bytes(asset_type, node):
+            if node is bad:
                 raise HTTPError("404")
             return b"img"
 


### PR DESCRIPTION
Closes #145.

## Changes

Image fetch is now **legacy-first with an authenticated-API recovery**:

- Try the legacy `download_url` first. Public storage (`local`, `s3`) and images stranded in a non-current storage directory after a mode switch resolve on this one request and never touch the API.
- Every image response is validated by a deny-list detector: reject a body starting with `<!doctype`/`<html` (after stripping a leading UTF-8 BOM + whitespace), or a response redirected to a `/login` path. Content-Type is deliberately **not** a trigger (proxies/CDNs mislabel valid image bytes).
- On that `AssetDecodeError` **only**, fall back to the authenticated `GET /api/image-gallery/{id}/data` (BookStack v25.11+). The fallback never fires on a plain `HTTPError`/`RetryError`, so a deleted (404) or transient legacy 5xx fails straight to a partial export instead of hitting the API retry ladder.

## Background

BookStack "secure image storage" (`STORAGE_IMAGE_TYPE=local_secure` / `local_secure_restricted`) serves gallery images behind an authenticated route. The legacy `/uploads` web URL does not honor the API token: under secure storage it 302-redirects to `/login`, `requests` follows the redirect, and the **login-page HTML was saved as the `.png` with a clean exit 0** — a silent corruption. Every degraded path now fails loud (asset skipped, run marked partial), never silent.

## Scalability

Holds across all four storage types and old instances:

| Storage | Path |
|---|---|
| `local`, `s3` (public) | legacy 200, API untouched |
| `local_secure`, `local_secure_restricted` | legacy 302→login → detector → authenticated `/data` |
| restricted, token lacks page visibility | `/data` errors → `HTTPError` → skip → partial (loud) |
| pre-v25.11 + secure | `/data` 404 immediate (no retry ladder) → skip → partial; docs state the v25.11+ requirement |

Secure images pay one wasted legacy round-trip per export; accepted by design (no config flag). No upfront public-vs-secure signal exists — storage mode is an instance-wide env not exposed by the API and image metadata is identical for both — so per-image behavioral detection is the only viable signal.

## In-depth

- **Fallback trigger is `AssetDecodeError` only, never `HTTPError`/`RetryError`.** This keeps a genuinely deleted or transient-failing legacy image from paying the API's expensive retry ladder before failing to partial.