### PR TITLE
fix: clearer one-shot run summary wording

### DIFF
--- a/bookstack_file_exporter/notify/models.py
+++ b/bookstack_file_exporter/notify/models.py
@@ -69,6 +69,14 @@ class NotifyResult:  # pylint: disable=too-many-instance-attributes
     export_level: str = "pages"
 
 
+# export_level -> singular noun for prose that reads "1 <thing> export(s) failed":
+# the notifier body (notifiers.py) and the no-content error (run.py). The log
+# summary uses the plural "<level>_failed" key form instead and needs no map.
+# Explicit map (not export_level[:-1]) so an unexpected value degrades to a
+# readable "node" fallback instead of a mangled slice.
+LEVEL_SINGULAR = {"pages": "page", "books": "book", "chapters": "chapter"}
+
+
 def format_run_summary(result: NotifyResult) -> str:
     """One-line plaintext run summary for the logs, mirroring the fields a
     notification carries. Distinct from the markdown notifier body: this is the
@@ -80,7 +88,7 @@ def format_run_summary(result: NotifyResult) -> str:
     total = len(result.uploads)
     if total:
         ok = sum(1 for u in result.uploads if u.dest is not None)
-        parts.append(f"uploads={ok}/{total} ok")
+        parts.append(f"uploads_ok={ok}/{total}")
         failed = [u.label for u in result.uploads if u.dest is None]
         if failed:
             parts.append(f"(failed: {', '.join(failed)})")
@@ -88,9 +96,11 @@ def format_run_summary(result: NotifyResult) -> str:
         if warned:
             parts.append(f"(retention-warned: {', '.join(warned)})")
     if result.failed_nodes or result.failed_assets:
-        parts.append(
-            f"content-loss={len(result.failed_nodes)} node/"
-            f"{len(result.failed_assets)} asset")
+        # export_level is already plural (pages/books/chapters), so a
+        # "<level>_failed" key needs no singular/plural handling and matches the
+        # key=value shape of the rest of the line.
+        parts.append(f"{result.export_level}_failed={len(result.failed_nodes)}")
+        parts.append(f"assets_failed={len(result.failed_assets)}")
     if result.removed:
         parts.append(f"removed={len(result.removed)}")
     pruned = sum(u.pruned for u in result.uploads)

--- a/bookstack_file_exporter/notify/notifiers.py
+++ b/bookstack_file_exporter/notify/notifiers.py
@@ -4,7 +4,8 @@ from datetime import datetime, timezone
 from apprise import Apprise, AppriseAsset, AppriseConfig, NotifyFormat
 
 from bookstack_file_exporter.config_helper import notifications
-from bookstack_file_exporter.notify.models import NotifyResult, ExportStatus, STATUS_EFFECTS
+from bookstack_file_exporter.notify.models import (
+    NotifyResult, ExportStatus, STATUS_EFFECTS, LEVEL_SINGULAR)
 
 _DEFAULT_TITLE_PREFIX = "Bookstack File Exporter "
 
@@ -61,10 +62,6 @@ def _pruned_group_lines(pruned: list[str], header: str, markdown: bool) -> list[
     lines.extend(pruned)
     return lines
 
-# export_level -> singular noun for the content-failure bullet. Explicit map
-# (not level[:-1]) so an unexpected value degrades to a readable fallback.
-_LEVEL_SINGULAR = {"pages": "page", "books": "book", "chapters": "chapter"}
-
 
 def _content_failure_bullets(result: NotifyResult | None) -> list[str]:
     """Count-only bullets for content dropped from the archive, shared by both
@@ -76,7 +73,7 @@ def _content_failure_bullets(result: NotifyResult | None) -> list[str]:
         return []
     bullets = []
     if result.failed_nodes:
-        label = _LEVEL_SINGULAR.get(result.export_level, "node")
+        label = LEVEL_SINGULAR.get(result.export_level, "node")
         bullets.append(
             f"- content: {len(result.failed_nodes)} {label} export(s) failed")
     if result.failed_assets:

