### PR TITLE
chore: add task minio:up/minio:down for local retention validation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,6 +59,20 @@ tasks:
     interactive: true
     cmd: uv run bookstack-file-exporter -c {{.TASKFILE_DIR}}/.local/config.yml
 
+  minio:up:
+    desc: Start a throwaway local minio + create the lt-bookstack bucket the retention scenarios target (LT_MINIO in .local/mkcfg.py)
+    cmd: |
+      docker run -d --rm --name lt-minio -p 9000:9000 \
+        -e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin \
+        minio/minio server /data
+      docker run --rm --network host --entrypoint sh minio/mc -c \
+        'until mc alias set lt http://localhost:9000 minioadmin minioadmin 2>/dev/null; do sleep 0.5; done; mc mb --ignore-existing lt/lt-bookstack'
+      echo "lt-minio up: localhost:9000 (minioadmin/minioadmin), bucket lt-bookstack ready"
+
+  minio:down:
+    desc: Stop the throwaway local minio started by task minio:up
+    cmd: docker stop lt-minio || true
+
   publish:
     desc: Publish to PyPI (uv publish)
     interactive: true


### PR DESCRIPTION
## Changes

Adds two Taskfile tasks for local retention validation against a real S3 implementation:

- `task minio:up` — starts a throwaway dockerized minio (`localhost:9000`, `minioadmin`/`minioadmin`, container auto-removed via `--rm`), waits for readiness, and idempotently creates the `lt-bookstack` bucket the local retention validation scenarios target.
- `task minio:down` — stops the container.

## Motivation

Exercising object-storage retention against a real S3 implementation (not moto) previously meant either pointing at real infra or hand-rolling a driver + bucket setup each time. These tasks make it one command with a disposable local target, so retention behavior can be validated against real minio semantics (listing, prefix handling, `DeleteObjects` batching) with no credentials and no real-data risk.

## Test plan

- `task --list` shows both `minio:up` and `minio:down`.
- Ran `minio:up`: container starts, bucket `lt-bookstack` is created; re-running is idempotent (bucket-exists is ignored).
- Ran `minio:down`: container stops and is removed.
- Drove the real `S3CompatibleArchiver` retention path against the resulting minio (level scoping, full/partial groups, multi-segment prefix, `keep_last` edge cases) — all behaved correctly against the real server.

## In-depth

Bucket creation uses a short-lived `minio/mc` container on the host network with a readiness retry loop, so no local `mc`/AWS CLI install is required. The tasks are self-contained (no dependency on gitignored local files). Intended as a developer convenience for manual/live validation; it does not add a docker dependency to the automated test suite.
