### PR TITLE
docs: v3 pre-release doc polish + image-fetch terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Table of Contents
 ## Background
 _If you encounter any issues, want to request an additional feature, or provide assistance, feel free to open a Github issue._
 
-This tool provides a way to export [Bookstack](https://github.com/BookStackApp/BookStack) pages and their content (_text, images, attachments, metadata, etc._) into a relational parent-child layout locally with an option to push to remote object storage locations. See [Backup Behavior](docs/backup-behavior.md#backup-behavior) section for more details on how pages are organized. Image and attachment links can also be modified in markdown and html exports to point to local exported paths.
+This self-admittedly, overly complicated tool provides a way to export [Bookstack](https://github.com/BookStackApp/BookStack) pages and their content (_text, images, attachments, metadata, etc._) into a relational parent-child layout locally with an option to push to remote object storage locations. See [Backup Behavior](docs/backup-behavior.md#backup-behavior) section for more details on how pages are organized. Image and attachment links can also be modified in markdown and html exports to point to local exported paths.
 
 This small project was mainly created to run as a cron job in k8s but works anywhere. This tool allows me to export my docs in markdown, or other formats like pdf. I use Bookstack's markdown editor as default instead of WYSIWYG editor and this makes my notes portable anywhere even if offline.
 
@@ -24,10 +24,9 @@ What it does:
 
 - Discover and build relationships between Bookstack `Shelves/Books/Chapters/Pages` to create a relational parent-child layout
 - Export Bookstack pages and their content to a `.tgz` archive
-- Additional page content — images, attachments, and metadata — can also be exported
-- Works with BookStack [secure image storage](docs/backup-behavior.md#secure-image-storage) (`local_secure` / `local_secure_restricted`): images are fetched via the authenticated image API automatically, no config toggling (requires BookStack v25.11+ for secure images; public storage works on all versions)
+- Additional page content: images, attachments, and metadata can also be exported
 - The exporter can also [Modify Links](docs/backup-behavior.md#modify-links) to replace image and/or attachment links with local exported paths for a more portable backup
-- Fine grained filtering and selectable export levels.
+- Fine grained filtering, selectable export levels (books/chapters/pages), and parallelization to speed up download of contents and assets
 - YAML configuration file for repeatable and easy runs
 - Can be run via [Python](docs/getting-started.md#run-via-pip) or [Docker](docs/getting-started.md#run-via-docker)
 - Can push archives to remote object storage like [MinIO](https://min.io/) or [AWS S3](https://aws.amazon.com/s3/)
@@ -73,10 +72,7 @@ Below are versions that have major changes to the way configuration or exporter 
 | ------------- | -------------- | ----------- |
 | `< 1.4.X` | `1.5.0` | `assets.verify_ssl` has been moved to `http_config.verify_ssl` and the default value has been updated to `false`. `additional_headers` has been moved to `http_config.additional_headers` |
 | `1.6.X` | `3.0.0` | `assets.modify_markdown` is deprecated — HTML image and attachment link rewrites are now supported, so the markdown-specific name no longer fits. Use `assets.modify_links` instead. The legacy `modify_markdown` key was removed in `3.0.0`. |
-| `< 3.0.0` | `3.0.0` | The top-level `minio:` config block is removed. Replace it with an `object_storage:` list entry using the flat schema (`name`, `endpoint`, `prefix`, `ambient_auth`, etc — no `type` field). See [Migrating from v2](docs/remote-storage.md#migrating-from-v2) for the exact mapping. |
-| `< 3.0.0` | `3.0.0` | `http_config.verify_ssl` now defaults to `true` (was `false`) — the exporter verifies the BookStack server's TLS certificate by default. If your BookStack uses a self-signed or internal-CA certificate, set `http_config.verify_ssl: false`, or point the `REQUESTS_CA_BUNDLE` environment variable at your CA bundle. |
-| `< 3.0.0` | `3.0.0` | Retention pruning is now skipped on partial runs (a run that drops content): neither local nor remote archives are pruned, and such archives are named `*_partial.tgz`. Set `prune_on_partial: true` for the old unconditional behavior. See [docs/backup-behavior.md](docs/backup-behavior.md). |
-| `< 3.0.0` | `3.0.0` | With `export_workers: 1` (the default), a node that fails to export no longer aborts the whole run: it is skipped, recorded, and the run completes as `PARTIAL` (exit `3`), matching parallel behavior. Combined with v3's retention gating, a degraded run also never prunes existing backups. |
+| `< 3.0.0` | `3.0.0` | For more details on exact changes see [`v3.0.0`](https://github.com/homeylab/bookstack-file-exporter/releases/tag/v3.0.0). Highlights below:<br>- `modify_markdown` key removed, use `modify_links` instead. <br>- The top-level `minio:` config block is removed. Replace it with an `object_storage:`, see [Migrating from v2](docs/remote-storage.md#migrating-from-v2).<br>- `http_config.verify_ssl` now defaults to `true` (was `false`). |
 
 ## Future Items
 1. ~~Be able to pull images locally and place in their respective page folders for a more complete file level backup.~~

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ What it does:
 - Discover and build relationships between Bookstack `Shelves/Books/Chapters/Pages` to create a relational parent-child layout
 - Export Bookstack pages and their content to a `.tgz` archive
 - Additional page content — images, attachments, and metadata — can also be exported
+- Works with BookStack [secure image storage](docs/backup-behavior.md#secure-image-storage) (`local_secure` / `local_secure_restricted`): images are fetched via the authenticated image API automatically, no config toggling (requires BookStack v25.11+ for secure images; public storage works on all versions)
 - The exporter can also [Modify Links](docs/backup-behavior.md#modify-links) to replace image and/or attachment links with local exported paths for a more portable backup
 - Fine grained filtering and selectable export levels.
 - YAML configuration file for repeatable and easy runs
@@ -61,7 +62,7 @@ Detailed docs live under [`docs/`](docs/):
 - [Getting Started](docs/getting-started.md) — install via Pip/Docker/Helm, run modes, scheduling, health endpoint, authentication
 - [Configuration](docs/configuration.md) — full `config.yml` reference, all options, environment variables, export level, parallel export
 - [Filters](docs/filters.md) — include/exclude shelves, books, chapters, pages by name
-- [Backup Behavior](docs/backup-behavior.md) — archive layout, file naming, images, attachments, modify-links
+- [Backup Behavior](docs/backup-behavior.md) — archive layout, file naming, images (incl. secure image storage), attachments, modify-links
 - [Remote Storage](docs/remote-storage.md) — MinIO / S3 upload, credential resolution, multi-target behavior, v2→v3 migration
 - [Notifications](docs/notifications.md) — apprise notifications on export success/failure
 

--- a/bookstack_file_exporter/archiver/archiver.py
+++ b/bookstack_file_exporter/archiver/archiver.py
@@ -141,10 +141,11 @@ class Archiver:
         exist on disk yet, so only earlier runs' leftovers are removed. Moving this
         call after any write would make it delete the live tar.
 
-        Globs on the unscoped base_dir_name (e.g. `bkps`), not the level-scoped
-        base_dir (`bkps_books`): intermediates are always junk regardless of export
-        level, so `bkps_*` clears incompletes stranded by prior runs at any level. The
-        `bkps_` prefix still anchors the scan so unrelated files are never touched.
+        Globs on the unscoped base_dir_name (e.g. `bkps/bookstack_export`), not the
+        level-scoped base_dir (`bkps/bookstack_export_books`): intermediates are always
+        junk regardless of export level, so `bkps/bookstack_export_*` clears incompletes
+        stranded by prior runs at any level. The `bkps/bookstack_export_` prefix still
+        anchors the scan so unrelated files are never touched.
         (keep_last retention deliberately stays level-scoped — those are deliverables.)
         Also retro-cleans .tar orphans stranded by pre-v3 versions (which staged
         an intermediate .tar before gzipping) and by past failed cycles.

--- a/bookstack_file_exporter/archiver/asset_archiver.py
+++ b/bookstack_file_exporter/archiver/asset_archiver.py
@@ -300,7 +300,7 @@ class AssetArchiver:
             node: ImageNode | AttachmentNode) -> bytes:
         """Get raw asset bytes for one node.
 
-        Images are fetched via their legacy /uploads/... URL first, falling back
+        Images are fetched via their public /uploads/... URL first, falling back
         to the authenticated image-data API only on a login/HTML response (see
         _get_image_bytes); attachments use their base64-JSON API route.
         """
@@ -314,9 +314,9 @@ class AssetArchiver:
                 raise ValueError(f"unsupported asset type: {asset_type}")
 
     def _get_image_bytes(self, node: ImageNode) -> bytes:
-        """Fetch image bytes: legacy web URL first, authenticated API as recovery.
+        """Fetch image bytes: public web URL first, authenticated API as recovery.
 
-        The legacy /uploads/... URL is served directly by the web tier for public
+        The public /uploads/... URL is served directly by the web tier for public
         images (STORAGE_IMAGE_TYPE local or s3) — fast, and the only route that
         reaches an image stranded in the non-current storage dir on a migrated
         instance. A SECURE image (local_secure / local_secure_restricted) instead
@@ -325,8 +325,8 @@ class AssetArchiver:
         real bytes from the authenticated image-data API (GET .../{id}/data,
         BookStack v25.11+).
 
-        The API fallback fires ONLY on that login/HTML signal, never on a legacy
-        HTTPError/RetryError: a missing image (404) or a transient legacy 5xx must
+        The API fallback fires ONLY on that login/HTML signal, never on a public-URL
+        HTTPError/RetryError: a missing image (404) or a transient public-URL 5xx must
         fail cleanly to a skipped asset (-> PARTIAL), not detour into /data and its
         retry ladder. Secure images always surface as login HTML, so narrowing the
         trigger loses no coverage. On a pre-v25.11 instance the /data recovery 404s
@@ -353,7 +353,7 @@ class AssetArchiver:
               ends /login — parsed via urlparse because BookStack redirects to
               /login?intended=... and a naive endswith('/login') would miss it.
         Content-Type is deliberately NOT a trigger: a proxy/CDN can mislabel
-        correct image bytes as text/html. Runs on both API and legacy paths.
+        correct image bytes as text/html. Runs on both API and public-URL paths.
         """
         content = response.content
         # Strip a leading UTF-8 BOM before the marker check: bytes.lstrip() removes

--- a/docs/backup-behavior.md
+++ b/docs/backup-behavior.md
@@ -130,7 +130,12 @@ bookstack_export_2023-11-28_06-24-25/programming/react/images/nextjs/tips.png
 
 If an API call to get an image or its metadata fails, the exporter will skip the image and log the error. If using `modify_links` option, the image links in the document will be untouched and in its original form. All API calls are retried 3 times after initial failure.
 
-Images stored with BookStack **secure image storage** (`STORAGE_IMAGE_TYPE=local_secure` or `local_secure_restricted`) are fetched through the authenticated image API, which requires **BookStack v25.11+**. On older BookStack a secure image cannot be exported and is skipped (the run is marked partial); public image storage (`local`, `s3`) works on all versions.
+### Secure image storage
+By default the exporter fetches each image from its **public image URL** (`/uploads/images/...`) — the URL BookStack embeds in page content, served directly and unauthenticated for `local` and `s3` storage.
+
+If BookStack uses **secure image storage** (`STORAGE_IMAGE_TYPE=local_secure` or `local_secure_restricted`), that public URL is not token-authenticated: it redirects to the login page instead of returning the image. The exporter detects the login/HTML response and automatically retries through the **authenticated image API** (`GET /api/image-gallery/{id}/data`), which is permission-checked inside BookStack and requires **BookStack v25.11+**.
+
+No configuration is required — an instance with a mix of public and secure images works with no toggling, at the cost of one extra request per secure image (public images are unaffected). On BookStack older than v25.11 a secure image cannot be retrieved by any route and is skipped, marking the run partial; public image storage works on all versions.
 
 ## Attachments
 Attachments will be dumped in a separate directory, `attachments` within the page parent (book/chapter) directory it belongs to. The relative path will be `{parent}/attachments/{page}/{attachment_name}`. As shown earlier:

--- a/docs/backup-behavior.md
+++ b/docs/backup-behavior.md
@@ -2,25 +2,26 @@
 
 [← Back to README](../README.md#documentation)
 
-- [General](#general)
+- [Format](#format)
   - [File Naming](#file-naming)
   - [Directory Layout](#directory-layout)
   - [Empty/New Pages](#emptynew-pages)
 - [Images](#images)
+  - [Secure image storage](#secure-image-storage)
 - [Attachments](#attachments)
 - [Modify Links](#modify-links)
   - [Markdown example](#markdown-example)
   - [HTML example](#html-example)
   - [Known limitations](#known-limitations)
 
-## General
-Backups are exported in `.tgz` format and generated based off timestamp. Export names will be in the format: `%Y-%m-%d_%H-%M-%S` (Year-Month-Day_Hour-Minute-Second). The timestamp is **UTC** as of v3.0.0 (earlier versions used the host's local time); notification bodies use the same UTC clock. *Files are first pulled locally to create the tarball and then can be sent to object storage if needed*. Example file name: `bookstack_export_2023-09-22_07-19-54.tgz`.
+## Format
+Backups are exported in `.tgz` format and generated based off timestamp. Export names will be in the format: `%Y-%m-%d_%H-%M-%S` (Year-Month-Day_Hour-Minute-Second). The timestamp is **UTC** and notification bodies use the same UTC clock. *Files are first pulled locally to create the tarball and then can be sent to object storage if needed*. Example file name: `bookstack_export_2023-09-22_07-19-54.tgz`.
 
 The exporter can also do housekeeping duties and keep a configured number of archives and delete older ones. See `keep_last` property in the [Configuration](configuration.md#options-and-descriptions) section. Object storage provider configurations include their own `keep_last` property for flexibility.
 
-A few behaviors worth knowing about partial runs and pruning:
-- A run that drops content (a failed node export or asset download) publishes its archive as `bookstack_export_<timestamp>_partial.tgz`. The `_partial` marker reflects **content** loss only — an upload-stage failure happens after the archive is named and does not add the marker.
-- Retention pruning is **skipped entirely** on a partial run — neither the top-level local `keep_last` nor any `object_storage` target's `keep_last` runs — unless `prune_on_partial: true` is set in the config. This trades loud disk growth for never letting a degraded backup evict a complete one. See the `prune_on_partial` property in the [Configuration](configuration.md#options-and-descriptions) section.
+**A few behaviors worth knowing about partial runs and pruning**:
+- A run that drops content (a failed node export or asset download) publishes its archive as `bookstack_export_<timestamp>_partial.tgz`. The `_partial` marker reflects **content** loss only; a failure that occurs after archive is completely written/named does not add the marker.
+- Retention pruning is **skipped entirely** on a partial run — neither the top-level local `keep_last` nor any `object_storage` target's `keep_last` runs — unless `prune_on_partial: true` is set in the config. This trades disk growth for never letting a degraded backup evict a complete one. See the `prune_on_partial` property in the [Configuration](configuration.md#options-and-descriptions) section.
 - `*_partial.tgz` archives still **count toward** `keep_last` slots and are pruned as they age by later successful runs, both locally and on remote targets — pruning is only skipped by the partial run itself, not by the runs that follow it.
 - With `keep_last: -1`, repeated partial runs accumulate one `*_partial.tgz` per run until the next clean run deletes all local copies — this is expected, and each partial run logs a WARNING calling out the skipped pruning.
 - In-progress (mid-write) archives are written as `*.tgz.incomplete` and are swept automatically at the start of the next run.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -162,7 +162,7 @@ The shelf/book/chapter hierarchy is preserved as directories inside the archive 
 
 `assets.export_meta` applies at all levels: when enabled, a `_meta.json` file is written alongside each exported node.
 
-For non-default levels the archive filename is suffixed with the level (e.g. `bkps_books_<timestamp>.tgz`, `bkps_chapters_<timestamp>.tgz`); `pages` keeps the unsuffixed `bkps_<timestamp>.tgz`. Because `keep_last` cleanup matches on this prefix, archive retention is scoped independently per level.
+For non-default levels the archive filename is suffixed with the level (e.g. `bookstack_export_books_<timestamp>.tgz`, `bookstack_export_chapters_<timestamp>.tgz`); `pages` keeps the unsuffixed `bookstack_export_<timestamp>.tgz`. Because `keep_last` cleanup matches on this prefix, archive retention is scoped independently per level.
 
 ## Parallel Export
 

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -4,6 +4,7 @@
 
 - [General](#general)
 - [Format](#format)
+  - [Body Format](#body-format)
 - [apprise](#apprise)
 
 ## General

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -124,7 +124,7 @@ run_interval: 0
 # when health_port is set, the daemon serves GET /healthz returning JSON:
 #   {"status","last_run":{...},"next_run","run_count","failure_count"}
 # liveness: returns 200 while the daemon is alive (a single failed cycle does NOT
-#   flip it off 200); the scrape signal is last_run.status (never/running/success/failed)
+#   flip it off 200); the scrape signal is last_run.status (never/running/success/degraded/failed)
 # no server is started unless health_port is set; ignored in one-shot mode
 # health_port: 8080
 # optional bind address; defaults to 0.0.0.0 (container/k8s friendly).

--- a/tests/unit/test_asset_archiver_core.py
+++ b/tests/unit/test_asset_archiver_core.py
@@ -317,7 +317,7 @@ def test_get_asset_bytes_attachment_decode_failure_raises_asset_decode_error(
 
 
 # ---------------------------------------------------------------------------
-# Issue #145 — legacy-first image fetch with authenticated image-data API
+# Issue #145 — public-first image fetch with authenticated image-data API
 # fallback + defense-in-depth login/HTML detection.
 # ---------------------------------------------------------------------------
 
@@ -337,8 +337,8 @@ def _make_http_error(status_code: int) -> HTTPError:
     return error
 
 
-class TestGetImageBytesLegacyFirst:
-    """Legacy-first fetch with authenticated /data recovery on login/HTML."""
+class TestGetImageBytesPublicFirst:
+    """Public-first fetch with authenticated /data recovery on login/HTML."""
 
     def test_saved_filename_derives_from_content_url_not_data_route(
             self, asset_archiver, image_node):
@@ -355,9 +355,9 @@ class TestGetImageBytesLegacyFirst:
         assert relative_path == "images/my-page/screenshot.png"
         assert not relative_path.endswith("data")
 
-    def test_public_image_uses_legacy_url_only(self, asset_archiver, image_node):
-        """Public image (STORAGE_IMAGE_TYPE local/s3): legacy 200s with real
-        bytes, so the /data API is never requested."""
+    def test_public_image_uses_public_url_only(self, asset_archiver, image_node):
+        """Public image (STORAGE_IMAGE_TYPE local/s3): the public URL 200s with
+        real bytes, so the /data API is never requested."""
         asset_archiver.http_client.http_get_request.return_value = _make_response(
             b"real_png_bytes")
 
@@ -369,7 +369,7 @@ class TestGetImageBytesLegacyFirst:
 
     def test_secure_image_login_html_falls_back_to_data_api(
             self, asset_archiver, image_node):
-        """The #145 fix: legacy redirects a secure image to a login page
+        """The #145 fix: the public URL redirects a secure image to a login page
         (HTML body); the detector raises AssetDecodeError internally and the
         authenticated /data API recovers the real bytes."""
         login_response = _make_response(b"<!DOCTYPE html><html>login</html>")
@@ -387,7 +387,7 @@ class TestGetImageBytesLegacyFirst:
 
     def test_secure_image_login_redirect_falls_back_to_data_api(
             self, asset_archiver, image_node):
-        """Rule (b) path: legacy 200s with non-HTML-looking bytes but the
+        """Rule (b) path: the public URL 200s with non-HTML-looking bytes but the
         request was redirected to /login — still triggers the /data fallback."""
         redirect_response = _make_response(
             b"not html, not empty",
@@ -406,9 +406,9 @@ class TestGetImageBytesLegacyFirst:
         assert calls[0].args[0] == image_node.download_url
         assert calls[1].args[0] == f"{asset_archiver.api_urls['images']}/{image_node.id_}/data"
 
-    def test_missing_image_legacy_404_propagates_without_api_fallback(
+    def test_missing_image_public_404_propagates_without_api_fallback(
             self, asset_archiver, image_node):
-        """A deleted/missing image (legacy 404) must fail cleanly — no
+        """A deleted/missing image (public URL 404) must fail cleanly — no
         wasteful detour into the /data API on a non-login error."""
         asset_archiver.http_client.http_get_request.side_effect = _make_http_error(404)
 
@@ -418,9 +418,9 @@ class TestGetImageBytesLegacyFirst:
         asset_archiver.http_client.http_get_request.assert_called_once_with(
             image_node.download_url)
 
-    def test_transient_legacy_5xx_propagates_without_api_fallback(
+    def test_transient_public_5xx_propagates_without_api_fallback(
             self, asset_archiver, image_node):
-        """A transient legacy RetryError must propagate — not trigger the
+        """A transient public-URL RetryError must propagate — not trigger the
         /data fallback (that's reserved for the login/HTML signal only)."""
         asset_archiver.http_client.http_get_request.side_effect = RetryError("max retries")
 
@@ -432,9 +432,9 @@ class TestGetImageBytesLegacyFirst:
 
     def test_secure_image_on_pre_v25_11_data_api_404s_and_propagates(
             self, asset_archiver, image_node):
-        """Secure image on a pre-v25.11 instance: legacy login-HTML triggers
-        the fallback attempt, but /data 404s there too (route doesn't exist
-        yet) -> propagates -> caller marks the run PARTIAL."""
+        """Secure image on a pre-v25.11 instance: the public URL's login-HTML
+        triggers the fallback attempt, but /data 404s there too (route doesn't
+        exist yet) -> propagates -> caller marks the run PARTIAL."""
         login_response = _make_response(b"<!DOCTYPE html><html>login</html>")
         asset_archiver.http_client.http_get_request.side_effect = [
             login_response, _make_http_error(404),


### PR DESCRIPTION
Pre-v3.0.0 documentation and comment cleanup. No functional code changes.

## Changes

**Docs**
- Document BookStack **secure image storage** support in `backup-behavior.md` (new *Secure image storage* section) and surface it via the README/Documentation entry — images under `local_secure` / `local_secure_restricted` are fetched from the public `/uploads` URL first, falling back to the authenticated image API (`/api/image-gallery/{id}/data`, BookStack v25.11+).
- README: point the *Potential Breaking Upgrades* table at the v3.0.0 release notes with key highlights inline; refresh Features (parallel export, selectable export levels) and Background wording.
- `backup-behavior.md`: rename the "General" section to "Format", add the *Secure image storage* TOC entry, tidy the partial-run/pruning notes.
- `notifications.md`: add the "Body Format" TOC entry.

**Stale-content fixes** (surfaced by a repo sweep)
- `configuration.md`: Export Level filename examples corrected — the archive prefix is `bookstack_export_<level>_<ts>.tgz`, not `bkps_*` (`bkps` is the output directory, not the filename prefix).
- `examples/config.yml`: include `degraded` in the documented `last_run.status` set (it is emitted by the health server).
- `archiver.py`: correct the stale glob-example comment in archive cleanup — `base_dir_name` is `<output>/bookstack_export` and `scan_archives` globs `{base_dir}_*`; examples updated to `bkps/bookstack_export*`. Comment only.

**Refactor**
- Rename the image-fetch path from "legacy" to "public" in `asset_archiver.py` docstrings/comments and the corresponding test names/docstrings. The `/uploads` image URL is BookStack's default public-serving URL, not a deprecated one — "legacy" was misleading. Comments and identifiers only; no behavior change. The genuinely-legacy naming for removed config keys (`modify_markdown`, the old `minio` block) is left as-is.

## Motivation

Get the docs and in-code comments accurate and consistent before v3.0.0 is tagged, and stop calling the default image URL "legacy" now that the secure-storage fallback exists.

## Test plan

- `pylint $(git ls-files '*.py')` — 10.00/10.
- `pytest tests/unit/` — 844 passed (image-fetch tests pass under the renamed `TestGetImageBytesPublicFirst`).
- Markdown-anchor spot check: all TOC and README cross-doc links resolve to existing headings.