--- a/bookstack_file_exporter/run.py
+++ b/bookstack_file_exporter/run.py
@@ -13,7 +13,7 @@ from bookstack_file_exporter.archiver.archiver import Archiver
 from bookstack_file_exporter.common.util import HttpHelper, seconds_until_next_cron
 from bookstack_file_exporter.notify.handler import NotifyHandler
 from bookstack_file_exporter.notify.models import (
-    NotifyResult, ExportStatus, STATUS_EFFECTS, format_run_summary)
+    NotifyResult, ExportStatus, STATUS_EFFECTS, LEVEL_SINGULAR, format_run_summary)
 from bookstack_file_exporter.health.status import RunStatus
 from bookstack_file_exporter.health.server import start_health_server
 
@@ -118,7 +118,9 @@ def _run_once(config: ConfigNode) -> int:
             log.info("Interrupted by signal %s, exiting", signum)
             return 128 + signum
         code = STATUS_EFFECTS[result.status].exit_code
-        log.info("One-shot run exit code: %d", code)
+        # Outcome already surfaced at INFO via the "Run summary [STATUS]" line;
+        # the resolved code is a debug breadcrumb, not a second INFO announcement.
+        log.debug("One-shot run exit code: %d", code)
         return code
     except KeyboardInterrupt:
         # Backstop only: a Ctrl-C landing in the brief window before the
@@ -343,9 +345,10 @@ def exporter(config: ConfigNode, stop: threading.Event | None = None) -> NotifyR
         # survived). Empty ledger + empty tar is a benign empty instance.
         if archive.failed_nodes or archive.failed_assets:
             if not archive.content_written:
+                level_word = LEVEL_SINGULAR.get(export_level, "node")
                 raise NoContentArchivedError(
                     f"no {export_level} content was archived: "
-                    f"{len(archive.failed_nodes)} node export(s) and "
+                    f"{len(archive.failed_nodes)} {level_word} export(s) and "
                     f"{len(archive.failed_assets)} asset download(s) failed")
         elif not archive.has_exported_content:
             log.warning("No %s content was archived. Nothing to upload", export_level)

--- a/tests/unit/test_notify_models.py
+++ b/tests/unit/test_notify_models.py
@@ -79,14 +79,28 @@ class TestFormatRunSummary:
                                   UploadOutcome("s3/dr", None, "boom")],
                          failed_nodes=["p1", "p2"], failed_assets=["img1"],
                          removed=["old.tgz"])
-        assert format_run_summary(r) == ("level=pages archive=/data/bkps.tgz uploads=1/2 ok "
-                                         "(failed: s3/dr) content-loss=2 node/1 asset removed=1")
+        assert format_run_summary(r) == ("level=pages archive=/data/bkps.tgz uploads_ok=1/2 "
+                                         "(failed: s3/dr) pages_failed=2 assets_failed=1 removed=1")
 
     def test_summary_success_pruned(self):
         r = NotifyResult(status=ExportStatus.SUCCESS, local="/data/bkps.tgz",
                          export_level="books",
                          uploads=[UploadOutcome("minio/b", "minio-b/a.tgz", pruned=3)])
-        assert format_run_summary(r) == "level=books archive=/data/bkps.tgz uploads=1/1 ok pruned=3"
+        assert format_run_summary(r) == "level=books archive=/data/bkps.tgz uploads_ok=1/1 pruned=3"
+
+    def test_summary_content_loss_uses_plural_level_key(self):
+        # failed-document count is keyed by the (already plural) export_level,
+        # matching the key=value shape of the rest of the line.
+        r = NotifyResult(status=ExportStatus.PARTIAL, export_level="books",
+                         failed_nodes=["shelf/infra.pdf"], failed_assets=["img1", "img2"])
+        assert "books_failed=1 assets_failed=2" in format_run_summary(r)
+
+    def test_summary_content_loss_reports_both_keys_when_only_assets_fail(self):
+        # assets-only loss still shows the zero document count, so the two
+        # failure axes are always both visible.
+        r = NotifyResult(status=ExportStatus.PARTIAL, export_level="pages",
+                         failed_assets=["img1"])
+        assert "pages_failed=0 assets_failed=1" in format_run_summary(r)
 
     def test_summary_empty(self):
         r = NotifyResult(status=ExportStatus.EMPTY, export_level="pages")
@@ -97,7 +111,7 @@ class TestFormatRunSummary:
                          export_level="pages",
                          uploads=[UploadOutcome("minio/b", "minio-b/a.tgz",
                                                 warning="cleanup slow")])
-        assert format_run_summary(r) == ("level=pages archive=/data/bkps.tgz uploads=1/1 ok "
+        assert format_run_summary(r) == ("level=pages archive=/data/bkps.tgz uploads_ok=1/1 "
                                          "(retention-warned: minio/b)")
 
     def test_summary_flattens_newline_in_cleanup_error(self):

--- a/tests/unit/test_run_exporter.py
+++ b/tests/unit/test_run_exporter.py
@@ -620,7 +620,7 @@ class TestExporterContentLoss:
             run.exporter(config)
 
         # counts in the message: it becomes the failure notification body
-        assert "1 node export(s)" in str(exc_info.value)
+        assert "1 page export(s)" in str(exc_info.value)
         assert "0 asset download(s)" in str(exc_info.value)
 
     def test_assets_survive_but_no_documents_still_raises(self, monkeypatch):


### PR DESCRIPTION
## Changes

Clarify the one-shot run summary line and align its vocabulary with the notification body.

- Content-loss counts in the `Run summary` line are now `key=value` tokens keyed by the export level: `pages_failed=0 assets_failed=115` (was `content-loss=0 node/115 asset`). This drops the internal `node` jargon and the singular-noun/plural-count mismatch. The key uses the export level directly (already plural: `pages`/`books`/`chapters`), so it needs no singular/plural handling and matches the `key=value` shape of the rest of the line.
- `uploads=1/1 ok` becomes `uploads_ok=1/1` — the numerator (successful uploads) is labeled by the key instead of trailed by a floating `ok`.
- The export-level → singular-noun map is consolidated into `notify/models.py` as the single source. It is still used for prose that needs grammatical agreement — the notification body and the no-content error message stay level-specific (e.g. `2 book export(s) failed`). The summary line does not use it.
- The `One-shot run exit code: N` line is demoted from info to debug. The `Run summary [STATUS]` line already carries the outcome at info, and the resolved code is available via the process exit status.

Example summary lines:

```
Run summary [SUCCESS]: level=pages archive=.../bookstack_export_...tgz uploads_ok=1/1
Run summary [PARTIAL]: level=pages archive=.../..._partial.tgz uploads_ok=1/1 pages_failed=0 assets_failed=115
Run summary [PARTIAL]: level=books archive=.../..._books_...tgz uploads_ok=1/2 (failed: s3/dr) books_failed=2 assets_failed=0
```

## Motivation

The summary line mixed internal vocabulary (`node`) with a bare singular noun on a plural count (`0 node`, `2 page`) and a floating `ok`, which read as odd/ambiguous to operators. This makes the line uniform `key=value` and reserves grammatical prose (singular + `(s)`) for the notification body and error message where sentences are actually read.

## Test plan

- `pytest`: 870 passed. Updated the summary-format assertions and added coverage for the plural-key form (including the assets-only case that still emits `<level>_failed=0`).
- `pylint bookstack_file_exporter tests`: 10.00/10.
- Rendered the summary line and notification body across success/partial/prune scenarios and at each export level to confirm wording.

## In-depth

The summary uses a plural `<level>_failed` key because a log token is grammar-free; the notification/error use a singular-noun map because prose must agree with counts of 1 (`1 book export(s)`, not `1 books`). That split is intentional: grep-friendly key on the log line, natural sentence in the notification. These log strings have no external contract yet (pre-v3.0.0), so the token changes are safe to make now.
